### PR TITLE
Fix sync import and idle risk calculation

### DIFF
--- a/app/services/risk_service.py
+++ b/app/services/risk_service.py
@@ -108,7 +108,11 @@ def score(
         history[0],
     )
     activity_ts = latest.last_seen or last_change.ts
-    idle_days = (latest.ts - activity_ts).days
+    # ``latest.ts`` reflects when the last snapshot was taken which could be
+    # stale if the sync service has been down.  Use the current time so the
+    # idle calculation accurately reflects how long it has been since the
+    # member was last active.
+    idle_days = (datetime.utcnow() - activity_ts).days
     idle_pct = _idle_pct_from_days(idle_days)
 
     ratio = latest.donations / max(latest.donations_received, 1)

--- a/sync/run.py
+++ b/sync/run.py
@@ -10,11 +10,16 @@ from flask import Flask
 from coclib.config import env_configs
 from coclib.extensions import db, cache, scheduler
 from coclib.logging_config import configure_logging
-# Import tasks with an absolute package path so the module can be executed
-# directly without Python treating it as a namespace package.  Using a
-# relative import here would raise ``ImportError: attempted relative import``
-# when ``sync/run.py`` is run as a script.
-from sync.tasks import register_jobs
+
+try:
+    # Prefer importing via the package name so ``python -m sync.run`` works
+    # when executed from the repository root.
+    from sync.tasks import register_jobs
+except ModuleNotFoundError:  # pragma: no cover - fallback for ``python -m run``
+    # ``python -m run`` executed from the ``sync`` directory does not have the
+    # parent package on ``sys.path``.  Fall back to a direct module import so
+    # it can still run as a standalone script.
+    from tasks import register_jobs
 
 cfg_name = os.getenv("APP_ENV", "production")
 cfg_cls = env_configs[cfg_name]

--- a/sync/run.py
+++ b/sync/run.py
@@ -10,7 +10,11 @@ from flask import Flask
 from coclib.config import env_configs
 from coclib.extensions import db, cache, scheduler
 from coclib.logging_config import configure_logging
-from .tasks import register_jobs
+# Import tasks with an absolute package path so the module can be executed
+# directly without Python treating it as a namespace package.  Using a
+# relative import here would raise ``ImportError: attempted relative import``
+# when ``sync/run.py`` is run as a script.
+from sync.tasks import register_jobs
 
 cfg_name = os.getenv("APP_ENV", "production")
 cfg_cls = env_configs[cfg_name]

--- a/sync/tasks.py
+++ b/sync/tasks.py
@@ -8,7 +8,15 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from coclib.extensions import scheduler, db
 from coclib.models import ClanSnapshot, LoyaltyMembership, PlayerSnapshot
-from .services import clan_service, player_service, war_service
+
+try:
+    # ``tasks`` may be executed either as part of the ``sync`` package or as a
+    # standalone module via ``python -m run``.  Prefer the relative import which
+    # works when ``sync`` is a package and fall back to importing the local
+    # ``services`` package when executed directly from the ``sync`` directory.
+    from .services import clan_service, player_service, war_service
+except ImportError:  # pragma: no cover - local execution
+    from services import clan_service, player_service, war_service
 from coclib.services.loyalty_service import ensure_membership
 from coclib.utils import normalize_tag
 


### PR DESCRIPTION
## Summary
- fix ImportError when running sync by using absolute import
- base idle days on current time instead of last snapshot

## Testing
- `ruff check sync/run.py app/services/risk_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68728c409b38832cb98e4afaf4f12c92