### PR TITLE
Fix first-time fetch by adding sync API

### DIFF
--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -5,6 +5,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
+ENV PYTHONPATH=/opt/app
+
 EXPOSE 8000
 
-CMD ["sh", "-c", "uvicorn run:asgi_app --host 0.0.0.0 --port ${PORT:-80} --workers 1"]
+CMD ["sh", "-c", "uvicorn sync.run:asgi_app --host 0.0.0.0 --port ${PORT:-80} --workers 1"]

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -7,4 +7,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "uvicorn sync.run:asgi_app --host 0.0.0.0 --port ${PORT:-80} --workers 1"]
+CMD ["sh", "-c", "uvicorn run:asgi_app --host 0.0.0.0 --port ${PORT:-80} --workers 1"]

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -5,4 +5,6 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
-CMD ["python", "-m", "run"]
+EXPOSE 8000
+
+CMD ["sh", "-c", "uvicorn sync.run:asgi_app --host 0.0.0.0 --port ${PORT:-80} --workers 1"]

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -9,4 +9,4 @@ ENV PYTHONPATH=/opt/app
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "uvicorn sync.run:asgi_app --host 0.0.0.0 --port ${PORT:-80} --workers 1"]
+CMD ["sh", "-c", "uvicorn run:asgi_app --host 0.0.0.0 --port ${PORT:-80} --workers 1"]

--- a/sync/api/__init__.py
+++ b/sync/api/__init__.py
@@ -1,6 +1,12 @@
 from flask import Blueprint, jsonify
 
-from sync.services import clan_service, player_service
+try:
+    # When ``sync`` is a package (e.g., executed via ``python -m sync.run``)
+    # prefer the relative import. Fallback to the local modules when the
+    # package name is not available (e.g., running from the sync directory).
+    from .services import clan_service, player_service
+except ImportError:  # pragma: no cover - executed directly
+    from services import clan_service, player_service
 
 bp = Blueprint("sync_api", __name__, url_prefix="/sync")
 

--- a/sync/api/__init__.py
+++ b/sync/api/__init__.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, jsonify
+
+from sync.services import clan_service, player_service
+
+bp = Blueprint("sync_api", __name__, url_prefix="/sync")
+
+
+@bp.post("/player/<string:tag>")
+async def fetch_player(tag: str):
+    data = await player_service.get_player(tag.upper())
+    return jsonify(data)
+
+
+@bp.post("/clan/<string:tag>")
+async def fetch_clan(tag: str):
+    data = await clan_service.get_clan(tag.upper())
+    return jsonify(data)


### PR DESCRIPTION
## Summary
- create sync API blueprint with clan/player endpoints
- register new blueprint and ASGI server in sync service
- expose port and update CMD in sync Dockerfile
- trigger remote sync from snapshot service and player service

## Testing
- `ruff check .`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687346d5bc84832c99564d637cc924f7