### PR TITLE
Add standalone DB app for migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This repository is a monorepo containing multiple services and a React front end
 - `front-end/` – a React dashboard built with Vite
 - `coclib/` – common Python modules used by both services
 - `migrations/` – Alembic database migrations
+- `db/` – minimal Flask app used to run migrations
 
 ## Testing and checks
 
@@ -14,7 +15,7 @@ The project currently has no unit tests. To validate changes, run the following 
 
 ```bash
 # Lint Python sources
-ruff back-end sync coclib
+ruff back-end sync coclib db
 
 # Build the React front end
 cd front-end
@@ -27,6 +28,12 @@ Any lint errors or build failures should fail the PR.
 ## Development notes
 
 - Keep shared logic in `coclib` rather than duplicating it in `sync` or `back-end`.
-- When modifying database models, also run flask db migrate so that `migrations/` reflects the changes.
+- When modifying database models, run migrations with the standalone db app:
+  ```bash
+  cd db
+  flask --app app db migrate -m "message"
+  flask --app app db upgrade
+  ```
+- This keeps `migrations/` in sync with the models.
 - Dockerfiles in each subproject expect Python 3.11 and Node 18+.
 - Follow Ruff's default style rules for Python code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,5 @@ Any lint errors or build failures should fail the PR.
 ## Development notes
 
 - Keep shared logic in `coclib` rather than duplicating it in `sync` or `back-end`.
-- When modifying database models, run migrations with the standalone db app:
-  ```bash
-  cd db
-  flask --app app db migrate -m "message"
-  flask --app app db upgrade
-  ```
-- This keeps `migrations/` in sync with the models.
 - Dockerfiles in each subproject expect Python 3.11 and Node 18+.
 - Follow Ruff's default style rules for Python code.

--- a/db/README.md
+++ b/db/README.md
@@ -7,9 +7,12 @@ Usage:
 
 ```bash
 cd db
-flask db migrate -m "message"
-flask db upgrade
+flask --app app db migrate -m "message"
+flask --app app db upgrade
 ```
+
+Alternatively set the `FLASK_APP` environment variable to `app` so the
+commands can be shortened to `flask db ...`.
 
 The application reads configuration from `coclib.config` and shares the
 models defined in `coclib.models`.

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,15 @@
+# Database Utilities
+
+This directory contains a minimal Flask application used for running
+Alembic migrations. It is independent from the API and sync services.
+
+Usage:
+
+```bash
+cd db
+flask db migrate -m "message"
+flask db upgrade
+```
+
+The application reads configuration from `coclib.config` and shares the
+models defined in `coclib.models`.

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,5 @@
+"""Database migration application."""
+
+from .app import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/db/app.py
+++ b/db/app.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+
+from flask import Flask
+
+from coclib.config import env_configs
+from coclib.extensions import db, migrate
+
+# Import models so that Flask-Migrate can detect them
+from coclib import models  # noqa: F401
+
+
+def create_app(cfg_cls=env_configs.get(os.getenv("APP_ENV", "production"))):
+    app = Flask(__name__)
+    app.config.from_object(cfg_cls)
+
+    db.init_app(app)
+
+    migrations_dir = Path(__file__).resolve().parents[1] / "migrations"
+    migrate.init_app(app, db, directory=str(migrations_dir))
+
+    return app
+
+
+app = create_app()


### PR DESCRIPTION
## Summary
- create `db` project with Flask app for migrations
- document how to run migrate and upgrade

## Testing
- `ruff check back-end sync coclib db`
- `npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68740746a7c8832c9fe514e9533dd454