### PR TITLE
Fix Google sign‑in config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Clash of Clans Dashboard
+
+This monorepo contains a Flask API, a data sync service and a React dashboard.
+
+## Google Sign-In setup
+
+The dashboard uses [Google Identity Services](https://developers.google.com/identity) for authentication. To run the app locally you must create an OAuth 2.0 **Web** client in the Google Cloud Console and configure it as follows:
+
+1. Add `http://localhost:5173` to the **Authorized JavaScript origins**. This is the default Vite development server address.
+2. Copy the generated client ID and set it in two environment variables:
+   - `VITE_GOOGLE_CLIENT_ID` for the React dev server.
+   - `GOOGLE_CLIENT_ID` for the Flask API.
+
+Without the JavaScript origin entry Google will return a `redirect_uri_mismatch` error when attempting to sign in.
+

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -14,6 +14,14 @@ npm run dev
 The `VITE_API_URL` variable tells the dev server where the Flask API is
 running. Omit it when the API shares the same origin.
 
+### Google Sign-In
+
+Create an OAuth 2.0 **Web** client in the Google Cloud Console and add
+`http://localhost:5173` to the **Authorized JavaScript origins**. Copy the
+client ID and provide it via the `VITE_GOOGLE_CLIENT_ID` environment variable
+when running the dev server. The backend must receive the same value through
+`GOOGLE_CLIENT_ID`.
+
 ## Production build
 
 ```bash


### PR DESCRIPTION
## Summary
- add repository README with Google sign-in setup instructions
- document Google sign-in configuration in the React README

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687439c6d1dc832c9db3e1e4a932c33a