### PR TITLE
Fix Google sign-in build

### DIFF
--- a/db/app.py
+++ b/db/app.py
@@ -2,9 +2,6 @@ import os
 from pathlib import Path
 
 from dotenv import load_dotenv
-
-load_dotenv()
-
 from flask import Flask
 
 from coclib.config import env_configs
@@ -12,6 +9,8 @@ from coclib.extensions import db, migrate
 
 # Import models so that Flask-Migrate can detect them
 from coclib import models  # noqa: F401
+
+load_dotenv()
 
 
 def create_app(cfg_cls=env_configs.get(os.getenv("APP_ENV", "production"))):

--- a/front-end/Dockerfile
+++ b/front-end/Dockerfile
@@ -4,9 +4,14 @@ COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 
-# Allow overriding the backend API during the build
+# Allow overriding build-time configuration
 ARG VITE_API_URL
-ENV VITE_API_URL=$VITE_API_URL
+ARG VITE_GOOGLE_CLIENT_ID
+ARG VITE_BASE_PATH
+ENV \
+    VITE_API_URL=$VITE_API_URL \
+    VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID \
+    VITE_BASE_PATH=$VITE_BASE_PATH
 
 RUN npm run build
 

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -30,9 +30,14 @@ npm run build
 ```
 
 The production build output will be in the `dist/` directory. When building the
-Docker image you can supply `VITE_API_URL` to hard-code the backend URL:
+Docker image you can supply build arguments to set the backend URL and Google
+client ID:
 
 ```bash
-docker build --build-arg VITE_API_URL=https://api.example.com -t dashboard .
+docker build \
+  --build-arg VITE_API_URL=https://api.example.com \
+  --build-arg VITE_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com \
+  --build-arg VITE_BASE_PATH=/ \
+  -t dashboard .
 ```
 


### PR DESCRIPTION
## Summary
- ensure env vars are loaded after imports for migrations app
- allow the dashboard Dockerfile to inject Google client id and base path
- document build args for production front-end build

## Testing
- `ruff check back-end sync coclib db`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68746eba108c832cbd4ec3dfaa664439