### PR TITLE
Fix google sign in env usage

### DIFF
--- a/front-end/vite.config.js
+++ b/front-end/vite.config.js
@@ -3,9 +3,6 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   base: process.env.VITE_BASE_PATH || '/',
-  define: {
-    'process.env.VITE_GOOGLE_CLIENT_ID': JSON.stringify(process.env.VITE_GOOGLE_CLIENT_ID || ''),
-    },
   plugins: [react()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- remove custom `define` in `vite.config.js` for Google client ID

## Testing
- `ruff check back-end sync coclib db`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68747c59121c832cb966a34388a112bf