### PR TITLE
Fix API URL detection in frontend

### DIFF
--- a/front-end/src/api.js
+++ b/front-end/src/api.js
@@ -5,7 +5,15 @@
 // In production the API runs on the same host as the front-end so we use a
 // relative path. During local development set `VITE_API_URL` to the backend
 // URL (for example `http://localhost:8080`).
-export const API_URL = import.meta.env.VITE_API_URL || '';
+let apiUrl = import.meta.env.VITE_API_URL || '';
+// If the provided API URL omits a scheme, assume HTTPS to ensure requests
+// are sent to the correct host. This also strips any leading slashes so that
+// `fetch` doesn't treat the value as a relative path.
+if (apiUrl && !/^https?:\/\//i.test(apiUrl)) {
+    apiUrl = apiUrl.replace(/^\/*/, '');
+    apiUrl = `https://${apiUrl}`;
+}
+export const API_URL = apiUrl;
 
 export async function fetchJSON(path, options = {}) {
     const token = localStorage.getItem('token');


### PR DESCRIPTION
## Summary
- ensure front-end adds scheme when VITE_API_URL has no protocol

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68751d673508832c9337af3b8f559682