### PR TITLE
Fix auth token expiry

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -3,10 +3,30 @@ import Loading from './Loading.jsx';
 
 const Dashboard = lazy(() => import('./Dashboard.jsx'));
 
+function isTokenExpired(tok) {
+  try {
+    const payload = JSON.parse(atob(tok.split('.')[1]));
+    return Date.now() >= payload.exp * 1000;
+  } catch {
+    return true;
+  }
+}
+
 export default function App() {
-  const [token, setToken] = useState(() => localStorage.getItem('token'));
+  const [token, setToken] = useState(() => {
+    const stored = localStorage.getItem('token');
+    if (stored && isTokenExpired(stored)) {
+      localStorage.removeItem('token');
+      return null;
+    }
+    return stored;
+  });
 
   useEffect(() => {
+    if (token && isTokenExpired(token)) {
+      setToken(null);
+      return;
+    }
     if (!token && window.google) {
       window.google.accounts.id.initialize({
         client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,

--- a/front-end/src/api.js
+++ b/front-end/src/api.js
@@ -22,6 +22,9 @@ export async function fetchJSON(path, options = {}) {
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
     };
     const res = await fetch(`${API_URL}${path}`, options);
+    if (res.status === 401) {
+        localStorage.removeItem('token');
+    }
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return res.json();
 }


### PR DESCRIPTION
## Summary
- handle 401 responses by clearing stored token
- detect expired Google ID tokens in front-end and prompt login again

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68753d4c4fe4832c8e9af41558ec49d3