### PR TITLE
Add risk breakdown display for player profiles

### DIFF
--- a/back-end/app/api/player_routes.py
+++ b/back-end/app/api/player_routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, jsonify
 from sync.services.player_service import get_player_snapshot
 from coclib.services.loyalty_service import get_player_loyalty
+from ..services.risk_service import get_history, score_breakdown
 
 bp = Blueprint("player", __name__, url_prefix="/player")
 
@@ -10,5 +11,11 @@ async def player_profile(tag: str):
     norm_tag = tag.upper().lstrip("#")
     data = await get_player_snapshot(norm_tag)
     data["loyalty"] = get_player_loyalty(norm_tag)
+
+    history = await get_history(norm_tag, 30)
+    score_val, _, breakdown = score_breakdown(history)
+    data["risk_score"] = score_val
+    data["risk_breakdown"] = breakdown
+
     return jsonify(data)
 

--- a/back-end/app/services/risk_service.py
+++ b/back-end/app/services/risk_service.py
@@ -1,5 +1,5 @@
 from datetime import timedelta, datetime
-from typing import List, Optional
+from typing import List, Optional, Tuple, Dict, Any
 
 from sqlalchemy import select, desc
 
@@ -74,12 +74,19 @@ async def get_history(player_tag: str, days: int = 30):
     return list(reversed(res))
 
 
-def score(
+def _axes_data(
     history: List[PlayerSnapshot], clan_history_map: dict | None = None
-) -> tuple[int, datetime]:
-    """Compute the 0-100 risk score for a single member."""
+) -> Tuple[Dict[str, Any], datetime]:
     if not history:
-        return 0, datetime.utcnow()
+        return {
+            "war": 0.0,
+            "idle": 0.0,
+            "deficit": 0.0,
+            "drop": 0.0,
+            "war_used": None,
+            "war_cap": None,
+            "idle_days": 0,
+        }, datetime.utcnow()
 
     latest = history[-1]
     if len(history) < 2:
@@ -87,18 +94,21 @@ def score(
     else:
         prev = history[-8] if len(history) >= 8 else history[0]
 
-    # WAR AXIS
     war_snap = _latest_war_snapshot(history)
-    if war_snap is None:                    # member wasn’t on the war roster
+    if war_snap is None:
         war_miss_pct = 0.0
+        war_used = None
+        cap = None
     else:
         cap = _infer_attack_cap(history)
-        war_miss_pct = _clamp01((cap - war_snap.war_attacks_used) / cap)
+        war_used = war_snap.war_attacks_used
+        war_miss_pct = _clamp01((cap - war_used) / cap)
 
-    # Disable war axis if the whole clan has been dormant.
     clan_active = True
     if clan_history_map is not None:
         clan_active = _clan_has_war(clan_history_map)
+    if not clan_active:
+        war_miss_pct = 0.0
 
     last_change = next(
         (
@@ -109,10 +119,6 @@ def score(
         history[0],
     )
     activity_ts = latest.last_seen or last_change.ts
-    # ``latest.ts`` reflects when the last snapshot was taken which could be
-    # stale if the sync service has been down.  Use the current time so the
-    # idle calculation accurately reflects how long it has been since the
-    # member was last active.
     idle_days = (datetime.utcnow() - activity_ts).days
     idle_pct = _idle_pct_from_days(idle_days)
 
@@ -122,14 +128,67 @@ def score(
     drop_ratio = (prev.donations - latest.donations) / max(prev.donations, 1)
     drop_pct = _clamp01(drop_ratio / _DROP_CEIL)
 
+    return (
+        {
+            "war": war_miss_pct,
+            "idle": idle_pct,
+            "deficit": deficit_pct,
+            "drop": drop_pct,
+            "war_used": war_used,
+            "war_cap": cap,
+            "idle_days": idle_days,
+        },
+        activity_ts,
+    )
+
+
+def score(
+    history: List[PlayerSnapshot], clan_history_map: dict | None = None
+) -> tuple[int, datetime]:
+    """Compute the 0-100 risk score for a single member."""
+    axes, activity_ts = _axes_data(history, clan_history_map)
+
     raw = (
-        (_WEIGHTS["war"] if clan_active else 0) * war_miss_pct
-        + _WEIGHTS["idle"] * idle_pct
-        + _WEIGHTS["don_deficit"] * deficit_pct
-        + _WEIGHTS["don_drop"] * drop_pct
+        _WEIGHTS["war"] * axes["war"]
+        + _WEIGHTS["idle"] * axes["idle"]
+        + _WEIGHTS["don_deficit"] * axes["deficit"]
+        + _WEIGHTS["don_drop"] * axes["drop"]
     )
 
     return int(round(raw * _MAX)), activity_ts
+
+
+def score_breakdown(
+    history: List[PlayerSnapshot], clan_history_map: dict | None = None
+) -> Tuple[int, datetime, List[Dict[str, Any]]]:
+    """Return risk score along with per-axis point breakdown."""
+    axes, activity_ts = _axes_data(history, clan_history_map)
+
+    war_pts = int(round(_WEIGHTS["war"] * axes["war"] * _MAX))
+    idle_pts = int(round(_WEIGHTS["idle"] * axes["idle"] * _MAX))
+    deficit_pts = int(round(_WEIGHTS["don_deficit"] * axes["deficit"] * _MAX))
+    drop_pts = int(round(_WEIGHTS["don_drop"] * axes["drop"] * _MAX))
+
+    breakdown: List[Dict[str, Any]] = []
+    if war_pts:
+        if axes["war_used"] is None:
+            reason = "not in war roster"
+        elif axes["war_used"] == 0:
+            reason = "no war attacks used"
+        else:
+            missed = (axes["war_cap"] or 0) - axes["war_used"]
+            reason = f"missed {missed} war attack{'s' if missed != 1 else ''}"
+        breakdown.append({"points": war_pts, "reason": reason})
+    if idle_pts:
+        reason = f"inactive for {axes['idle_days']} day{'s' if axes['idle_days'] != 1 else ''}"
+        breakdown.append({"points": idle_pts, "reason": reason})
+    if deficit_pts:
+        breakdown.append({"points": deficit_pts, "reason": "donation deficit"})
+    if drop_pts:
+        breakdown.append({"points": drop_pts, "reason": "donations dropped"})
+
+    total = war_pts + idle_pts + deficit_pts + drop_pts
+    return total, activity_ts, breakdown
 
 
 async def clan_at_risk(clan_tag: str) -> list[dict]:

--- a/front-end/src/PlayerModal.jsx
+++ b/front-end/src/PlayerModal.jsx
@@ -62,6 +62,18 @@ export default function PlayerModal({ tag, onClose }) {
                 <span className="font-semibold">Last seen:</span>{' '}
                 {player.last_seen ? new Date(player.last_seen).toLocaleDateString() : '—'}
               </p>
+              {player.risk_breakdown && player.risk_breakdown.length > 0 && (
+                <div className="mt-4">
+                  <p className="font-semibold">Risk Score: {player.risk_score}</p>
+                  <ul className="list-disc list-inside text-sm mt-1">
+                    {player.risk_breakdown.map((r, i) => (
+                      <li key={i}>
+                        {r.points} pts – {r.reason}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary
- expose per-player risk breakdown from the API
- compute axis data in `risk_service` and add `score_breakdown`
- show risk score details in the player modal

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875549d7090832c887e85633c7fa70d