### PR TITLE
Improve mobile sign-in UI

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -12,6 +12,22 @@ function isTokenExpired(tok) {
   }
 }
 
+function getInitials(tok) {
+  try {
+    const payload = JSON.parse(atob(tok.split('.')[1]));
+    const name = payload.name || '';
+    return name
+      .split(' ')
+      .filter(Boolean)
+      .map((n) => n[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase();
+  } catch {
+    return '';
+  }
+}
+
 export default function App() {
   const [token, setToken] = useState(() => {
     const stored = localStorage.getItem('token');
@@ -21,6 +37,7 @@ export default function App() {
     }
     return stored;
   });
+  const [initials, setInitials] = useState(() => (token ? getInitials(token) : ''));
 
   useEffect(() => {
     if (token && isTokenExpired(token)) {
@@ -44,6 +61,10 @@ export default function App() {
   }, [token]);
 
   useEffect(() => {
+    setInitials(token ? getInitials(token) : '');
+  }, [token]);
+
+  useEffect(() => {
     if (token) {
       localStorage.setItem('token', token);
     } else {
@@ -53,24 +74,37 @@ export default function App() {
 
   if (!token) {
     return (
-      <div className="flex justify-center items-center h-screen">
-        <div id="signin"></div>
-      </div>
+      <>
+        <header className="bg-gradient-to-r from-blue-600 to-slate-800 text-white p-4 text-center shadow-md">
+          <h1 className="text-lg font-semibold">Clan Dashboard</h1>
+        </header>
+        <div className="flex justify-center items-center h-[calc(100vh-4rem)]">
+          <div id="signin"></div>
+        </div>
+      </>
     );
   }
 
   return (
     <>
-      <button
-        className="absolute top-4 right-4 px-2 py-1 bg-slate-800 text-white rounded"
-        onClick={() => {
-          window.google?.accounts.id.disableAutoSelect();
-          localStorage.removeItem('token');
-          setToken(null);
-        }}
-      >
-        Sign Out
-      </button>
+      <header className="bg-gradient-to-r from-blue-600 to-slate-800 text-white p-4 flex items-center justify-between shadow-md">
+        <h1 className="text-lg font-semibold">Clan Dashboard</h1>
+        <div className="flex items-center gap-3">
+          <span className="w-8 h-8 rounded-full bg-slate-700 flex items-center justify-center text-sm font-medium uppercase">
+            {initials}
+          </span>
+          <button
+            className="px-3 py-1 text-sm rounded bg-slate-700"
+            onClick={() => {
+              window.google?.accounts.id.disableAutoSelect();
+              localStorage.removeItem('token');
+              setToken(null);
+            }}
+          >
+            Sign Out
+          </button>
+        </div>
+      </header>
       <Suspense fallback={<Loading className="h-screen" />}>
         <Dashboard />
       </Suspense>

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -3,5 +3,11 @@ body {
     -webkit-font-smoothing: antialiased;
     background: linear-gradient(to bottom right, #f1f5f9, #e2e8f0);
     min-height: 100vh;
-    padding: 1rem;
+    padding: 0.5rem;
+}
+
+@media (min-width: 640px) {
+    body {
+        padding: 1rem;
+    }
 }


### PR DESCRIPTION
## Summary
- improve mobile spacing defaults
- add header banner
- show profile badge with user initials
- clean up sign-in screen

## Testing
- `ruff check back-end sync coclib db`
- `npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68756f9baa3c832ca68e5e24dc22fce4