### PR TITLE
Add client-side caching for faster UI

### DIFF
--- a/front-end/src/PlayerModal.jsx
+++ b/front-end/src/PlayerModal.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { fetchJSON } from './api.js';
+import { fetchJSONCached } from './api.js';
 import Loading from './Loading.jsx';
 
 export default function PlayerModal({ tag, onClose }) {
@@ -9,7 +9,7 @@ export default function PlayerModal({ tag, onClose }) {
   useEffect(() => {
     const load = async () => {
       try {
-        const data = await fetchJSON(`/player/${encodeURIComponent(tag)}`);
+        const data = await fetchJSONCached(`/player/${encodeURIComponent(tag)}`);
         setPlayer(data);
       } catch (err) {
         setError(err.message);


### PR DESCRIPTION
## Summary
- add `fetchJSONCached` helper that caches responses in `localStorage`
- use cached fetches in Dashboard and Player modal
- pre-populate UI from cache before fetching updates

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687578a1859c832c8f84e0fbcbd5649e