### PR TITLE
Add player tag support for user accounts

### DIFF
--- a/back-end/app/__init__.py
+++ b/back-end/app/__init__.py
@@ -55,10 +55,17 @@ def create_app(cfg_cls: type[Config] = Config) -> Flask:
 
         user = User.query.filter_by(sub=info["sub"]).one_or_none()
         if not user:
-            user = User(sub=info["sub"], email=info.get("email"), name=info.get("name"))
+            user = User(
+                sub=info["sub"],
+                email=info.get("email"),
+                name=info.get("name"),
+            )
             db.session.add(user)
             db.session.commit()
         g.user = user
+
+        if not user.player_tag and not path.startswith("/user"):
+            abort(400)
 
     app.before_request(require_auth)
 

--- a/back-end/app/api/__init__.py
+++ b/back-end/app/api/__init__.py
@@ -4,6 +4,7 @@ from .clan_routes import bp as clan_bp
 from .player_routes import bp as player_bp
 from .war_routes import bp as war_bp
 from .health_routes import bp as health_bp
+from .user_routes import bp as user_bp
 
 
 def register_blueprints(app: Flask):
@@ -11,3 +12,4 @@ def register_blueprints(app: Flask):
     app.register_blueprint(player_bp)
     app.register_blueprint(war_bp)
     app.register_blueprint(health_bp)
+    app.register_blueprint(user_bp)

--- a/back-end/app/api/user_routes.py
+++ b/back-end/app/api/user_routes.py
@@ -1,0 +1,28 @@
+from flask import Blueprint, jsonify, request, g, abort
+from coclib.extensions import db
+from coclib.utils import normalize_tag
+
+bp = Blueprint("user", __name__, url_prefix="/user")
+
+
+@bp.get("/me")
+def me():
+    return jsonify(
+        {
+            "email": g.user.email,
+            "name": g.user.name,
+            "player_tag": g.user.player_tag,
+        }
+    )
+
+
+@bp.post("/player-tag")
+def set_player_tag():
+    data = request.get_json(silent=True) or {}
+    tag = data.get("player_tag", "").strip()
+    if not tag:
+        abort(400)
+    g.user.player_tag = normalize_tag(tag)
+    db.session.add(g.user)
+    db.session.commit()
+    return jsonify({"player_tag": g.user.player_tag})

--- a/coclib/models.py
+++ b/coclib/models.py
@@ -87,3 +87,4 @@ class User(db.Model):
     sub = db.Column(db.String(255), unique=True, nullable=False)
     email = db.Column(db.String(255), unique=True, nullable=False)
     name = db.Column(db.String(255))
+    player_tag = db.Column(db.String(15), index=True)

--- a/front-end/src/Dashboard.jsx
+++ b/front-end/src/Dashboard.jsx
@@ -21,9 +21,7 @@ function Stat({icon, label, value}) {
     );
 }
 
-const DEFAULT_TAG = 'UV0YR2Q8';
-
-export default function Dashboard() {
+export default function Dashboard({ defaultTag }) {
     const [tag, setTag] = useState('');
     const [clan, setClan] = useState(null);
     const [topRisk, setTopRisk] = useState([]);
@@ -116,8 +114,10 @@ export default function Dashboard() {
     };
 
     useEffect(() => {
-        load(DEFAULT_TAG);
-    }, []);
+        if (defaultTag) {
+            load(defaultTag);
+        }
+    }, [defaultTag]);
 
     useEffect(() => {
         if (window.lucide) {

--- a/front-end/src/PlayerTagForm.jsx
+++ b/front-end/src/PlayerTagForm.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { fetchJSON } from './api.js';
+import Loading from './Loading.jsx';
+
+export default function PlayerTagForm({ onSaved }) {
+  const [tag, setTag] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const trimmed = tag.trim();
+    if (!trimmed) return;
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetchJSON('/user/player-tag', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ player_tag: trimmed }),
+      });
+      onSaved(res.player_tag);
+    } catch (err) {
+      setError('Failed to save');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="flex justify-center items-center h-[calc(100vh-4rem)]">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow space-y-4 w-full max-w-sm">
+        <p className="font-medium text-slate-700">Enter your player tag</p>
+        <input
+          className="w-full px-3 py-2 rounded border"
+          placeholder="Tag (without #)"
+          value={tag}
+          onChange={(e) => setTag(e.target.value)}
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button
+          type="submit"
+          className="w-full px-4 py-2 rounded bg-slate-800 text-white"
+          disabled={loading}
+        >
+          {loading ? 'Saving…' : 'Save'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/migrations/versions/9b0f4bb2cf2b_add_player_tag_to_user.py
+++ b/migrations/versions/9b0f4bb2cf2b_add_player_tag_to_user.py
@@ -1,0 +1,27 @@
+"""add player_tag column to users
+
+Revision ID: 9b0f4bb2cf2b
+Revises: 7c1104746dcc
+Create Date: 2025-07-15 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '9b0f4bb2cf2b'
+down_revision = '7c1104746dcc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('player_tag', sa.String(length=15), nullable=True))
+        batch_op.create_index(batch_op.f('ix_users_player_tag'), ['player_tag'], unique=False)
+
+
+def downgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_users_player_tag'))
+        batch_op.drop_column('player_tag')


### PR DESCRIPTION
## Summary
- add `player_tag` field to the `User` model and migration
- require player tag on authenticated requests unless hitting `/user` APIs
- expose `/user/me` and `/user/player-tag` endpoints
- load user clan dynamically in the dashboard
- prompt for player tag in the UI when missing

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875937976bc832c8a44b50a7f7d6293