### PR TITLE
Fix clan fetch and improve risk visuals

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -89,6 +89,19 @@ export default function App() {
   }, [token]);
 
   useEffect(() => {
+    const loadClan = async () => {
+      if (!token || !playerTag) return;
+      try {
+        const player = await fetchJSON(`/player/${encodeURIComponent(playerTag)}`);
+        if (player.clanTag) setClanTag(player.clanTag);
+      } catch {
+        /* ignore */
+      }
+    };
+    loadClan();
+  }, [playerTag, token]);
+
+  useEffect(() => {
     if (token) {
       localStorage.setItem('token', token);
     } else {

--- a/front-end/src/Dashboard.jsx
+++ b/front-end/src/Dashboard.jsx
@@ -1,6 +1,7 @@
 import React, {useState, useEffect, useMemo, Suspense, lazy} from 'react';
 import Loading from './Loading.jsx';
 import {fetchJSONCached} from './api.js';
+import RiskBadge from './RiskBadge.jsx';
 
 const PlayerModal = lazy(() => import('./PlayerModal.jsx'));
 
@@ -183,7 +184,6 @@ export default function Dashboard({ defaultTag }) {
                             <tr>
                                 <th className="px-4 py-3">Player</th>
                                 <th className="px-4 py-3">Tag</th>
-                                <th className="px-4 py-3">Last Seen</th>
                                 <th className="px-4 py-3">Loyalty</th>
                                 <th className="px-4 py-3">Score</th>
                             </tr>
@@ -197,9 +197,8 @@ export default function Dashboard({ defaultTag }) {
                                 >
                                     <td className="px-4 py-2 font-medium">{m.name}</td>
                                     <td className="px-4 py-2 text-slate-500">{m.tag}</td>
-                                    <td className="px-4 py-2">{m.last_seen || '\u2014'}</td>
                                     <td className="px-4 py-2 text-center">{m.loyalty}</td>
-                                    <td className="px-4 py-2">{m.risk_score}</td>
+                                    <td className="px-4 py-2"><RiskBadge score={m.risk_score} /></td>
                                 </tr>
                             ))}
                             </tbody>
@@ -271,7 +270,7 @@ export default function Dashboard({ defaultTag }) {
                                     </td>
                                     <td className="px-3 py-2 text-center">{m.last_seen || '\u2014'}</td>
                                     <td className="px-3 py-2 text-center hidden sm:table-cell">{m.loyalty}</td>
-                                    <td className="px-3 py-2 text-center">{m.risk_score}</td>
+                                    <td className="px-3 py-2 text-center"><RiskBadge score={m.risk_score} /></td>
                                 </tr>
                             ))}
                             </tbody>

--- a/front-end/src/PlayerModal.jsx
+++ b/front-end/src/PlayerModal.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchJSONCached } from './api.js';
 import Loading from './Loading.jsx';
+import RiskBadge from './RiskBadge.jsx';
 
 export default function PlayerModal({ tag, onClose }) {
   const [player, setPlayer] = useState(null);
@@ -64,7 +65,9 @@ export default function PlayerModal({ tag, onClose }) {
               </p>
               {player.risk_breakdown && player.risk_breakdown.length > 0 && (
                 <div className="mt-4">
-                  <p className="font-semibold">Risk Score: {player.risk_score}</p>
+                  <p className="font-semibold flex items-center gap-2">
+                    Risk Score: <RiskBadge score={player.risk_score} />
+                  </p>
                   <ul className="list-disc list-inside text-sm mt-1">
                     {player.risk_breakdown.map((r, i) => (
                       <li key={i}>

--- a/front-end/src/PlayerTagForm.jsx
+++ b/front-end/src/PlayerTagForm.jsx
@@ -9,8 +9,9 @@ export default function PlayerTagForm({ onSaved }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const trimmed = tag.trim();
+    let trimmed = tag.trim();
     if (!trimmed) return;
+    if (trimmed.startsWith('#')) trimmed = trimmed.slice(1);
     setLoading(true);
     setError('');
     try {
@@ -32,7 +33,7 @@ export default function PlayerTagForm({ onSaved }) {
         <p className="font-medium text-slate-700">Enter your player tag</p>
         <input
           className="w-full px-3 py-2 rounded border"
-          placeholder="Tag (without #)"
+          placeholder="Player tag (e.g. #ABC123)"
           value={tag}
           onChange={(e) => setTag(e.target.value)}
         />

--- a/front-end/src/RiskBadge.jsx
+++ b/front-end/src/RiskBadge.jsx
@@ -1,0 +1,13 @@
+function getRiskClasses(score) {
+  if (score >= 80) return 'bg-red-600 text-white';
+  if (score >= 60) return 'bg-orange-500 text-white';
+  if (score >= 30) return 'bg-yellow-400 text-black';
+  return 'bg-green-600 text-white';
+}
+
+export default function RiskBadge({ score }) {
+  const cls = getRiskClasses(score);
+  return (
+    <span className={`px-2 py-1 rounded text-xs font-medium ${cls}`}>{score}</span>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch clan info when the player tag is first saved
- allow `#` in player tag input
- remove `Last Seen` column from at-risk table
- colorize risk score badges

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68759a2e51a0832c976c60ad6ddc7297