### PR TITLE
Improve mobile headers and clan search

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -4,6 +4,7 @@ import PlayerTagForm from './PlayerTagForm.jsx';
 import { fetchJSON } from './api.js';
 
 const Dashboard = lazy(() => import('./Dashboard.jsx'));
+const ClanSearchModal = lazy(() => import('./ClanSearchModal.jsx'));
 
 function isTokenExpired(tok) {
   try {
@@ -43,6 +44,7 @@ export default function App() {
   const [playerTag, setPlayerTag] = useState(null);
   const [clanTag, setClanTag] = useState(null);
   const [loadingUser, setLoadingUser] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
 
   useEffect(() => {
     if (token && isTokenExpired(token)) {
@@ -109,13 +111,17 @@ export default function App() {
     }
   }, [token]);
 
+  useEffect(() => {
+    window.lucide?.createIcons();
+  });
+
   if (!token) {
     return (
       <>
-        <header className="bg-gradient-to-r from-blue-600 to-slate-800 text-white p-4 text-center shadow-md">
+        <header className="bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 text-center shadow-md">
           <h1 className="text-lg font-semibold">Clan Dashboard</h1>
         </header>
-        <div className="flex justify-center items-center h-[calc(100vh-4rem)]">
+        <div className="flex justify-center items-center h-[calc(100vh-4rem)] p-2 sm:p-4">
           <div id="signin"></div>
         </div>
       </>
@@ -124,9 +130,15 @@ export default function App() {
 
   return (
     <>
-      <header className="bg-gradient-to-r from-blue-600 to-slate-800 text-white p-4 flex items-center justify-between shadow-md">
+      <header className="bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 flex items-center justify-between shadow-md">
         <h1 className="text-lg font-semibold">Clan Dashboard</h1>
         <div className="flex items-center gap-3">
+          <button
+            className="p-2 rounded hover:bg-slate-700"
+            onClick={() => setShowSearch(true)}
+          >
+            <i data-lucide="search" className="w-5 h-5" />
+          </button>
           <span className="w-8 h-8 rounded-full bg-slate-700 flex items-center justify-center text-sm font-medium uppercase">
             {initials}
           </span>
@@ -144,17 +156,24 @@ export default function App() {
           </button>
         </div>
       </header>
-      {loadingUser && <Loading className="h-[calc(100vh-4rem)]" />}
-      {!loadingUser && !playerTag && (
-        <PlayerTagForm
-          onSaved={(tag) => {
-            setPlayerTag(tag);
-          }}
-        />
-      )}
-      {!loadingUser && playerTag && (
+      <main className="p-2 sm:p-4">
+        {loadingUser && <Loading className="h-[calc(100vh-4rem)]" />}
+        {!loadingUser && !playerTag && (
+          <PlayerTagForm
+            onSaved={(tag) => {
+              setPlayerTag(tag);
+            }}
+          />
+        )}
+        {!loadingUser && playerTag && (
+          <Suspense fallback={<Loading className="h-screen" />}>
+            <Dashboard defaultTag={clanTag} showSearchForm={false} />
+          </Suspense>
+        )}
+      </main>
+      {showSearch && (
         <Suspense fallback={<Loading className="h-screen" />}>
-          <Dashboard defaultTag={clanTag} />
+          <ClanSearchModal onClose={() => setShowSearch(false)} />
         </Suspense>
       )}
     </>

--- a/front-end/src/ClanSearchModal.jsx
+++ b/front-end/src/ClanSearchModal.jsx
@@ -1,0 +1,22 @@
+import React, { Suspense, lazy } from 'react';
+import Loading from './Loading.jsx';
+
+const Dashboard = lazy(() => import('./Dashboard.jsx'));
+
+export default function ClanSearchModal({ onClose }) {
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose}></div>
+      <div className="fixed inset-0 overflow-y-auto flex items-start justify-center p-4 z-50">
+        <div className="relative bg-white w-full max-w-4xl rounded shadow p-4 sm:p-6">
+          <button className="absolute top-3 right-3 text-slate-400" onClick={onClose}>
+            ✕
+          </button>
+          <Suspense fallback={<Loading className="py-8" />}>
+            <Dashboard showSearchForm={true} />
+          </Suspense>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/front-end/src/Dashboard.jsx
+++ b/front-end/src/Dashboard.jsx
@@ -22,7 +22,7 @@ function Stat({icon, label, value}) {
     );
 }
 
-export default function Dashboard({ defaultTag }) {
+export default function Dashboard({ defaultTag, showSearchForm = true }) {
     const [tag, setTag] = useState('');
     const [clan, setClan] = useState(null);
     const [topRisk, setTopRisk] = useState([]);
@@ -149,23 +149,25 @@ export default function Dashboard({ defaultTag }) {
 
     return (
         <div className="max-w-5xl mx-auto space-y-6">
-            <form
-                onSubmit={handleSubmit}
-                className="flex flex-col sm:flex-row gap-2 justify-center"
-            >
-                <input
-                    className="flex-1 w-full px-3 py-2 rounded border"
-                    placeholder="Clan tag (without #)"
-                    value={tag}
-                    onChange={(e) => setTag(e.target.value)}
-                />
-                <button
-                    type="submit"
-                    className="px-4 py-2 rounded bg-slate-800 text-white w-full sm:w-auto"
+            {showSearchForm && (
+                <form
+                    onSubmit={handleSubmit}
+                    className="flex flex-col sm:flex-row gap-2 justify-center"
                 >
-                    Load
-                </button>
-            </form>
+                    <input
+                        className="flex-1 w-full px-3 py-2 rounded border"
+                        placeholder="Clan tag (without #)"
+                        value={tag}
+                        onChange={(e) => setTag(e.target.value)}
+                    />
+                    <button
+                        type="submit"
+                        className="px-4 py-2 rounded bg-slate-800 text-white w-full sm:w-auto"
+                    >
+                        Load
+                    </button>
+                </form>
+            )}
             {error && <p className="text-center text-red-600 font-medium">{error}</p>}
             {loading && !clan && <Loading className="py-20"/>}
             {loading && clan && <Loading className="py-4"/>}

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -3,11 +3,15 @@ body {
     -webkit-font-smoothing: antialiased;
     background: linear-gradient(to bottom right, #f1f5f9, #e2e8f0);
     min-height: 100vh;
+    margin: 0;
+}
+
+#root {
     padding: 0.5rem;
 }
 
 @media (min-width: 640px) {
-    body {
+    #root {
         padding: 1rem;
     }
 }


### PR DESCRIPTION
## Summary
- modernize gradient headers and remove body padding
- show user's clan dashboard inside padded `<main>` container
- add clan search modal using existing dashboard component
- hide search form in the default dashboard view

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875a1ef48d8832cad084b98db9d30f6