### PR TITLE
Improve mobile UI

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -118,7 +118,7 @@ export default function App() {
   if (!token) {
     return (
       <>
-        <header className="bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 text-center shadow-md">
+        <header className="banner bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 text-center shadow-md">
           <h1 className="text-lg font-semibold">Clan Dashboard</h1>
         </header>
         <div className="flex justify-center items-center h-[calc(100vh-4rem)] p-2 sm:p-4">
@@ -130,7 +130,7 @@ export default function App() {
 
   return (
     <>
-      <header className="bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 flex items-center justify-between shadow-md">
+      <header className="banner bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 flex items-center justify-between shadow-md">
         <h1 className="text-lg font-semibold">Clan Dashboard</h1>
         <div className="flex items-center gap-3">
           <button

--- a/front-end/src/Dashboard.jsx
+++ b/front-end/src/Dashboard.jsx
@@ -181,7 +181,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true }) {
                     </div>
                     <h2 className="text-xl font-semibold text-slate-700">At-Risk Members</h2>
                     <div className="overflow-x-auto shadow bg-white rounded mb-6">
-                        <table className="min-w-full text-xs sm:text-sm">
+                        <table className="mobile-table min-w-full text-xs sm:text-sm">
                             <thead className="bg-slate-50 text-left text-slate-600">
                             <tr>
                                 <th className="px-4 py-3">Player</th>
@@ -197,10 +197,10 @@ export default function Dashboard({ defaultTag, showSearchForm = true }) {
                                     className="border-b last:border-none hover:bg-rose-50 cursor-pointer"
                                     onClick={() => setSelected(m.tag)}
                                 >
-                                    <td className="px-4 py-2 font-medium">{m.name}</td>
-                                    <td className="px-4 py-2 text-slate-500">{m.tag}</td>
-                                    <td className="px-4 py-2 text-center">{m.loyalty}</td>
-                                    <td className="px-4 py-2"><RiskBadge score={m.risk_score} /></td>
+                                    <td data-label="Player" className="px-4 py-2 font-medium">{m.name}</td>
+                                    <td data-label="Tag" className="px-4 py-2 text-slate-500">{m.tag}</td>
+                                    <td data-label="Loyalty" className="px-4 py-2 text-center">{m.loyalty}</td>
+                                    <td data-label="Score" className="px-4 py-2"><RiskBadge score={m.risk_score} /></td>
                                 </tr>
                             ))}
                             </tbody>
@@ -208,7 +208,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true }) {
                     </div>
                     <h2 className="text-xl font-semibold text-slate-700">All Members</h2>
                     <div className="overflow-x-auto shadow bg-white rounded">
-                        <table className="min-w-full text-xs sm:text-sm" id="membersTable">
+                        <table className="mobile-table min-w-full text-xs sm:text-sm" id="membersTable">
                             <thead className="bg-slate-50 text-left text-slate-600">
                             <tr>
                                 <th className="px-3 py-2">Player</th>
@@ -263,16 +263,16 @@ export default function Dashboard({ defaultTag, showSearchForm = true }) {
                                     className="border-b last:border-none hover:bg-slate-50 cursor-pointer"
                                     onClick={() => setSelected(m.tag)}
                                 >
-                                    <td className="px-3 py-2 font-medium">{m.name}</td>
-                                    <td className="px-3 py-2 hidden sm:table-cell">{m.role}</td>
-                                    <td className="px-3 py-2 text-center">{m.townHallLevel}</td>
-                                    <td className="px-3 py-2 text-center hidden md:table-cell">{m.trophies}</td>
-                                    <td className="px-3 py-2 text-center hidden md:table-cell">
+                                    <td data-label="Player" className="px-3 py-2 font-medium">{m.name}</td>
+                                    <td data-label="Role" className="px-3 py-2 hidden sm:table-cell">{m.role}</td>
+                                    <td data-label="TH" className="px-3 py-2 text-center">{m.townHallLevel}</td>
+                                    <td data-label="Trophies" className="px-3 py-2 text-center hidden md:table-cell">{m.trophies}</td>
+                                    <td data-label="Don/Rec" className="px-3 py-2 text-center hidden md:table-cell">
                                         {m.donations}/{m.donationsReceived}
                                     </td>
-                                    <td className="px-3 py-2 text-center">{m.last_seen || '\u2014'}</td>
-                                    <td className="px-3 py-2 text-center hidden sm:table-cell">{m.loyalty}</td>
-                                    <td className="px-3 py-2 text-center"><RiskBadge score={m.risk_score} /></td>
+                                    <td data-label="Last Seen" className="px-3 py-2 text-center">{m.last_seen || '\u2014'}</td>
+                                    <td data-label="Loyalty" className="px-3 py-2 text-center hidden sm:table-cell">{m.loyalty}</td>
+                                    <td data-label="Risk" className="px-3 py-2 text-center"><RiskBadge score={m.risk_score} /></td>
                                 </tr>
                             ))}
                             </tbody>

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -15,3 +15,64 @@ body {
         padding: 1rem;
     }
 }
+
+.banner {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+}
+
+@media (min-width: 640px) {
+    .banner {
+        margin-left: -1rem;
+        margin-right: -1rem;
+    }
+}
+
+.mobile-table thead {
+    display: none;
+}
+
+.mobile-table tbody tr {
+    display: block;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+    padding: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.mobile-table tbody td {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.25rem 0;
+    font-size: 0.875rem;
+}
+
+.mobile-table tbody td::before {
+    content: attr(data-label);
+    font-weight: 500;
+    color: #64748b;
+    margin-right: 1rem;
+}
+
+@media (min-width: 640px) {
+    .mobile-table thead {
+        display: table-header-group;
+    }
+    .mobile-table tbody tr {
+        display: table-row;
+        border: none;
+        border-bottom: 1px solid #e5e7eb;
+        border-radius: 0;
+        padding: 0;
+        margin-bottom: 0;
+    }
+    .mobile-table tbody td {
+        display: table-cell;
+        padding: 0.5rem 1rem;
+        font-size: 0.75rem;
+    }
+    .mobile-table tbody td::before {
+        display: none;
+        content: none;
+    }
+}


### PR DESCRIPTION
## Summary
- make header banner stretch edge-to-edge
- add responsive styles for mobile tables
- tag table cells with data-label attributes

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875ba2f088c832c8f00323f40a958f7