### PR TITLE
Improve mobile UI

### DIFF
--- a/front-end/index.html
+++ b/front-end/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="google-signin-client_id" content="%VITE_GOOGLE_CLIENT_ID%" />
+    <meta name="theme-color" content="#1e3a8a" />
     <title>Clan Dashboard</title>
     <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
     <script src="https://unpkg.com/lucide@latest"></script>

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -115,6 +115,23 @@ export default function App() {
     window.lucide?.createIcons();
   });
 
+  useEffect(() => {
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (!meta) return;
+    const banner = document.querySelector('.banner');
+    const update = () => {
+      const threshold = banner ? banner.offsetHeight : 0;
+      if (window.scrollY > threshold) {
+        meta.setAttribute('content', '#ffffff');
+      } else {
+        meta.setAttribute('content', '#1e3a8a');
+      }
+    };
+    window.addEventListener('scroll', update);
+    update();
+    return () => window.removeEventListener('scroll', update);
+  }, []);
+
   if (!token) {
     return (
       <>
@@ -156,7 +173,7 @@ export default function App() {
           </button>
         </div>
       </header>
-      <main className="p-2 sm:p-4">
+      <main className="px-2 pt-0 pb-2 sm:px-4 sm:pt-0 sm:pb-4">
         {loadingUser && <Loading className="h-[calc(100vh-4rem)]" />}
         {!loadingUser && !playerTag && (
           <PlayerTagForm

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -7,12 +7,12 @@ body {
 }
 
 #root {
-    padding: 0.5rem;
+    padding: 0 0.5rem 0.5rem;
 }
 
 @media (min-width: 640px) {
     #root {
-        padding: 1rem;
+        padding: 0 1rem 1rem;
     }
 }
 
@@ -36,8 +36,10 @@ body {
     display: block;
     border: 1px solid #e2e8f0;
     border-radius: 0.5rem;
-    padding: 0.5rem;
+    padding: 0.75rem;
     margin-bottom: 0.75rem;
+    background-color: #ffffff;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .mobile-table tbody td {


### PR DESCRIPTION
## Summary
- tweak top padding to remove blank space between banner and content
- change search bar color while scrolling via theme-color meta
- add mobile card backgrounds and subtle drop shadows for member tables

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875be3bc8e0832c9e792bd64aba5b6f