### PR TITLE
Add clan details, badge and tag copy feature

### DIFF
--- a/back-end/app/models.py
+++ b/back-end/app/models.py
@@ -1,5 +1,6 @@
 from coclib.models import (
     ClanSnapshot,
+    Clan,
     WarSnapshot,
     PlayerSnapshot,
     Player,
@@ -9,6 +10,7 @@ from coclib.models import (
 
 __all__ = [
     "ClanSnapshot",
+    "Clan",
     "WarSnapshot",
     "PlayerSnapshot",
     "Player",

--- a/coclib/models.py
+++ b/coclib/models.py
@@ -16,6 +16,17 @@ class ClanSnapshot(db.Model):
     __table_args__ = (db.UniqueConstraint("clan_tag", "ts", name="uq_clan_ts"),)
 
 
+class Clan(db.Model):
+    __tablename__ = "clans"
+    tag = db.Column(db.String(15), primary_key=True)
+    data = db.Column(db.JSON)
+    updated_at = db.Column(
+        db.DateTime,
+        server_default=db.func.now(),
+        onupdate=db.func.now(),
+    )
+
+
 class WarSnapshot(db.Model):
     __tablename__ = "war_snapshots"
 
@@ -88,3 +99,4 @@ class User(db.Model):
     email = db.Column(db.String(255), unique=True, nullable=False)
     name = db.Column(db.String(255))
     player_tag = db.Column(db.String(15), index=True)
+

--- a/front-end/src/ClanModal.jsx
+++ b/front-end/src/ClanModal.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function ClanModal({ clan, onClose }) {
+  if (!clan) return null;
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose}></div>
+      <div className="fixed inset-0 flex items-center justify-center z-50">
+        <div className="bg-white w-full max-w-md rounded-xl shadow-xl p-6 relative">
+          <button className="absolute top-3 right-3 text-slate-400" onClick={onClose}>✕</button>
+          <div className="flex items-center gap-3">
+            {clan.badgeUrls && (
+              <img src={clan.badgeUrls.medium} alt="badge" className="w-12 h-12" />
+            )}
+            <h3 className="text-xl font-semibold">{clan.name}</h3>
+          </div>
+          {clan.description && (
+            <p className="mt-4 whitespace-pre-line text-sm">{clan.description}</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/front-end/src/ClanSearchModal.jsx
+++ b/front-end/src/ClanSearchModal.jsx
@@ -3,7 +3,7 @@ import Loading from './Loading.jsx';
 
 const Dashboard = lazy(() => import('./Dashboard.jsx'));
 
-export default function ClanSearchModal({ onClose }) {
+export default function ClanSearchModal({ onClose, onClanLoaded }) {
   return (
     <>
       <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose}></div>
@@ -13,7 +13,7 @@ export default function ClanSearchModal({ onClose }) {
             ✕
           </button>
           <Suspense fallback={<Loading className="py-8" />}>
-            <Dashboard showSearchForm={true} />
+            <Dashboard showSearchForm={true} onClanLoaded={(c) => { onClanLoaded?.(c); onClose(); }} />
           </Suspense>
         </div>
       </div>

--- a/front-end/src/Dashboard.jsx
+++ b/front-end/src/Dashboard.jsx
@@ -6,9 +6,12 @@ import RiskBadge from './RiskBadge.jsx';
 const PlayerModal = lazy(() => import('./PlayerModal.jsx'));
 
 
-function Stat({icon, label, value}) {
+function Stat({icon, label, value, onClick}) {
     return (
-        <div className="flex items-center gap-3 bg-white shadow rounded p-4">
+        <div
+            className={`flex items-center gap-3 bg-white shadow rounded p-4 ${onClick ? 'cursor-pointer' : ''}`}
+            onClick={onClick}
+        >
             {icon && (
                 <div className="p-3 rounded-full bg-slate-200">
                     <i data-lucide={icon} className="w-7 h-7"/>
@@ -22,7 +25,7 @@ function Stat({icon, label, value}) {
     );
 }
 
-export default function Dashboard({ defaultTag, showSearchForm = true }) {
+export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoaded }) {
     const [tag, setTag] = useState('');
     const [clan, setClan] = useState(null);
     const [topRisk, setTopRisk] = useState([]);
@@ -73,6 +76,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true }) {
             try {
                 const data = JSON.parse(cached);
                 setClan(data.clan);
+                if (onClanLoaded) onClanLoaded(data.clan);
                 setMembers(data.members);
                 setTopRisk(data.topRisk);
             } catch {
@@ -100,6 +104,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true }) {
             }));
             const top = [...merged].sort((a, b) => b.risk_score - a.risk_score).slice(0, 10);
             setClan(clanData);
+            if (onClanLoaded) onClanLoaded(clanData);
             setMembers(merged);
             setTopRisk(top);
             setError('');
@@ -133,7 +138,8 @@ export default function Dashboard({ defaultTag, showSearchForm = true }) {
 
     const handleSubmit = (e) => {
         e.preventDefault();
-        const clanTag = tag.trim().toUpperCase();
+        let clanTag = tag.trim().toUpperCase();
+        if (clanTag.startsWith('#')) clanTag = clanTag.slice(1);
         if (clanTag) load(clanTag);
     };
 
@@ -156,7 +162,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true }) {
                 >
                     <input
                         className="flex-1 w-full px-3 py-2 rounded border"
-                        placeholder="Clan tag (without #)"
+                        placeholder="Clan tag"
                         value={tag}
                         onChange={(e) => setTag(e.target.value)}
                     />
@@ -173,7 +179,13 @@ export default function Dashboard({ defaultTag, showSearchForm = true }) {
             {loading && clan && <Loading className="py-4"/>}
             {clan && (
                 <>
-                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+                        <Stat
+                            icon="hash"
+                            label="Tag"
+                            value={`#${clan.tag}`}
+                            onClick={() => navigator.clipboard.writeText(`#${clan.tag}`)}
+                        />
                         <Stat icon="users" label="Members" value={members.length}/>
                         <Stat icon="shield-alert" label="Level" value={clan.clanLevel}/>
                         <Stat icon="sword" label="War Wins" value={clan.warWins || 0}/>

--- a/migrations/versions/e32985c6af01_add_clans_table.py
+++ b/migrations/versions/e32985c6af01_add_clans_table.py
@@ -1,0 +1,29 @@
+"""add clans table
+
+Revision ID: 000_add_clans_table
+Revises: c50b95df90c9
+Create Date: 2025-07-20 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '000_add_clans_table'
+down_revision = 'c50b95df90c9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'clans',
+        sa.Column('tag', sa.String(length=15), nullable=False),
+        sa.Column('data', sa.JSON(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.text('now()'), nullable=True),
+        sa.PrimaryKeyConstraint('tag')
+    )
+
+
+def downgrade():
+    op.drop_table('clans')


### PR DESCRIPTION
## Summary
- store full clan JSON in a new `clans` table
- persist clan details while syncing
- expose clan description and badge via snapshot service
- show clan badge and name in header
- make clan name open a modal with description
- add copyable clan tag card and accept `#` in search

## Testing
- `ruff check back-end sync coclib db`
- `npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875c4b076f0832c9bc4e87e311d3c00