### PR TITLE
Implement mobile tabs with virtualization

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-window": "^1.8.8"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.0.0",
@@ -262,6 +263,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1385,6 +1395,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1500,6 +1516,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/rollup": {

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-window": "^1.8.8"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/front-end/src/Dashboard.jsx
+++ b/front-end/src/Dashboard.jsx
@@ -2,6 +2,9 @@ import React, {useState, useEffect, useMemo, Suspense, lazy} from 'react';
 import Loading from './Loading.jsx';
 import {fetchJSONCached} from './api.js';
 import RiskBadge from './RiskBadge.jsx';
+import MobileTabs from './MobileTabs.jsx';
+import RiskRing from './RiskRing.jsx';
+import MemberAccordionList from './MemberAccordionList.jsx';
 
 const PlayerModal = lazy(() => import('./PlayerModal.jsx'));
 
@@ -36,6 +39,9 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
     const [selected, setSelected] = useState(null);
     const [sortField, setSortField] = useState('');
     const [sortDir, setSortDir] = useState('asc');
+    const [activeTab, setActiveTab] = useState('top');
+    const [isDesktop, setIsDesktop] = useState(() => window.matchMedia('(min-width:640px)').matches);
+    const [listHeight, setListHeight] = useState(() => Math.min(500, window.innerHeight - 200));
 
     const sortedMembers = useMemo(() => {
         if (!sortField) return members;
@@ -135,6 +141,21 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
         document.title = clan?.name || 'Clan Dashboard';
     }, [clan]);
 
+    useEffect(() => {
+        const mq = window.matchMedia('(min-width:640px)');
+        const handler = (e) => setIsDesktop(e.matches);
+        mq.addEventListener('change', handler);
+        setIsDesktop(mq.matches);
+        return () => mq.removeEventListener('change', handler);
+    }, []);
+
+    useEffect(() => {
+        const handler = () => setListHeight(Math.min(500, window.innerHeight - 200));
+        window.addEventListener('resize', handler);
+        handler();
+        return () => window.removeEventListener('resize', handler);
+    }, []);
+
 
     const handleSubmit = (e) => {
         e.preventDefault();
@@ -185,105 +206,145 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                         <Stat icon="sword" label="War Wins" value={clan.warWins || 0}/>
                         <Stat icon="shield-off" label="War Losses" value={clan.warLosses || 0}/>
                     </div>
-                    <h2 className="text-xl font-semibold text-slate-700">At-Risk Members</h2>
-                    <div className="overflow-x-auto shadow bg-white rounded mb-6">
-                        <table className="mobile-table min-w-full text-xs sm:text-sm">
-                            <thead className="bg-slate-50 text-left text-slate-600">
-                            <tr>
-                                <th className="px-4 py-3">Player</th>
-                                <th className="px-4 py-3">Tag</th>
-                                <th className="px-4 py-3">Loyalty</th>
-                                <th className="px-4 py-3">Score</th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            {topRisk.map((m) => (
-                                <tr
-                                    key={m.tag}
-                                    className="border-b last:border-none hover:bg-rose-50 cursor-pointer"
-                                    onClick={() => setSelected(m.tag)}
-                                >
-                                    <td data-label="Player" className="px-4 py-2 font-medium">{m.name}</td>
-                                    <td data-label="Tag" className="px-4 py-2 text-slate-500">{m.tag}</td>
-                                    <td data-label="Loyalty" className="px-4 py-2 text-center">{m.loyalty}</td>
-                                    <td data-label="Score" className="px-4 py-2"><RiskBadge score={m.risk_score} /></td>
-                                </tr>
-                            ))}
-                            </tbody>
-                        </table>
-                    </div>
-                    <h2 className="text-xl font-semibold text-slate-700">All Members</h2>
-                    <div className="overflow-x-auto shadow bg-white rounded">
-                        <table className="mobile-table min-w-full text-xs sm:text-sm" id="membersTable">
-                            <thead className="bg-slate-50 text-left text-slate-600">
-                            <tr>
-                                <th className="px-3 py-2">Player</th>
-                                <th
-                                    className="px-3 py-2 cursor-pointer select-none hidden sm:table-cell"
-                                    onClick={() => toggleSort('role')}
-                                >
-                                    Role {sortField === 'role' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
-                                </th>
-                                <th
-                                    className="px-3 py-2 cursor-pointer select-none text-center"
-                                    onClick={() => toggleSort('th')}
-                                >
-                                    TH {sortField === 'th' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
-                                </th>
-                                <th
-                                    className="px-3 py-2 cursor-pointer select-none text-center hidden md:table-cell"
-                                    onClick={() => toggleSort('trophies')}
-                                >
-                                    Trophies {sortField === 'trophies' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
-                                </th>
-                                <th
-                                    className="px-3 py-2 cursor-pointer select-none text-center hidden md:table-cell"
-                                    onClick={() => toggleSort('donations')}
-                                >
-                                    Don&nbsp;/&nbsp;Rec {sortField === 'donations' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
-                                </th>
-                                <th
-                                    className="px-3 py-2 cursor-pointer select-none text-center"
-                                    onClick={() => toggleSort('last')}
-                                >
-                                    Last Seen {sortField === 'last' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
-                                </th>
-                                <th
-                                    className="px-3 py-2 cursor-pointer select-none text-center hidden sm:table-cell"
-                                    onClick={() => toggleSort('loyalty')}
-                                >
-                                    Loyalty {sortField === 'loyalty' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
-                                </th>
-                                <th
-                                    className="px-3 py-2 cursor-pointer select-none text-center"
-                                    onClick={() => toggleSort('risk')}
-                                >
-                                    Risk {sortField === 'risk' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
-                                </th>
-                            </tr>
-                            </thead>
-                            <tbody>
-                            {sortedMembers.map((m) => (
-                                <tr
-                                    key={m.tag}
-                                    className="border-b last:border-none hover:bg-slate-50 cursor-pointer"
-                                    onClick={() => setSelected(m.tag)}
-                                >
-                                    <td data-label="Player" className="px-3 py-2 font-medium">{m.name}</td>
-                                    <td data-label="Role" className="px-3 py-2 hidden sm:table-cell">{m.role}</td>
-                                    <td data-label="TH" className="px-3 py-2 text-center">{m.townHallLevel}</td>
-                                    <td data-label="Trophies" className="px-3 py-2 text-center hidden md:table-cell">{m.trophies}</td>
-                                    <td data-label="Don/Rec" className="px-3 py-2 text-center hidden md:table-cell">
-                                        {m.donations}/{m.donationsReceived}
-                                    </td>
-                                    <td data-label="Last Seen" className="px-3 py-2 text-center">{m.last_seen || '\u2014'}</td>
-                                    <td data-label="Loyalty" className="px-3 py-2 text-center hidden sm:table-cell">{m.loyalty}</td>
-                                    <td data-label="Risk" className="px-3 py-2 text-center"><RiskBadge score={m.risk_score} /></td>
-                                </tr>
-                            ))}
-                            </tbody>
-                        </table>
-                    </div>
+                    {isDesktop ? (
+                        <>
+                            <h2 className="text-xl font-semibold text-slate-700">At-Risk Members</h2>
+                            <div className="overflow-x-auto shadow bg-white rounded mb-6">
+                                <table className="mobile-table min-w-full text-xs sm:text-sm">
+                                    <thead className="bg-slate-50 text-left text-slate-600">
+                                    <tr>
+                                        <th className="px-4 py-3">Player</th>
+                                        <th className="px-4 py-3">Tag</th>
+                                        <th className="px-4 py-3">Loyalty</th>
+                                        <th className="px-4 py-3">Score</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {topRisk.map((m) => (
+                                        <tr
+                                            key={m.tag}
+                                            className="border-b last:border-none hover:bg-rose-50 cursor-pointer"
+                                            onClick={() => setSelected(m.tag)}
+                                        >
+                                            <td data-label="Player" className="px-4 py-2 font-medium">{m.name}</td>
+                                            <td data-label="Tag" className="px-4 py-2 text-slate-500">{m.tag}</td>
+                                            <td data-label="Loyalty" className="px-4 py-2 text-center">{m.loyalty}</td>
+                                            <td data-label="Score" className="px-4 py-2"><RiskBadge score={m.risk_score} /></td>
+                                        </tr>
+                                    ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                            <h2 className="text-xl font-semibold text-slate-700">All Members</h2>
+                            <div className="overflow-x-auto shadow bg-white rounded">
+                                <table className="mobile-table min-w-full text-xs sm:text-sm" id="membersTable">
+                                    <thead className="bg-slate-50 text-left text-slate-600">
+                                    <tr>
+                                        <th className="px-3 py-2">Player</th>
+                                        <th
+                                            className="px-3 py-2 cursor-pointer select-none hidden sm:table-cell"
+                                            onClick={() => toggleSort('role')}
+                                        >
+                                            Role {sortField === 'role' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
+                                        </th>
+                                        <th
+                                            className="px-3 py-2 cursor-pointer select-none text-center"
+                                            onClick={() => toggleSort('th')}
+                                        >
+                                            TH {sortField === 'th' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
+                                        </th>
+                                        <th
+                                            className="px-3 py-2 cursor-pointer select-none text-center hidden md:table-cell"
+                                            onClick={() => toggleSort('trophies')}
+                                        >
+                                            Trophies {sortField === 'trophies' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
+                                        </th>
+                                        <th
+                                            className="px-3 py-2 cursor-pointer select-none text-center hidden md:table-cell"
+                                            onClick={() => toggleSort('donations')}
+                                        >
+                                            Don&nbsp;/&nbsp;Rec {sortField === 'donations' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
+                                        </th>
+                                        <th
+                                            className="px-3 py-2 cursor-pointer select-none text-center"
+                                            onClick={() => toggleSort('last')}
+                                        >
+                                            Last Seen {sortField === 'last' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
+                                        </th>
+                                        <th
+                                            className="px-3 py-2 cursor-pointer select-none text-center hidden sm:table-cell"
+                                            onClick={() => toggleSort('loyalty')}
+                                        >
+                                            Loyalty {sortField === 'loyalty' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
+                                        </th>
+                                        <th
+                                            className="px-3 py-2 cursor-pointer select-none text-center"
+                                            onClick={() => toggleSort('risk')}
+                                        >
+                                            Risk {sortField === 'risk' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
+                                        </th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {sortedMembers.map((m) => (
+                                        <tr
+                                            key={m.tag}
+                                            className="border-b last:border-none hover:bg-slate-50 cursor-pointer"
+                                            onClick={() => setSelected(m.tag)}
+                                        >
+                                            <td data-label="Player" className="px-3 py-2 font-medium">{m.name}</td>
+                                            <td data-label="Role" className="px-3 py-2 hidden sm:table-cell">{m.role}</td>
+                                            <td data-label="TH" className="px-3 py-2 text-center">{m.townHallLevel}</td>
+                                            <td data-label="Trophies" className="px-3 py-2 text-center hidden md:table-cell">{m.trophies}</td>
+                                            <td data-label="Don/Rec" className="px-3 py-2 text-center hidden md:table-cell">
+                                                {m.donations}/{m.donationsReceived}
+                                            </td>
+                                            <td data-label="Last Seen" className="px-3 py-2 text-center">{m.last_seen || '\u2014'}</td>
+                                            <td data-label="Loyalty" className="px-3 py-2 text-center hidden sm:table-cell">{m.loyalty}</td>
+                                            <td data-label="Risk" className="px-3 py-2 text-center"><RiskBadge score={m.risk_score} /></td>
+                                        </tr>
+                                    ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </>
+                    ) : (
+                        <>
+                            <MobileTabs
+                                tabs={[{ value: 'top', label: 'Top 10 At-Risk' }, { value: 'all', label: 'All Members' }]}
+                                active={activeTab}
+                                onChange={setActiveTab}
+                            />
+                            {activeTab === 'top' && (
+                                <div className="flex overflow-x-auto gap-4 snap-x snap-mandatory pb-4">
+                                    {topRisk.map((m) => (
+                                        <div
+                                            key={m.tag}
+                                            className="snap-start shrink-0 w-[80vw] bg-white rounded shadow p-4"
+                                            onClick={() => setSelected(m.tag)}
+                                        >
+                                            <div className="flex items-center gap-3">
+                                                <div className="w-10 h-10 bg-slate-200 rounded-full flex items-center justify-center">
+                                                    <i data-lucide="user" className="w-6 h-6 text-slate-500" />
+                                                </div>
+                                                <div className="flex-1">
+                                                    <p className="font-medium">{m.name}</p>
+                                                    <p className="text-sm text-slate-500">{m.tag}</p>
+                                                </div>
+                                                <RiskRing score={m.risk_score} size={50} />
+                                            </div>
+                                            <p className="text-sm mt-2">Loyalty: {m.loyalty}</p>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                            {activeTab === 'all' && (
+                                <div className="bg-white rounded shadow" style={{ height: listHeight }}>
+                                    <MemberAccordionList members={sortedMembers} height={listHeight} />
+                                </div>
+                            )}
+                        </>
+                    )}
                 </>
             )}
             {selected && (

--- a/front-end/src/MemberAccordionList.jsx
+++ b/front-end/src/MemberAccordionList.jsx
@@ -1,0 +1,63 @@
+import React, { useRef } from 'react';
+import { VariableSizeList as List } from 'react-window';
+import RiskBadge, { getRiskClasses } from './RiskBadge.jsx';
+
+function RiskDot({ score }) {
+  const cls = getRiskClasses(score).split(' ')[0];
+  return <span className={`inline-block w-3 h-3 rounded-full ${cls}`}></span>;
+}
+
+function Row({ index, style, data }) {
+  const { members, openIndex, setOpenIndex, getSize, listRef } = data;
+  const m = members[index];
+  const open = openIndex === index;
+  const toggle = () => {
+    setOpenIndex(open ? null : index);
+    listRef.current.resetAfterIndex(index);
+  };
+  return (
+    <div style={style} className="border-b px-3" onClick={toggle}>
+      <div className="flex justify-between items-center py-2">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{m.name}</span>
+          {m.role && (
+            <span className="text-xs bg-slate-200 rounded px-1">{m.role}</span>
+          )}
+          <span className="text-xs bg-slate-200 rounded px-1">TH{m.townHallLevel}</span>
+        </div>
+        <RiskDot score={m.risk_score} />
+      </div>
+      {open && (
+        <div className="text-sm space-y-1 pb-2">
+          <div className="flex justify-between">
+            <span>Trophies: {m.trophies}</span>
+            <span>Last: {m.last_seen || '—'}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Loyalty: {m.loyalty}</span>
+            <span>Risk: <RiskBadge score={m.risk_score} /></span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function MemberAccordionList({ members, height }) {
+  const listRef = useRef();
+  const [openIndex, setOpenIndex] = React.useState(null);
+  const getSize = (index) => (openIndex === index ? 120 : 56);
+
+  return (
+    <List
+      height={height}
+      itemCount={members.length}
+      itemSize={getSize}
+      width="100%"
+      itemData={{ members, openIndex, setOpenIndex, getSize, listRef }}
+      ref={listRef}
+    >
+      {Row}
+    </List>
+  );
+}

--- a/front-end/src/MobileTabs.jsx
+++ b/front-end/src/MobileTabs.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function MobileTabs({ tabs, active, onChange }) {
+  return (
+    <div className="flex justify-center gap-2 mb-4">
+      {tabs.map((t) => (
+        <button
+          key={t.value}
+          onClick={() => onChange(t.value)}
+          className={
+            'px-3 py-1 rounded-full text-sm ' +
+            (active === t.value
+              ? 'bg-slate-800 text-white'
+              : 'bg-slate-200 text-slate-700')
+          }
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/front-end/src/RiskBadge.jsx
+++ b/front-end/src/RiskBadge.jsx
@@ -1,4 +1,4 @@
-function getRiskClasses(score) {
+export function getRiskClasses(score) {
   if (score >= 80) return 'bg-red-600 text-white';
   if (score >= 60) return 'bg-orange-500 text-white';
   if (score >= 30) return 'bg-yellow-400 text-black';

--- a/front-end/src/RiskRing.jsx
+++ b/front-end/src/RiskRing.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { getRiskClasses } from './RiskBadge.jsx';
+
+export default function RiskRing({ score, size = 60 }) {
+  const radius = (size - 6) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const pct = Math.max(0, Math.min(100, score));
+  const offset = circumference - (pct / 100) * circumference;
+  const [bg, text] = getRiskClasses(score).split(' ');
+  const color = bg.replace('bg-', 'stroke-');
+
+  return (
+    <svg width={size} height={size} className="flex-shrink-0">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="#e5e7eb"
+        strokeWidth="6"
+        fill="none"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        className={color}
+        strokeWidth="6"
+        fill="none"
+        strokeLinecap="round"
+      />
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        className="text-xs font-semibold"
+      >
+        {score}
+      </text>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add react-window dependency
- implement `RiskRing` progress circle and `MobileTabs` pill navigation
- add virtualized `MemberAccordionList`
- update dashboard mobile layout to use tabs

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875d599bdfc832cae5960b947c99909