### PR TITLE
Fix war risk penalties during active war

### DIFF
--- a/back-end/app/services/risk_service.py
+++ b/back-end/app/services/risk_service.py
@@ -103,6 +103,12 @@ def _axes_data(
         cap = _infer_attack_cap(history)
         war_used = war_snap.war_attacks_used
         war_miss_pct = _clamp01((cap - war_used) / cap)
+        if (
+            war_used == 0
+            and datetime.utcnow() - war_snap.ts < timedelta(hours=24)
+        ):
+            # War likely still in progress – don't penalize yet
+            war_miss_pct = 0.0
 
     clan_active = True
     if clan_history_map is not None:


### PR DESCRIPTION
## Summary
- adjust risk calculation to ignore ongoing wars

## Testing
- `ruff check back-end sync coclib db`
- `npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68765c6e1708832c970be503d2db7790