### PR TITLE
Improve mobile risk deck display

### DIFF
--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -17,6 +17,38 @@ body {
     }
 }
 
+.scroller {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+}
+
+.scroller::-webkit-scrollbar {
+    display: none;
+}
+
+.bullets {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+    list-style: none;
+    padding: 0;
+}
+
+.bullets li {
+    width: 0.5rem;
+    height: 0.5rem;
+    background-color: #1e3a8a;
+    border-radius: 9999px;
+    opacity: 0.6;
+    transition: transform 0.2s, opacity 0.2s;
+}
+
+.bullets li.active {
+    opacity: 1;
+    transform: scale(1.3);
+}
+
 .banner {
     margin-left: -0.5rem;
     margin-right: -0.5rem;


### PR DESCRIPTION
## Summary
- show only top 5 at-risk players on dashboard
- enlarge mobile risk cards and add page indicator
- hide horizontal scroll bar

## Testing
- `ruff check back-end sync coclib db`
- `cd front-end && npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68765eb26788832cadfe4b28dcaa1782