### PR TITLE
Add per-project agent context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,25 @@
 # Codex Guidelines
 
-This repository is a monorepo containing multiple services and a React front end. It consists of:
+This monorepo hosts several projects that make up a Clash of Clans dashboard. The key directories are:
 
-- `sync/` – a Python service responsible for synchronizing data
-- `back-end/` – the Flask based API service
-- `front-end/` – a React dashboard built with Vite
-- `coclib/` – common Python modules used by both services
-- `migrations/` – Alembic database migrations
-- `db/` – minimal Flask app used to run migrations
+- `back-end/` – Flask API service
+- `sync/` – background worker used to synchronize data
+- `front-end/` – React dashboard built with Vite
+- `coclib/` – shared Python modules for both services
+- `db/` – minimal Flask app used solely for running migrations
+- `migrations/` – Alembic migration scripts
+
+Each directory contains its own `AGENTS.md` with project specific notes. Check those files when working in a subfolder.
+
+## Crawling the codebase
+
+- Application code lives under `back-end/app` and `sync/services`.
+- Shared models and utilities reside in `coclib`.
+- Database migrations are stored in the `migrations` directory at the repo root.
 
 ## Testing and checks
 
-The project currently has no unit tests. To validate changes, run the following checks:
+There are currently no unit tests. Validate changes using:
 
 ```bash
 # Lint Python sources
@@ -27,6 +35,6 @@ Any lint errors or build failures should fail the PR.
 
 ## Development notes
 
-- Keep shared logic in `coclib` rather than duplicating it in `sync` or `back-end`.
-- Dockerfiles in each subproject expect Python 3.11 and Node 18+.
+- Keep shared logic in `coclib` rather than duplicating it in other projects.
+- Dockerfiles expect Python 3.11 and Node 18+.
 - Follow Ruff's default style rules for Python code.

--- a/back-end/AGENTS.md
+++ b/back-end/AGENTS.md
@@ -1,0 +1,10 @@
+# Back-end Guidelines
+
+This folder contains the Flask API service. Source code lives inside `app/`.
+
+- Register new API routes inside `app/api/` and keep business logic in `app/services/`.
+- Configuration classes are provided in `coclib.config` and loaded in `run.py`.
+- The database models shared with other services are defined in `coclib/models.py`.
+- Migrations live in the repo root `migrations/` directory; do not place them here.
+
+Before opening a pull request run `ruff back-end` to lint the code.

--- a/coclib/AGENTS.md
+++ b/coclib/AGENTS.md
@@ -1,0 +1,9 @@
+# Shared Library Guidelines
+
+This package contains utilities, database models and configuration used by both the API and sync services.
+
+- Add reusable functions and models here rather than duplicating them in other projects.
+- Files such as `config.py` and `extensions.py` provide common Flask setup helpers.
+- Code in this directory should not import from `back-end` or `sync`.
+
+Lint changes with `ruff coclib`.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -1,0 +1,8 @@
+# DB Helper Guidelines
+
+This small Flask app exists only to run Alembic migrations. Do not place application code here.
+
+- The app factory lives in `app.py` and loads configuration from `coclib.config`.
+- All migrations reside in the repository level `migrations/` directory.
+
+Use `ruff db` to lint this folder before submitting a pull request.

--- a/migrations/AGENTS.md
+++ b/migrations/AGENTS.md
@@ -1,0 +1,7 @@
+# Migrations Guidelines
+
+This directory contains Alembic migration scripts shared by all services.
+
+- Create new revisions using `alembic revision` from the repo root so that the paths match.
+- Do not modify existing migration files.
+- The `alembic.ini` configuration lives in this folder.

--- a/sync/AGENTS.md
+++ b/sync/AGENTS.md
@@ -1,0 +1,10 @@
+# Sync Service Guidelines
+
+This directory holds the background worker responsible for synchronizing data with the Clash of Clans API.
+
+- The entry point is `run.py` and most logic lives in `services/`.
+- Shared database models and utilities come from the top-level `coclib` package.
+- API blueprints are defined under `sync/api` if needed.
+- Database migrations are stored in the root `migrations/` directory.
+
+Run `ruff sync` before submitting a pull request.


### PR DESCRIPTION
## Summary
- expand root AGENTS.md with info on how to crawl the repo and run checks
- add AGENTS.md files for `back-end`, `sync`, `coclib`, `db`, and `migrations`

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687663fb4b70832cad6f688dbfae5a3b