### PR TITLE
Store full CoC JSON in snapshots

### DIFF
--- a/coclib/models.py
+++ b/coclib/models.py
@@ -12,6 +12,7 @@ class ClanSnapshot(db.Model):
     level = db.Column(db.Integer)
     war_wins = db.Column(db.Integer)
     war_losses = db.Column(db.Integer)
+    data = db.Column(db.JSON)
 
     __table_args__ = (db.UniqueConstraint("clan_tag", "ts", name="uq_clan_ts"),)
 
@@ -52,6 +53,7 @@ class PlayerSnapshot(db.Model):
     donations_received = db.Column(db.Integer)
     war_attacks_used = db.Column(db.Integer)
     last_seen = db.Column(db.DateTime, index=True)
+    data = db.Column(db.JSON)
 
     __table_args__ = (db.UniqueConstraint("player_tag", "ts", name="uq_player_ts"),)
 
@@ -63,6 +65,7 @@ class Player(db.Model):
     town_hall = db.Column(db.Integer)
     role = db.Column(db.String(20))
     clan_tag = db.Column(db.String(15), index=True)
+    data = db.Column(db.JSON)
     updated_at = db.Column(
         db.DateTime,
         server_default=db.func.now(),

--- a/migrations/versions/a2ee3dc47f05_add_json_columns.py
+++ b/migrations/versions/a2ee3dc47f05_add_json_columns.py
@@ -1,0 +1,39 @@
+"""add json columns to snapshot and player tables
+
+Revision ID: a2ee3dc47f05
+Revises: 6579bd364dee
+Create Date: 2025-07-21 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a2ee3dc47f05"
+down_revision = "6579bd364dee"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("clan_snapshots", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("data", sa.JSON(), nullable=True))
+
+    with op.batch_alter_table("player_snapshots", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("data", sa.JSON(), nullable=True))
+
+    with op.batch_alter_table("players", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("data", sa.JSON(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("players", schema=None) as batch_op:
+        batch_op.drop_column("data")
+
+    with op.batch_alter_table("player_snapshots", schema=None) as batch_op:
+        batch_op.drop_column("data")
+
+    with op.batch_alter_table("clan_snapshots", schema=None) as batch_op:
+        batch_op.drop_column("data")
+

--- a/sync/coclib/models.py
+++ b/sync/coclib/models.py
@@ -12,6 +12,7 @@ class ClanSnapshot(db.Model):
     level = db.Column(db.Integer)
     war_wins = db.Column(db.Integer)
     war_losses = db.Column(db.Integer)
+    data = db.Column(db.JSON)
 
     __table_args__ = (db.UniqueConstraint("clan_tag", "ts", name="uq_clan_ts"),)
 
@@ -41,6 +42,7 @@ class PlayerSnapshot(db.Model):
     donations_received = db.Column(db.Integer)
     war_attacks_used = db.Column(db.Integer)
     last_seen = db.Column(db.DateTime, index=True)
+    data = db.Column(db.JSON)
 
     __table_args__ = (db.UniqueConstraint("player_tag", "ts", name="uq_player_ts"),)
 
@@ -52,6 +54,7 @@ class Player(db.Model):
     town_hall = db.Column(db.Integer)
     role = db.Column(db.String(20))
     clan_tag = db.Column(db.String(15), index=True)
+    data = db.Column(db.JSON)
     updated_at = db.Column(
         db.DateTime,
         server_default=db.func.now(),

--- a/sync/services/player_cache.py
+++ b/sync/services/player_cache.py
@@ -12,6 +12,7 @@ def upsert_player(data: dict):
         town_hall=data["townHallLevel"],
         role=data.get("role"),
         clan_tag=normalize_tag(data.get("clan", {}).get("tag", "")),
+        data=data,
     )
     stmt = stmt.on_conflict_do_update(
         index_elements=[Player.tag],
@@ -20,6 +21,7 @@ def upsert_player(data: dict):
             "town_hall": stmt.excluded.town_hall,
             "role": stmt.excluded.role,
             "clan_tag": stmt.excluded.clan_tag,
+            "data": stmt.excluded.data,
             "updated_at": db.func.now(),
         },
     )

--- a/sync/services/war_service.py
+++ b/sync/services/war_service.py
@@ -30,9 +30,15 @@ async def current_war(clan_tag: str) -> dict:
     clan_tag = normalize_tag(clan_tag)
     data = await get_client().current_war(clan_tag)
 
-    ws = WarSnapshot(ts=datetime.utcnow(), clan_tag=clan_tag, data=data)
-    db.session.add(ws)
-    db.session.commit()
+    last = (
+        WarSnapshot.query.filter_by(clan_tag=clan_tag)
+        .order_by(WarSnapshot.ts.desc())
+        .first()
+    )
+    if not last or last.data != data:
+        ws = WarSnapshot(ts=datetime.utcnow(), clan_tag=clan_tag, data=data)
+        db.session.add(ws)
+        db.session.commit()
 
     return data
 


### PR DESCRIPTION
## Summary
- add JSON `data` columns to player, clan and snapshot tables
- store snapshot rows only when data changes to avoid bloat
- keep players up to date with raw API data
- provide Alembic migration for new columns

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68766549bee0832cbc3c36a39678a03d