### PR TITLE
Show relative last seen time

### DIFF
--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import { VariableSizeList as List } from 'react-window';
 import RiskBadge, { getRiskClasses } from './RiskBadge.jsx';
+import { timeAgo } from '../lib/time.js';
 
 function RiskDot({ score }) {
   const cls = getRiskClasses(score).split(' ')[0];
@@ -32,7 +33,7 @@ function Row({ index, style, data }) {
         <div className="text-sm space-y-1 pb-2">
           <div className="flex justify-between">
             <span>Trophies: {m.trophies}</span>
-            <span>Last: {m.last_seen || '—'}</span>
+            <span>Last: {m.last_seen ? timeAgo(m.last_seen) : '—'}</span>
           </div>
           <div className="flex justify-between">
             <span>Loyalty: {m.loyalty}</span>

--- a/front-end/src/components/PlayerModal.jsx
+++ b/front-end/src/components/PlayerModal.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { fetchJSONCached } from '../lib/api.js';
+import { timeAgo } from '../lib/time.js';
 import Loading from './Loading.jsx';
 import RiskBadge from './RiskBadge.jsx';
 
@@ -64,7 +65,7 @@ export default function PlayerModal({ tag, onClose }) {
 
               <p className="mt-4">
                 <span className="font-semibold">Last seen:</span>{' '}
-                {player.last_seen ? new Date(player.last_seen).toLocaleDateString() : '—'}
+                {player.last_seen ? timeAgo(player.last_seen) : '—'}
               </p>
               {player.risk_breakdown && player.risk_breakdown.length > 0 && (
                 <div className="mt-4">

--- a/front-end/src/lib/time.js
+++ b/front-end/src/lib/time.js
@@ -1,0 +1,17 @@
+export function timeAgo(date) {
+    const ts = new Date(date).getTime();
+    const diffSec = Math.floor((Date.now() - ts) / 1000);
+    if (diffSec < 60) {
+        return `${diffSec} second${diffSec === 1 ? '' : 's'} ago`;
+    }
+    const diffMin = Math.floor(diffSec / 60);
+    if (diffMin < 60) {
+        return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`;
+    }
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) {
+        return `${diffHr} hour${diffHr === 1 ? '' : 's'} ago`;
+    }
+    const diffDay = Math.floor(diffHr / 24);
+    return `${diffDay} day${diffDay === 1 ? '' : 's'} ago`;
+}

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 import React, {useState, useEffect, useMemo, Suspense, lazy} from 'react';
 import Loading from '../components/Loading.jsx';
 import {fetchJSONCached} from '../lib/api.js';
+import { timeAgo } from '../lib/time.js';
 import RiskBadge from '../components/RiskBadge.jsx';
 import MobileTabs from '../components/MobileTabs.jsx';
 import RiskRing from '../components/RiskRing.jsx';
@@ -336,7 +337,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                             <td data-label="Don/Rec" className="px-3 py-2 text-center hidden md:table-cell">
                                                 {m.donations}/{m.donationsReceived}
                                             </td>
-                                            <td data-label="Last Seen" className="px-3 py-2 text-center">{m.last_seen || '\u2014'}</td>
+                                            <td data-label="Last Seen" className="px-3 py-2 text-center">{m.last_seen ? timeAgo(m.last_seen) : '\u2014'}</td>
                                             <td data-label="Loyalty" className="px-3 py-2 text-center hidden sm:table-cell">{m.loyalty}</td>
                                             <td data-label="Risk" className="px-3 py-2 text-center"><RiskBadge score={m.risk_score} /></td>
                                         </tr>


### PR DESCRIPTION
## Summary
- add a `timeAgo` helper
- show relative times in the player modal
- show relative times on member accordion and dashboard table

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876733ca9e8832c8b4f50d5e5d64e8e