### PR TITLE
Add API versioning and CI using nox

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  nox:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install nox
+        run: pip install nox
+      - name: Run nox
+        run: nox -s lint tests
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash
+      - name: Merge
+        uses: peter-evans/pull-request-merge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash

--- a/back-end/app/__init__.py
+++ b/back-end/app/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from flask import Flask, g, request, abort
 from flask_cors import CORS
 
-from .api import register_blueprints
+from .api import register_blueprints, API_PREFIX
 from .models import User
 from google.oauth2 import id_token
 from google.auth.transport import requests as google_requests
@@ -37,7 +37,7 @@ def create_app(cfg_cls: type[Config] = Config) -> Flask:
 
     def require_auth():
         path = request.path.rstrip("/")
-        if request.method == "OPTIONS" or path == "/health":
+        if request.method == "OPTIONS" or path.endswith("/health"):
             return
         auth = request.headers.get("Authorization", "")
         if not auth.startswith("Bearer "):
@@ -64,7 +64,8 @@ def create_app(cfg_cls: type[Config] = Config) -> Flask:
             db.session.commit()
         g.user = user
 
-        if not user.player_tag and not path.startswith("/user"):
+        user_prefix = f"{API_PREFIX}/user"
+        if not user.player_tag and not path.startswith(user_prefix):
             abort(400)
 
     app.before_request(require_auth)

--- a/back-end/app/api/__init__.py
+++ b/back-end/app/api/__init__.py
@@ -1,4 +1,7 @@
+# ruff: noqa: E402
 from flask import Flask
+
+API_PREFIX = "/api/v1"
 
 from .clan_routes import bp as clan_bp
 from .player_routes import bp as player_bp

--- a/back-end/app/api/clan_routes.py
+++ b/back-end/app/api/clan_routes.py
@@ -3,8 +3,9 @@ from flask import Blueprint, jsonify
 from ..services.snapshot_service import get_clan as get_clan_snapshot
 from coclib.services.loyalty_service import get_clan_loyalty
 from ..services.risk_service import clan_at_risk
+from . import API_PREFIX
 
-bp = Blueprint("clan", __name__, url_prefix="/clan")
+bp = Blueprint("clan", __name__, url_prefix=f"{API_PREFIX}/clan")
 
 
 @bp.get("/<string:tag>")

--- a/back-end/app/api/health_routes.py
+++ b/back-end/app/api/health_routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, jsonify
+from . import API_PREFIX
 
-bp = Blueprint("health", __name__, url_prefix="/health")
+bp = Blueprint("health", __name__, url_prefix=f"{API_PREFIX}/health")
 
 
 @bp.route("/", methods=["GET"], strict_slashes=False)

--- a/back-end/app/api/player_routes.py
+++ b/back-end/app/api/player_routes.py
@@ -2,8 +2,9 @@ from flask import Blueprint, jsonify
 from sync.services.player_service import get_player_snapshot
 from coclib.services.loyalty_service import get_player_loyalty
 from ..services.risk_service import get_history, score_breakdown
+from . import API_PREFIX
 
-bp = Blueprint("player", __name__, url_prefix="/player")
+bp = Blueprint("player", __name__, url_prefix=f"{API_PREFIX}/player")
 
 
 @bp.get("/<string:tag>")

--- a/back-end/app/api/user_routes.py
+++ b/back-end/app/api/user_routes.py
@@ -1,8 +1,9 @@
 from flask import Blueprint, jsonify, request, g, abort
 from coclib.extensions import db
 from coclib.utils import normalize_tag
+from . import API_PREFIX
 
-bp = Blueprint("user", __name__, url_prefix="/user")
+bp = Blueprint("user", __name__, url_prefix=f"{API_PREFIX}/user")
 
 
 @bp.get("/me")

--- a/back-end/app/api/war_routes.py
+++ b/back-end/app/api/war_routes.py
@@ -1,7 +1,8 @@
 from flask import Blueprint, jsonify
 from sync.services.war_service import current_war_snapshot
+from . import API_PREFIX
 
-bp = Blueprint("war", __name__, url_prefix="/war")
+bp = Blueprint("war", __name__, url_prefix=f"{API_PREFIX}/war")
 
 
 @bp.get("/<string:clan_tag>/current")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,14 @@
+import nox
+
+@nox.session(python="3.11")
+def lint(session: nox.Session) -> None:
+    session.install("ruff")
+    session.run("ruff", "check", "back-end", "sync", "coclib", "db")
+
+
+@nox.session(python="3.11")
+def tests(session: nox.Session) -> None:
+    session.install("pytest")
+    session.install("-r", "back-end/requirements.txt")
+    session.install("-r", "sync/requirements.txt")
+    session.run("pytest", "-q")

--- a/tests/test_api_version.py
+++ b/tests/test_api_version.py
@@ -1,0 +1,23 @@
+import pathlib
+import sys
+
+from flask.testing import FlaskClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+
+from app import create_app
+from coclib.config import Config
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    GOOGLE_CLIENT_ID = "dummy"
+
+
+def test_health_endpoint():
+    app = create_app(TestConfig)
+    client: FlaskClient = app.test_client()
+    resp = client.get("/api/v1/health")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}

--- a/tests/test_risk_service.py
+++ b/tests/test_risk_service.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+from app.services import risk_service
+
+
+@dataclass
+class Snap:
+    ts: datetime
+    donations: int = 0
+    donations_received: int = 0
+    war_attacks_used: int | None = None
+    trophies: int = 0
+    last_seen: datetime | None = None
+
+
+def test_clamp01():
+    assert risk_service._clamp01(-1) == 0.0
+    assert risk_service._clamp01(0.5) == 0.5
+    assert risk_service._clamp01(2) == 1.0
+
+
+def test_idle_pct_from_days():
+    assert risk_service._idle_pct_from_days(1) == 0.0
+    assert risk_service._idle_pct_from_days(2) == 0.5
+    assert risk_service._idle_pct_from_days(3) == 0.75
+    assert risk_service._idle_pct_from_days(4) == 1.0
+
+
+def test_latest_war_snapshot_and_cap():
+    now = datetime.utcnow()
+    history = [
+        Snap(now - timedelta(days=2), war_attacks_used=None),
+        Snap(now - timedelta(days=1), war_attacks_used=1),
+        Snap(now, war_attacks_used=0),
+    ]
+    war_snap = risk_service._latest_war_snapshot(history)
+    assert war_snap is history[-1]
+    cap = risk_service._infer_attack_cap(history)
+    assert cap in {1, 2}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+import pytest
+from coclib.utils import normalize_tag, encode_tag
+
+
+def test_normalize_tag_strip_and_upper():
+    assert normalize_tag('#abc') == 'ABC'
+    assert normalize_tag('Def') == 'DEF'
+
+
+def test_encode_tag_quotes_percent23():
+    assert encode_tag('abc') == '%23ABC'
+    assert encode_tag('#def') == '%23DEF'


### PR DESCRIPTION
## Summary
- add API version prefix `/api/v1`
- update auth logic to handle new prefix
- provide nox sessions for linting and testing
- add basic unit tests
- run nox in new pull request workflow with auto‑merge

## Testing
- `ruff check back-end sync coclib db`
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687676ae8dbc832c9efa2ac1361a8e97