### PR TITLE
Trigger deploy workflow after CI success

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,15 @@ name: Build and Deploy
 on:
   push:
     branches: [main]
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   deploy:
+    if: github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:
       AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
## Summary
- ensure `deploy.yml` runs after the CI workflow completes successfully

## Testing
- `ruff check back-end sync coclib db`
- `npm install && npm run build` in `front-end`

------
https://chatgpt.com/codex/tasks/task_e_6876825a1d88832cae49f4a4566614a1