### PR TITLE
Fix API prefix bug and expand tests

### DIFF
--- a/front-end/src/lib/api.js
+++ b/front-end/src/lib/api.js
@@ -13,7 +13,14 @@ if (apiUrl && !/^https?:\/\//i.test(apiUrl)) {
     apiUrl = apiUrl.replace(/^\/*/, '');
     apiUrl = `https://${apiUrl}`;
 }
+// Strip any trailing slash so we can safely append the API prefix
+if (apiUrl.endsWith('/')) {
+    apiUrl = apiUrl.slice(0, -1);
+}
 export const API_URL = apiUrl;
+
+// All API endpoints are versioned under /api/v1 on the backend
+const API_PREFIX = '/api/v1';
 
 export async function fetchJSON(path, options = {}) {
     const token = localStorage.getItem('token');
@@ -21,7 +28,7 @@ export async function fetchJSON(path, options = {}) {
         ...(options.headers || {}),
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
     };
-    const res = await fetch(`${API_URL}${path}`, options);
+    const res = await fetch(`${API_URL}${API_PREFIX}${path}`, options);
     if (res.status === 401) {
         localStorage.removeItem('token');
     }

--- a/tests/test_api_version.py
+++ b/tests/test_api_version.py
@@ -21,3 +21,16 @@ def test_health_endpoint():
     resp = client.get("/api/v1/health")
     assert resp.status_code == 200
     assert resp.get_json() == {"status": "ok"}
+
+
+def test_user_me_requires_version_prefix_and_auth():
+    app = create_app(TestConfig)
+    client: FlaskClient = app.test_client()
+
+    # Endpoint without the prefix should not exist
+    resp = client.options("/user/me")
+    assert resp.status_code == 404
+
+    # Versioned endpoint exists but requires authentication
+    resp = client.get("/api/v1/user/me")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- fix front-end API helper to prepend `/api/v1` to requests
- extend API version tests to cover the `/user/me` endpoint

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687691a6602c832cae01e2ad15ff757b