### PR TITLE
Improve member risk display

### DIFF
--- a/back-end/app/services/risk_service.py
+++ b/back-end/app/services/risk_service.py
@@ -225,13 +225,14 @@ async def clan_at_risk(clan_tag: str) -> list[dict]:
     results = []
     for p in players:
         hist = await get_history(p.player_tag, 30)
-        score_val, last_seen_ts = score(hist)
+        score_val, last_seen_ts, breakdown = score_breakdown(hist)
         results.append(
             {
                 "player_tag": p.player_tag,
                 "name": p.name,
                 "risk_score": score_val,
                 "last_seen": last_seen_ts.date().isoformat(),
+                "risk_breakdown": breakdown,
             }
         )
 

--- a/front-end/src/components/DonationRing.jsx
+++ b/front-end/src/components/DonationRing.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+export default function DonationRing({ donations, received, size = 60 }) {
+  const radius = (size - 6) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const ratio = donations / Math.max(received, 1);
+  const pct = Math.min(1, Math.max(0, ratio));
+  const offset = circumference - pct * circumference;
+
+  let color = 'stroke-red-600';
+  if (ratio >= 1) {
+    color = 'stroke-green-600';
+  } else if (ratio >= 0.5) {
+    color = 'stroke-yellow-400';
+  }
+
+  return (
+    <svg width={size} height={size} className="flex-shrink-0">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="#e5e7eb"
+        strokeWidth="6"
+        fill="none"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        className={color}
+        strokeWidth="6"
+        fill="none"
+        strokeLinecap="round"
+      />
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        className="text-xs font-semibold"
+      >
+        {(ratio * 100).toFixed(0)}%
+      </text>
+    </svg>
+  );
+}

--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -1,12 +1,8 @@
 import React, { useRef } from 'react';
 import { VariableSizeList as List } from 'react-window';
-import RiskBadge, { getRiskClasses } from './RiskBadge.jsx';
+import RiskRing from './RiskRing.jsx';
+import DonationRing from './DonationRing.jsx';
 import { timeAgo } from '../lib/time.js';
-
-function RiskDot({ score }) {
-  const cls = getRiskClasses(score).split(' ')[0];
-  return <span className={`inline-block w-3 h-3 rounded-full ${cls}`}></span>;
-}
 
 function Row({ index, style, data }) {
   const { members, openIndex, setOpenIndex, getSize, listRef } = data;
@@ -27,18 +23,31 @@ function Row({ index, style, data }) {
           )}
           <span className="text-xs bg-slate-200 rounded px-1">TH{m.townHallLevel}</span>
         </div>
-        <RiskDot score={m.risk_score} />
+        <RiskRing score={m.risk_score} size={32} />
       </div>
       {open && (
         <div className="text-sm space-y-1 pb-2">
           <div className="flex justify-between">
             <span>Trophies: {m.trophies}</span>
-            <span>Last: {m.last_seen ? timeAgo(m.last_seen) : '—'}</span>
+            <span>Last Seen: {m.last_seen ? timeAgo(m.last_seen) : '—'}</span>
           </div>
-          <div className="flex justify-between">
+          <div className="flex justify-between items-center">
+            <span>Don/Rec: {m.donations}/{m.donationsReceived}</span>
+            <DonationRing donations={m.donations} received={m.donationsReceived} size={32} />
+          </div>
+          <div className="flex justify-between items-center">
             <span>Days in Clan: {m.loyalty}</span>
-            <span>Risk: <RiskBadge score={m.risk_score} /></span>
+            <RiskRing score={m.risk_score} size={32} />
           </div>
+          {m.risk_breakdown && m.risk_breakdown.length > 0 && (
+            <ul className="list-disc list-inside text-xs pt-1">
+              {m.risk_breakdown.map((r, i) => (
+                <li key={i}>
+                  {r.points} pts – {r.reason}
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
     </div>

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -2,9 +2,9 @@ import React, {useState, useEffect, useMemo, Suspense, lazy} from 'react';
 import Loading from '../components/Loading.jsx';
 import {fetchJSONCached} from '../lib/api.js';
 import { timeAgo } from '../lib/time.js';
-import RiskBadge from '../components/RiskBadge.jsx';
 import MobileTabs from '../components/MobileTabs.jsx';
 import RiskRing from '../components/RiskRing.jsx';
+import DonationRing from '../components/DonationRing.jsx';
 import MemberAccordionList from '../components/MemberAccordionList.jsx';
 
 const PlayerModal = lazy(() => import('../components/PlayerModal.jsx'));
@@ -111,6 +111,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
 
                 risk_score: rmap[m.tag.replace('#', '')]?.risk_score || 0,
                 last_seen: rmap[m.tag.replace('#', '')]?.last_seen || null,
+                risk_breakdown: rmap[m.tag.replace('#', '')]?.risk_breakdown || [],
                 loyalty: loyaltyMap[m.tag.replace('#', '')] || 0,
             }));
             const top = [...merged]
@@ -273,7 +274,18 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                             </td>
                                             <td data-label="Tag" className="px-4 py-2 text-slate-500">{m.tag}</td>
                                             <td data-label="Days in Clan" className="px-4 py-2 text-center">{m.loyalty}</td>
-                                            <td data-label="Score" className="px-4 py-2"><RiskBadge score={m.risk_score} /></td>
+                                            <td data-label="Score" className="px-4 py-2">
+                                                <div className="flex items-center gap-2">
+                                                    <RiskRing score={m.risk_score} size={40} />
+                                                    {m.risk_breakdown && m.risk_breakdown.length > 0 && (
+                                                        <ul className="list-disc list-inside text-xs">
+                                                            {m.risk_breakdown.map((r, i) => (
+                                                                <li key={i}>{r.points} pts – {r.reason}</li>
+                                                            ))}
+                                                        </ul>
+                                                    )}
+                                                </div>
+                                            </td>
                                         </tr>
                                     ))}
                                     </tbody>
@@ -348,11 +360,16 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                             <td data-label="TH" className="px-3 py-2 text-center">{m.townHallLevel}</td>
                                             <td data-label="Trophies" className="px-3 py-2 text-center hidden md:table-cell">{m.trophies}</td>
                                             <td data-label="Don/Rec" className="px-3 py-2 text-center hidden md:table-cell">
-                                                {m.donations}/{m.donationsReceived}
+                                                <div className="flex items-center justify-center gap-2">
+                                                    {m.donations}/{m.donationsReceived}
+                                                    <DonationRing donations={m.donations} received={m.donationsReceived} size={36} />
+                                                </div>
                                             </td>
                                             <td data-label="Last Seen" className="px-3 py-2 text-center">{m.last_seen ? timeAgo(m.last_seen) : '\u2014'}</td>
                                             <td data-label="Days in Clan" className="px-3 py-2 text-center hidden sm:table-cell">{m.loyalty}</td>
-                                            <td data-label="Risk" className="px-3 py-2 text-center"><RiskBadge score={m.risk_score} /></td>
+                                            <td data-label="Risk" className="px-3 py-2 text-center">
+                                                <RiskRing score={m.risk_score} size={36} />
+                                            </td>
                                         </tr>
                                     ))}
                                     </tbody>
@@ -367,8 +384,11 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                 onChange={setActiveTab}
                             />
                             {activeTab === 'top' && (
-                                <div className="bg-white rounded shadow ring-2 ring-rose-200" style={{ height: listHeight }}>
-                                    <MemberAccordionList members={topRisk} height={listHeight} />
+                                <div
+                                    className="bg-white rounded shadow ring-2 ring-rose-200"
+                                    style={{ height: Math.min(listHeight, topRisk.length * 60) }}
+                                >
+                                    <MemberAccordionList members={topRisk} height={Math.min(listHeight, topRisk.length * 60)} />
                                 </div>
                             )}
                             {activeTab === 'all' && (


### PR DESCRIPTION
## Summary
- include risk breakdown in clan at risk results
- visualize donation ratio
- use ring graphics for risk and donations
- adjust list height to reduce whitespace

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68769f4de9a0832cb4c5139156af722a