### PR TITLE
Fix mobile member list toggle and donation ring display

### DIFF
--- a/front-end/src/components/DonationRing.jsx
+++ b/front-end/src/components/DonationRing.jsx
@@ -14,6 +14,8 @@ export default function DonationRing({ donations, received, size = 60 }) {
     color = 'stroke-yellow-400';
   }
 
+  const display = ratio >= 1 ? '∞' : `${Math.round(ratio * 100)}%`;
+
   return (
     <svg width={size} height={size} className="flex-shrink-0">
       <circle
@@ -42,7 +44,7 @@ export default function DonationRing({ donations, received, size = 60 }) {
         textAnchor="middle"
         className="text-xs font-semibold"
       >
-        {(ratio * 100).toFixed(0)}%
+        {display}
       </text>
     </svg>
   );

--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -9,8 +9,12 @@ function Row({ index, style, data }) {
   const m = members[index];
   const open = openIndex === index;
   const toggle = () => {
+    const prev = openIndex;
     setOpenIndex(open ? null : index);
-    listRef.current.resetAfterIndex(index);
+    if (listRef.current) {
+      const start = Math.min(index, prev ?? index);
+      listRef.current.resetAfterIndex(start);
+    }
   };
   return (
     <div style={style} className="border-b px-3" onClick={toggle}>


### PR DESCRIPTION
## Summary
- fix resetting of variable row heights when toggling members
- cap donation ring percentage display and show infinity symbol for generous donors

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876a6e7e964832cabb6c05ce905b559