### PR TITLE
Fix mobile member card overlap and risk view

### DIFF
--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -17,7 +17,7 @@ function Row({ index, style, data }) {
     }
   };
   return (
-    <div style={style} className="border-b px-3" onClick={toggle}>
+    <div style={{ ...style, overflow: 'hidden' }} className="border-b px-3" onClick={toggle}>
       <div className="flex justify-between items-center py-2">
         <div className="flex items-center gap-2">
           {m.leagueIcon && <img src={m.leagueIcon} alt="league" className="w-5 h-5" />}
@@ -27,7 +27,7 @@ function Row({ index, style, data }) {
           )}
           <span className="text-xs bg-slate-200 rounded px-1">TH{m.townHallLevel}</span>
         </div>
-        <RiskRing score={m.risk_score} size={32} />
+        {!open && <RiskRing score={m.risk_score} size={32} />}
       </div>
       {open && (
         <div className="text-sm space-y-1 pb-2">
@@ -61,7 +61,13 @@ function Row({ index, style, data }) {
 export default function MemberAccordionList({ members, height }) {
   const listRef = useRef();
   const [openIndex, setOpenIndex] = React.useState(null);
-  const getSize = (index) => (openIndex === index ? 120 : 56);
+  const getSize = (index) => {
+    const m = members[index];
+    const base = 56;
+    if (openIndex !== index) return base;
+    const lines = (m.risk_breakdown?.length || 0) + 3; // three base rows
+    return base + 24 + lines * 20;
+  };
 
   return (
     <List

--- a/front-end/src/components/ProfileCard.jsx
+++ b/front-end/src/components/ProfileCard.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import RiskRing from './RiskRing.jsx';
+import DonationRing from './DonationRing.jsx';
+import { timeAgo } from '../lib/time.js';
+
+export default function ProfileCard({ member, onClick }) {
+  if (!member) return null;
+  return (
+    <div
+      className="bg-white rounded shadow ring-2 ring-rose-200 px-4 py-3 flex flex-col items-center text-sm cursor-pointer w-40 shrink-0"
+      onClick={onClick}
+    >
+      {member.leagueIcon && (
+        <img src={member.leagueIcon} alt="league" className="w-6 h-6 mb-1" />
+      )}
+      <p className="font-medium text-center mb-1">{member.name}</p>
+      <RiskRing score={member.risk_score} size={48} />
+      <div className="mt-2 text-center space-y-1 w-full">
+        <p>TH{member.townHallLevel}</p>
+        <p className="flex justify-between">
+          <span>{member.donations}/{member.donationsReceived}</span>
+          <DonationRing
+            donations={member.donations}
+            received={member.donationsReceived}
+            size={32}
+          />
+        </p>
+        <p className="text-xs text-slate-500">
+          {member.last_seen ? timeAgo(member.last_seen) : '\u2014'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -6,6 +6,7 @@ import MobileTabs from '../components/MobileTabs.jsx';
 import RiskRing from '../components/RiskRing.jsx';
 import DonationRing from '../components/DonationRing.jsx';
 import MemberAccordionList from '../components/MemberAccordionList.jsx';
+import ProfileCard from '../components/ProfileCard.jsx';
 
 const PlayerModal = lazy(() => import('../components/PlayerModal.jsx'));
 
@@ -384,11 +385,14 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                 onChange={setActiveTab}
                             />
                             {activeTab === 'top' && (
-                                <div
-                                    className="bg-white rounded shadow ring-2 ring-rose-200"
-                                    style={{ height: Math.min(listHeight, topRisk.length * 60) }}
-                                >
-                                    <MemberAccordionList members={topRisk} height={Math.min(listHeight, topRisk.length * 60)} />
+                                <div className="flex overflow-x-auto gap-3 pb-2 scroller">
+                                    {topRisk.map((m) => (
+                                        <ProfileCard
+                                            key={m.tag}
+                                            member={m}
+                                            onClick={() => setSelected(m.tag)}
+                                        />
+                                    ))}
                                 </div>
                             )}
                             {activeTab === 'all' && (


### PR DESCRIPTION
## Summary
- allow variable height in `MemberAccordionList`
- hide header risk ring when open to avoid duplicates
- add `ProfileCard` component for modern at-risk display
- show at risk members as scrollable cards on mobile

## Testing
- `npm install`
- `npm test`
- `npm run build`
- `ruff check back-end sync coclib db`

------
https://chatgpt.com/codex/tasks/task_e_6876caca609c832c8ad470c4c2b997be