### PR TITLE
UI improvements for mobile

### DIFF
--- a/front-end/src/components/DonationRing.jsx
+++ b/front-end/src/components/DonationRing.jsx
@@ -14,7 +14,7 @@ export default function DonationRing({ donations, received, size = 60 }) {
     color = 'stroke-yellow-400';
   }
 
-  const display = ratio >= 1 ? '∞' : `${Math.round(ratio * 100)}%`;
+  const display = `${received}/${donations}`;
 
   return (
     <svg width={size} height={size} className="flex-shrink-0">

--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -3,6 +3,7 @@ import { VariableSizeList as List } from 'react-window';
 import RiskRing from './RiskRing.jsx';
 import DonationRing from './DonationRing.jsx';
 import { timeAgo } from '../lib/time.js';
+import { getTownHallIcon } from '../lib/townhall.js';
 
 function Row({ index, style, data }) {
   const { members, openIndex, setOpenIndex, getSize, listRef } = data;
@@ -19,13 +20,24 @@ function Row({ index, style, data }) {
   return (
     <div style={{ ...style, overflow: 'hidden' }} className="border-b px-3" onClick={toggle}>
       <div className="flex justify-between items-center py-2">
-        <div className="flex items-center gap-2">
-          {m.leagueIcon && <img src={m.leagueIcon} alt="league" className="w-5 h-5" />}
-          <span className="font-medium">{m.name}</span>
-          {m.role && (
-            <span className="text-xs bg-slate-200 rounded px-1">{m.role}</span>
-          )}
-          <span className="text-xs bg-slate-200 rounded px-1">TH{m.townHallLevel}</span>
+        <div className="flex flex-col">
+          <div className="flex items-center gap-2">
+            {m.leagueIcon && (
+              <img src={m.leagueIcon} alt="league" className="w-5 h-5" />
+            )}
+            <img
+              src={getTownHallIcon(m.townHallLevel)}
+              alt={`TH${m.townHallLevel}`}
+              className="w-5 h-5"
+            />
+            <span className="font-medium">{m.name}</span>
+            {m.role && (
+              <span className="text-xs bg-slate-200 rounded px-1">{m.role}</span>
+            )}
+          </div>
+          <p className="text-xs text-slate-500">
+            {m.last_seen ? timeAgo(m.last_seen) : '\u2014'}
+          </p>
         </div>
         {!open && <RiskRing score={m.risk_score} size={32} />}
       </div>

--- a/front-end/src/components/ProfileCard.jsx
+++ b/front-end/src/components/ProfileCard.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import RiskRing from './RiskRing.jsx';
 import DonationRing from './DonationRing.jsx';
 import { timeAgo } from '../lib/time.js';
+import { getTownHallIcon } from '../lib/townhall.js';
 
 export default function ProfileCard({ member, onClick }) {
   if (!member) return null;
@@ -10,9 +11,16 @@ export default function ProfileCard({ member, onClick }) {
       className="bg-white rounded shadow ring-2 ring-rose-200 px-4 py-3 flex flex-col items-center text-sm cursor-pointer w-40 shrink-0"
       onClick={onClick}
     >
-      {member.leagueIcon && (
-        <img src={member.leagueIcon} alt="league" className="w-6 h-6 mb-1" />
-      )}
+      <div className="flex gap-1 mb-1">
+        {member.leagueIcon && (
+          <img src={member.leagueIcon} alt="league" className="w-6 h-6" />
+        )}
+        <img
+          src={getTownHallIcon(member.townHallLevel)}
+          alt={`TH${member.townHallLevel}`}
+          className="w-6 h-6"
+        />
+      </div>
       <p className="font-medium text-center mb-1">{member.name}</p>
       <RiskRing score={member.risk_score} size={48} />
       <div className="mt-2 text-center space-y-1 w-full">

--- a/front-end/src/lib/townhall.js
+++ b/front-end/src/lib/townhall.js
@@ -1,0 +1,3 @@
+export function getTownHallIcon(level) {
+  return `https://raw.githubusercontent.com/smlbiobot/coc-assets/master/png/town-hall/town-hall-${level}.png`;
+}

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -7,6 +7,7 @@ import RiskRing from '../components/RiskRing.jsx';
 import DonationRing from '../components/DonationRing.jsx';
 import MemberAccordionList from '../components/MemberAccordionList.jsx';
 import ProfileCard from '../components/ProfileCard.jsx';
+import { getTownHallIcon } from '../lib/townhall.js';
 
 const PlayerModal = lazy(() => import('../components/PlayerModal.jsx'));
 
@@ -270,6 +271,11 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                     {m.leagueIcon && (
                                                         <img src={m.leagueIcon} alt="league" className="w-5 h-5" />
                                                     )}
+                                                    <img
+                                                        src={getTownHallIcon(m.townHallLevel)}
+                                                        alt={`TH${m.townHallLevel}`}
+                                                        className="w-5 h-5"
+                                                    />
                                                     {m.name}
                                                 </span>
                                             </td>
@@ -323,12 +329,6 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                             Don&nbsp;/&nbsp;Rec {sortField === 'donations' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
                                         </th>
                                         <th
-                                            className="px-3 py-2 cursor-pointer select-none text-center"
-                                            onClick={() => toggleSort('last')}
-                                        >
-                                            Last Seen {sortField === 'last' ? (sortDir === 'asc' ? '▲' : '▼') : ''}
-                                        </th>
-                                        <th
                                             className="px-3 py-2 cursor-pointer select-none text-center hidden sm:table-cell"
                                             onClick={() => toggleSort('loyalty')}
                                         >
@@ -350,12 +350,22 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                             onClick={() => setSelected(m.tag)}
                                         >
                                             <td data-label="Player" className="px-3 py-2 font-medium">
-                                                <span className="flex items-center gap-2">
-                                                    {m.leagueIcon && (
-                                                        <img src={m.leagueIcon} alt="league" className="w-5 h-5" />
-                                                    )}
-                                                    {m.name}
-                                                </span>
+                                                <div className="flex flex-col">
+                                                    <span className="flex items-center gap-2">
+                                                        {m.leagueIcon && (
+                                                            <img src={m.leagueIcon} alt="league" className="w-5 h-5" />
+                                                        )}
+                                                        <img
+                                                            src={getTownHallIcon(m.townHallLevel)}
+                                                            alt={`TH${m.townHallLevel}`}
+                                                            className="w-5 h-5"
+                                                        />
+                                                        {m.name}
+                                                    </span>
+                                                    <span className="text-xs text-slate-500">
+                                                        {m.last_seen ? timeAgo(m.last_seen) : '\u2014'}
+                                                    </span>
+                                                </div>
                                             </td>
                                             <td data-label="Role" className="px-3 py-2 hidden sm:table-cell">{m.role}</td>
                                             <td data-label="TH" className="px-3 py-2 text-center">{m.townHallLevel}</td>
@@ -366,7 +376,6 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                     <DonationRing donations={m.donations} received={m.donationsReceived} size={36} />
                                                 </div>
                                             </td>
-                                            <td data-label="Last Seen" className="px-3 py-2 text-center">{m.last_seen ? timeAgo(m.last_seen) : '\u2014'}</td>
                                             <td data-label="Days in Clan" className="px-3 py-2 text-center hidden sm:table-cell">{m.loyalty}</td>
                                             <td data-label="Risk" className="px-3 py-2 text-center">
                                                 <RiskRing score={m.risk_score} size={36} />


### PR DESCRIPTION
## Summary
- show TH icons next to league badges
- display donation rings as received/donated values
- add last seen info under names in member list
- expose helper to get TH icon URL

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876d3ebdea4832c83159e7f959b7ffd