### PR TITLE
Fix mobile card view

### DIFF
--- a/front-end/src/components/PlayerModal.jsx
+++ b/front-end/src/components/PlayerModal.jsx
@@ -3,6 +3,8 @@ import { fetchJSONCached } from '../lib/api.js';
 import { timeAgo } from '../lib/time.js';
 import Loading from './Loading.jsx';
 import RiskBadge from './RiskBadge.jsx';
+import RiskRing from './RiskRing.jsx';
+import DonationRing from './DonationRing.jsx';
 
 export default function PlayerModal({ tag, onClose }) {
   const [player, setPlayer] = useState(null);
@@ -60,6 +62,18 @@ export default function PlayerModal({ tag, onClose }) {
                 <div>
                   <p className="text-sm text-slate-500">Days in Clan</p>
                   <p className="text-xl font-semibold">{player.loyalty}</p>
+                </div>
+              </div>
+
+              <div className="mt-4">
+                <p className="font-semibold mb-2">Member Health</p>
+                <div className="flex justify-center gap-6">
+                  <RiskRing score={player.risk_score} size={64} />
+                  <DonationRing
+                    donations={player.donations}
+                    received={player.donationsReceived}
+                    size={64}
+                  />
                 </div>
               </div>
 

--- a/front-end/src/components/ProfileCard.jsx
+++ b/front-end/src/components/ProfileCard.jsx
@@ -25,14 +25,13 @@ export default function ProfileCard({ member, onClick }) {
       <RiskRing score={member.risk_score} size={48} />
       <div className="mt-2 text-center space-y-1 w-full">
         <p>TH{member.townHallLevel}</p>
-        <p className="flex justify-between">
-          <span>{member.donations}/{member.donationsReceived}</span>
+        <div className="flex justify-end">
           <DonationRing
             donations={member.donations}
             received={member.donationsReceived}
             size={32}
           />
-        </p>
+        </div>
         <p className="text-xs text-slate-500">
           {member.last_seen ? timeAgo(member.last_seen) : '\u2014'}
         </p>

--- a/front-end/src/lib/townhall.js
+++ b/front-end/src/lib/townhall.js
@@ -1,3 +1,4 @@
 export function getTownHallIcon(level) {
-  return `https://raw.githubusercontent.com/smlbiobot/coc-assets/master/png/town-hall/town-hall-${level}.png`;
+  const sanitized = String(level).replace('.', '-');
+  return new URL(`../assets/Town_Hall${sanitized}.webp`, import.meta.url).href;
 }


### PR DESCRIPTION
## Summary
- render donation ring alone on profile cards
- show risk & donation rings in player modal as **Member Health** section
- generate town hall icons from local assets instead of external URLs
- remove unused town hall binary assets

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876de0dc364832c8850fdfc82400e8e