### PR TITLE
Deploy front-end to S3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,10 @@ jobs:
     env:
       AWS_REGION: ${{ secrets.AWS_REGION }}
       ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-      APP_REPOSITORY: ${{ secrets.APP_REPOSITORY }}
       WORKER_REPOSITORY: ${{ secrets.WORKER_REPOSITORY }}
       STATIC_REPOSITORY: ${{ secrets.STATIC_REPOSITORY }}
+      FRONTEND_BUCKET: ${{ secrets.FRONTEND_BUCKET }}
       CLUSTER: ${{ secrets.CLUSTER }}
-      APP_SERVICE: ${{ secrets.APP_SERVICE }}
       WORKER_SERVICE: ${{ secrets.WORKER_SERVICE }}
       STATIC_SERVICE: ${{ secrets.STATIC_SERVICE }}
       VITE_API_URL: ${{ secrets.VITE_API_URL }}
@@ -61,22 +60,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and push app image
+      - name: Build front-end
         if: steps.changes.outputs.app_any_changed == 'true'
         run: |
-          docker buildx build \
-            --platform linux/arm64 \
-            -f front-end/Dockerfile \
-            --build-arg VITE_API_URL=$VITE_API_URL \
-            --build-arg VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID \
-            -t $ECR_REGISTRY/$APP_REPOSITORY:latest \
-            -t $ECR_REGISTRY/$APP_REPOSITORY:${{ github.sha }} \
-            --push front-end
-          task_def=$(aws ecs describe-services --cluster $CLUSTER --services $APP_SERVICE --query 'services[0].taskDefinition' --output text)
-          aws ecs describe-task-definition --task-definition "$task_def" --query 'taskDefinition' > taskdef.json
-          jq --arg IMAGE "$ECR_REGISTRY/$APP_REPOSITORY:${{ github.sha }}" 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy, .deregisteredAt) | .containerDefinitions[].image=$IMAGE' taskdef.json > new-taskdef.json
-          new_def=$(aws ecs register-task-definition --cli-input-json file://new-taskdef.json --query 'taskDefinition.taskDefinitionArn' --output text)
-          aws ecs update-service --cluster $CLUSTER --service $APP_SERVICE --task-definition "$new_def"
+          npm ci --prefix front-end
+          VITE_API_URL=$VITE_API_URL \
+          VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID \
+          npm run --prefix front-end build
+
+      - name: Sync front-end to S3
+        if: steps.changes.outputs.app_any_changed == 'true'
+        run: aws s3 sync front-end/dist s3://$FRONTEND_BUCKET --delete
 
       - name: Build and push worker image
         if: steps.changes.outputs.worker_any_changed == 'true'

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -1,8 +1,9 @@
 # GitHub Actions deployment
 
-This repository ships with a workflow that builds Docker images and deploys them to
-Amazon ECS. Images are only rebuilt when files in their respective directories
-change.
+This repository ships with a workflow that builds Docker images for the Python
+services and deploys them to Amazon ECS. The front-end is uploaded to an S3
+bucket instead of running in a container. Images are only rebuilt when files in
+their respective directories change.
 
 ## Workflow summary
 
@@ -10,9 +11,11 @@ The workflow lives at `.github/workflows/deploy.yml` and runs on every push to t
 `main` branch. It performs the following steps:
 
 1. Detects which subdirectories changed using `tj-actions/changed-files`.
-2. Logs in to Amazon ECR and builds the Docker images for the changed services.
-3. Pushes the images with the tags `latest` and the Git commit SHA.
-4. Forces the corresponding ECS service to deploy the new image.
+2. Logs in to Amazon ECR and builds the Docker images for any changed Python
+   services.
+3. Uploads the rebuilt front-end to the configured S3 bucket.
+4. Pushes new images to ECR and forces the corresponding ECS services to deploy
+   them.
 
 ## Required GitHub secrets
 
@@ -23,19 +26,19 @@ access AWS resources:
 - `AWS_SECRET_ACCESS_KEY` – secret for the key above.
 - `AWS_REGION` – AWS region where the cluster lives.
 - `ECR_REGISTRY` – registry domain, e.g. `123456789012.dkr.ecr.us-east-1.amazonaws.com`.
-- `APP_REPOSITORY` – ECR repository for the front‑end image.
 - `WORKER_REPOSITORY` – repository for the worker service image.
 - `STATIC_REPOSITORY` – repository for the static sync image.
+- `FRONTEND_BUCKET` – S3 bucket used to host the front-end.
 - `CLUSTER` – name of the ECS cluster.
-- `APP_SERVICE` – ECS service name for the front‑end.
 - `WORKER_SERVICE` – service name for the worker.
 - `STATIC_SERVICE` – service name for the static sync job.
 
 ## First‑time setup
 
-1. Create the three ECR repositories referenced above.
-2. Grant the IAM user or role used by the workflow permissions to push to ECR and
-   update ECS services.
+1. Create the worker and static ECR repositories as well as the S3 bucket for
+   the front-end.
+2. Grant the IAM user or role used by the workflow permissions to push to ECR,
+   sync files to S3 and update ECS services.
 3. Populate all required secrets in the GitHub repository settings.
 4. Push to the `main` branch to trigger the workflow. Only services with modified
    files will rebuild and deploy.

--- a/S3MIGRATIONTIPS.md
+++ b/S3MIGRATIONTIPS.md
@@ -1,0 +1,11 @@
+# S3 Deployment Migration
+
+Follow this checklist to switch the dashboard front-end from an ECS service to a static S3 website.
+
+- [ ] **Create the S3 bucket** using the Terraform module. Enable static website hosting and public read access as shown in `terraform.tf`.
+- [ ] **Configure a domain or CloudFront distribution** to point at the bucket if desired.
+- [ ] **Populate the `FRONTEND_BUCKET` secret** in GitHub with the name of the bucket.
+- [ ] **Remove the old front-end ECS service and ECR repository** once traffic is served from S3.
+- [ ] **Push to `main`** to trigger the updated workflow and verify that files upload correctly.
+
+The workflow will now build the React project and sync the `dist/` directory to S3 whenever files in `front-end/` change.


### PR DESCRIPTION
## Summary
- publish the React build to S3 instead of building a container
- document the updated workflow and new secrets
- add migration checklist for switching to S3

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm test`
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e7f48a7c832cb9045c7077cdb128