### PR TITLE
Display last seen time in presence dot

### DIFF
--- a/front-end/src/components/PlayerModal.jsx
+++ b/front-end/src/components/PlayerModal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { fetchJSONCached } from '../lib/api.js';
-import { timeAgo } from '../lib/time.js';
+
 import Loading from './Loading.jsx';
 import RiskRing from './RiskRing.jsx';
 import DonationRing from './DonationRing.jsx';
@@ -81,11 +81,8 @@ export default function PlayerModal({ tag, onClose }) {
                       <p className="text-xs text-slate-500 mt-1">Donations</p>
                     </div>
                     <div className="flex flex-col items-center">
-                      <PresenceDot lastSeen={player.last_seen} />
+                      <PresenceDot lastSeen={player.last_seen} size={64} />
                       <p className="text-xs text-slate-500 mt-1">Seen</p>
-                      <p className="text-xs text-slate-500">
-                        {player.last_seen ? timeAgo(player.last_seen) : '—'}
-                      </p>
                     </div>
                   </div>
                 </div>

--- a/front-end/src/components/PresenceDot.jsx
+++ b/front-end/src/components/PresenceDot.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { shortTimeAgo } from '../lib/time.js';
 
 export default function PresenceDot({ lastSeen, size = 16 }) {
   let color = 'bg-gray-400';
+  let label = '';
   if (lastSeen) {
     const diffDays = Math.floor((Date.now() - new Date(lastSeen).getTime()) / 86400000);
     if (diffDays >= 4) {
@@ -11,11 +13,17 @@ export default function PresenceDot({ lastSeen, size = 16 }) {
     } else {
       color = 'bg-green-600';
     }
+    label = shortTimeAgo(lastSeen);
   }
+
+  const showLabel = size >= 24 && label;
+
   return (
     <span
-      className={`inline-block rounded-full ${color}`}
+      className={`inline-flex items-center justify-center rounded-full ${color} ${showLabel ? 'text-white font-semibold text-xs' : ''}`}
       style={{ width: size, height: size }}
-    />
+    >
+      {showLabel ? label : null}
+    </span>
   );
 }

--- a/front-end/src/lib/time.js
+++ b/front-end/src/lib/time.js
@@ -15,3 +15,21 @@ export function timeAgo(date) {
     const diffDay = Math.floor(diffHr / 24);
     return `${diffDay} day${diffDay === 1 ? '' : 's'} ago`;
 }
+
+export function shortTimeAgo(date) {
+    const ts = new Date(date).getTime();
+    const diffSec = Math.floor((Date.now() - ts) / 1000);
+    if (diffSec < 60) {
+        return `${diffSec}s`;
+    }
+    const diffMin = Math.floor(diffSec / 60);
+    if (diffMin < 60) {
+        return `${diffMin}m`;
+    }
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) {
+        return `${diffHr}h`;
+    }
+    const diffDay = Math.floor(diffHr / 24);
+    return `${diffDay}d`;
+}

--- a/front-end/src/lib/time.test.js
+++ b/front-end/src/lib/time.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { timeAgo } from './time.js';
+import { timeAgo, shortTimeAgo } from './time.js';
 
 afterEach(() => {
   vi.useRealTimers();
@@ -24,5 +24,27 @@ describe('timeAgo', () => {
   it('formats days ago', () => {
     vi.setSystemTime(new Date('2024-01-04T00:00:00Z'));
     expect(timeAgo('2024-01-01T00:00:00Z')).toBe('3 days ago');
+  });
+});
+
+describe('shortTimeAgo', () => {
+  it('formats seconds', () => {
+    vi.setSystemTime(new Date('2024-01-01T00:00:30Z'));
+    expect(shortTimeAgo('2024-01-01T00:00:00Z')).toBe('30s');
+  });
+
+  it('formats minutes', () => {
+    vi.setSystemTime(new Date('2024-01-01T00:02:00Z'));
+    expect(shortTimeAgo('2024-01-01T00:00:00Z')).toBe('2m');
+  });
+
+  it('formats hours', () => {
+    vi.setSystemTime(new Date('2024-01-01T03:00:00Z'));
+    expect(shortTimeAgo('2024-01-01T00:00:00Z')).toBe('3h');
+  });
+
+  it('formats days', () => {
+    vi.setSystemTime(new Date('2024-01-04T00:00:00Z'));
+    expect(shortTimeAgo('2024-01-01T00:00:00Z')).toBe('3d');
   });
 });


### PR DESCRIPTION
## Summary
- show relative time inside `PresenceDot`
- enlarge presence dot in player modal and remove extraneous time text
- add a short time formatter and accompanying tests

## Testing
- `ruff check back-end sync coclib db`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876f8c7e214832cad9c25e763ae0fd0