### PR TITLE
Fix member list scrolling and search results

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -43,6 +43,7 @@ export default function App() {
   });
   const [initials, setInitials] = useState(() => (token ? getInitials(token) : ''));
   const [playerTag, setPlayerTag] = useState(null);
+  const [homeClanTag, setHomeClanTag] = useState(null);
   const [clanTag, setClanTag] = useState(null);
   const [clanInfo, setClanInfo] = useState(null);
   const [showClanInfo, setShowClanInfo] = useState(false);
@@ -85,7 +86,10 @@ export default function App() {
         setPlayerTag(me.player_tag);
         if (me.player_tag) {
           const player = await fetchJSON(`/player/${encodeURIComponent(me.player_tag)}`);
-          if (player.clanTag) setClanTag(player.clanTag);
+          if (player.clanTag) {
+            setClanTag(player.clanTag);
+            setHomeClanTag(player.clanTag);
+          }
         }
       } catch {
         setToken(null);
@@ -100,7 +104,10 @@ export default function App() {
       if (!token || !playerTag) return;
       try {
         const player = await fetchJSON(`/player/${encodeURIComponent(playerTag)}`);
-        if (player.clanTag) setClanTag(player.clanTag);
+        if (player.clanTag) {
+          setClanTag(player.clanTag);
+          if (!homeClanTag) setHomeClanTag(player.clanTag);
+        }
       } catch {
         /* ignore */
       }
@@ -175,6 +182,14 @@ export default function App() {
           </button>
         </h1>
         <div className="flex items-center gap-3">
+          {homeClanTag && clanTag !== homeClanTag && (
+            <button
+              className="p-2 rounded hover:bg-slate-700"
+              onClick={() => setClanTag(homeClanTag)}
+            >
+              <i data-lucide="arrow-left" className="w-5 h-5" />
+            </button>
+          )}
           <button
             className="p-2 rounded hover:bg-slate-700"
             onClick={() => setShowSearch(true)}
@@ -226,7 +241,13 @@ export default function App() {
       </main>
       {showSearch && (
         <Suspense fallback={<Loading className="h-screen" />}>
-          <ClanSearchModal onClose={() => setShowSearch(false)} onClanLoaded={setClanInfo} />
+          <ClanSearchModal
+            onClose={() => setShowSearch(false)}
+            onClanLoaded={(c) => {
+              setClanTag(c.tag);
+              setShowSearch(false);
+            }}
+          />
         </Suspense>
       )}
       {showClanInfo && (

--- a/front-end/src/components/LoyaltyRing.jsx
+++ b/front-end/src/components/LoyaltyRing.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+export default function LoyaltyRing({ days, size = 60 }) {
+  const radius = (size - 6) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const maxDays = 180;
+  const pct = Math.min(1, Math.max(0, days / maxDays));
+  const offset = circumference - pct * circumference;
+
+  let color = 'stroke-red-600';
+  if (days >= 90) {
+    color = 'stroke-green-600';
+  } else if (days >= 30) {
+    color = 'stroke-yellow-400';
+  }
+
+  return (
+    <svg width={size} height={size} className="flex-shrink-0">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="#e5e7eb"
+        strokeWidth="6"
+        fill="none"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        className={color}
+        strokeWidth="6"
+        fill="none"
+        strokeLinecap="round"
+      />
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        className="text-xs font-semibold"
+      >
+        {days}
+      </text>
+    </svg>
+  );
+}

--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -11,10 +11,14 @@ function Row({ index, style, data }) {
   const open = openIndex === index;
   const toggle = () => {
     const prev = openIndex;
-    setOpenIndex(open ? null : index);
+    const next = open ? null : index;
+    setOpenIndex(next);
     if (listRef.current) {
       const start = Math.min(index, prev ?? index);
       listRef.current.resetAfterIndex(start);
+      if (next !== null) {
+        requestAnimationFrame(() => listRef.current?.scrollToItem(next));
+      }
     }
   };
   return (

--- a/front-end/src/components/PlayerModal.jsx
+++ b/front-end/src/components/PlayerModal.jsx
@@ -5,6 +5,7 @@ import Loading from './Loading.jsx';
 import RiskRing from './RiskRing.jsx';
 import DonationRing from './DonationRing.jsx';
 import PresenceDot from './PresenceDot.jsx';
+import LoyaltyRing from './LoyaltyRing.jsx';
 
 export default function PlayerModal({ tag, onClose }) {
   const [player, setPlayer] = useState(null);
@@ -28,7 +29,7 @@ export default function PlayerModal({ tag, onClose }) {
     <>
       <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose}></div>
       <div className="fixed inset-0 flex items-center justify-center z-50">
-        <div className="bg-white w-full max-w-lg rounded-xl shadow-xl p-6 relative">
+        <div className="bg-white w-full max-w-md rounded-xl shadow-xl p-6 relative">
           <button className="absolute top-3 right-3 text-slate-400" onClick={onClose}>✕</button>
           {!player && !error && <p className="text-center py-8">Loading…</p>}
           {!player && !error && <Loading className="py-8" />}
@@ -42,26 +43,26 @@ export default function PlayerModal({ tag, onClose }) {
                 <span>{player.name}</span>
                 <span className="text-sm font-normal text-slate-500">{player.tag}</span>
               </h3>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
-                <div>
-                  <p className="text-sm text-slate-500">Town Hall</p>
-                  <p className="text-xl font-semibold">{player.townHallLevel}</p>
+              <div className="space-y-2 mt-4">
+                <div className="flex justify-between gap-4">
+                  <div>
+                    <p className="text-sm text-slate-500">Town Hall</p>
+                    <p className="text-xl font-semibold">{player.townHallLevel}</p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-slate-500">Trophies</p>
+                    <p className="text-xl font-semibold">{player.trophies}</p>
+                  </div>
                 </div>
-                <div>
-                  <p className="text-sm text-slate-500">Trophies</p>
-                  <p className="text-xl font-semibold">{player.trophies}</p>
-                </div>
-                <div>
-                  <p className="text-sm text-slate-500">Donations</p>
-                  <p className="text-xl font-semibold">{player.donations}</p>
-                </div>
-                <div>
-                  <p className="text-sm text-slate-500">Received</p>
-                  <p className="text-xl font-semibold">{player.donationsReceived}</p>
-                </div>
-                <div>
-                  <p className="text-sm text-slate-500">Days in Clan</p>
-                  <p className="text-xl font-semibold">{player.loyalty}</p>
+                <div className="flex justify-between gap-4">
+                  <div>
+                    <p className="text-sm text-slate-500">Donations</p>
+                    <p className="text-xl font-semibold">{player.donations}</p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-slate-500">Received</p>
+                    <p className="text-xl font-semibold">{player.donationsReceived}</p>
+                  </div>
                 </div>
               </div>
 
@@ -83,6 +84,10 @@ export default function PlayerModal({ tag, onClose }) {
                     <div className="flex flex-col items-center">
                       <PresenceDot lastSeen={player.last_seen} size={64} />
                       <p className="text-xs text-slate-500 mt-1">Seen</p>
+                    </div>
+                    <div className="flex flex-col items-center">
+                      <LoyaltyRing days={player.loyalty} size={64} />
+                      <p className="text-xs text-slate-500 mt-1">In Clan</p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- add LoyaltyRing component for player loyalty visualization
- scroll to an expanded member on mobile
- tweak PlayerModal layout with smaller card and improved rings
- allow viewing other clans and returning to home clan

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687701475518832c8c74cae0514c8589