### PR TITLE
Add user profile and preferences

### DIFF
--- a/back-end/app/api/clan_routes.py
+++ b/back-end/app/api/clan_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, g
 
 from ..services.snapshot_service import get_clan as get_clan_snapshot
 from coclib.services.loyalty_service import get_clan_loyalty
@@ -16,7 +16,16 @@ async def clan_profile(tag: str):
 
 @bp.get("/<string:tag>/members/at-risk")
 async def at_risk(tag: str):
-    scores = await clan_at_risk(tag.upper())
+    weights = None
+    profile = getattr(g.user, "profile", None)
+    if profile:
+        weights = {
+            "war": profile.risk_weight_war,
+            "idle": profile.risk_weight_idle,
+            "don_deficit": profile.risk_weight_don_deficit,
+            "don_drop": profile.risk_weight_don_drop,
+        }
+    scores = await clan_at_risk(tag.upper(), weights=weights)
     return jsonify(scores)
 
 

--- a/back-end/app/api/user_routes.py
+++ b/back-end/app/api/user_routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, jsonify, request, g, abort
 from coclib.extensions import db
 from coclib.utils import normalize_tag
+from coclib.models import UserProfile
 from . import API_PREFIX
 
 bp = Blueprint("user", __name__, url_prefix=f"{API_PREFIX}/user")
@@ -27,3 +28,35 @@ def set_player_tag():
     db.session.add(g.user)
     db.session.commit()
     return jsonify({"player_tag": g.user.player_tag})
+
+
+@bp.get("/profile")
+def get_profile():
+    prof = g.user.profile
+    if not prof:
+        prof = UserProfile(user_id=g.user.id)
+        db.session.add(prof)
+        db.session.commit()
+    return jsonify(
+        {
+            "risk_weight_war": prof.risk_weight_war,
+            "risk_weight_idle": prof.risk_weight_idle,
+            "risk_weight_don_deficit": prof.risk_weight_don_deficit,
+            "risk_weight_don_drop": prof.risk_weight_don_drop,
+            "is_leader": prof.is_leader,
+        }
+    )
+
+
+@bp.post("/profile")
+def update_profile():
+    data = request.get_json(silent=True) or {}
+    prof = g.user.profile or UserProfile(user_id=g.user.id)
+    prof.risk_weight_war = float(data.get("risk_weight_war", prof.risk_weight_war))
+    prof.risk_weight_idle = float(data.get("risk_weight_idle", prof.risk_weight_idle))
+    prof.risk_weight_don_deficit = float(data.get("risk_weight_don_deficit", prof.risk_weight_don_deficit))
+    prof.risk_weight_don_drop = float(data.get("risk_weight_don_drop", prof.risk_weight_don_drop))
+    prof.is_leader = bool(data.get("is_leader", prof.is_leader))
+    db.session.add(prof)
+    db.session.commit()
+    return jsonify({"status": "ok"})

--- a/coclib/models.py
+++ b/coclib/models.py
@@ -103,3 +103,17 @@ class User(db.Model):
     name = db.Column(db.String(255))
     player_tag = db.Column(db.String(15), index=True)
 
+
+class UserProfile(db.Model):
+    __tablename__ = "user_profiles"
+
+    id = db.Column(db.BigInteger, primary_key=True)
+    user_id = db.Column(db.BigInteger, db.ForeignKey("users.id"), unique=True, nullable=False)
+    risk_weight_war = db.Column(db.Float, nullable=False, default=0.40)
+    risk_weight_idle = db.Column(db.Float, nullable=False, default=0.35)
+    risk_weight_don_deficit = db.Column(db.Float, nullable=False, default=0.15)
+    risk_weight_don_drop = db.Column(db.Float, nullable=False, default=0.10)
+    is_leader = db.Column(db.Boolean, nullable=False, default=False)
+
+    user = db.relationship("User", backref=db.backref("profile", uselist=False))
+

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -6,6 +6,7 @@ import { fetchJSON } from './lib/api.js';
 const Dashboard = lazy(() => import('./pages/Dashboard.jsx'));
 const ClanSearchModal = lazy(() => import('./components/ClanSearchModal.jsx'));
 const ClanModal = lazy(() => import('./components/ClanModal.jsx'));
+const ProfileModal = lazy(() => import('./components/ProfileModal.jsx'));
 
 function isTokenExpired(tok) {
   try {
@@ -50,6 +51,7 @@ export default function App() {
   const [loadingUser, setLoadingUser] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
+  const [showProfile, setShowProfile] = useState(false);
   const menuRef = React.useRef(null);
 
   useEffect(() => {
@@ -209,6 +211,15 @@ export default function App() {
                 <button
                   className="block w-full text-left px-3 py-2 hover:bg-slate-100"
                   onClick={() => {
+                    setShowMenu(false);
+                    setShowProfile(true);
+                  }}
+                >
+                  Profile
+                </button>
+                <button
+                  className="block w-full text-left px-3 py-2 hover:bg-slate-100"
+                  onClick={() => {
                     window.google?.accounts.id.disableAutoSelect();
                     localStorage.removeItem('token');
                     setToken(null);
@@ -253,6 +264,11 @@ export default function App() {
       {showClanInfo && (
         <Suspense fallback={<Loading className="h-screen" />}>
           <ClanModal clan={clanInfo} onClose={() => setShowClanInfo(false)} />
+        </Suspense>
+      )}
+      {showProfile && (
+        <Suspense fallback={<Loading className="h-screen" />}>
+          <ProfileModal onClose={() => setShowProfile(false)} />
         </Suspense>
       )}
     </>

--- a/front-end/src/components/PlayerModal.jsx
+++ b/front-end/src/components/PlayerModal.jsx
@@ -5,7 +5,7 @@ import Loading from './Loading.jsx';
 import RiskRing from './RiskRing.jsx';
 import DonationRing from './DonationRing.jsx';
 import PresenceDot from './PresenceDot.jsx';
-import LoyaltyBadge from './LoyaltyBadge.jsx';
+import { timeAgo } from '../lib/time.js';
 
 export default function PlayerModal({ tag, onClose }) {
   const [player, setPlayer] = useState(null);
@@ -79,8 +79,10 @@ export default function PlayerModal({ tag, onClose }) {
                       <p className="text-xs text-slate-500 mt-1">Seen</p>
                     </div>
                     <div className="flex flex-col items-center">
-                      <LoyaltyBadge days={player.loyalty} size={64} />
-                      <p className="text-xs text-slate-500 mt-1">In Clan</p>
+                      <span className="text-lg font-semibold">
+                        {player.last_seen ? timeAgo(player.last_seen) : '—'}
+                      </span>
+                      <p className="text-xs text-slate-500 mt-1">Last Seen</p>
                     </div>
                   </div>
                 </div>

--- a/front-end/src/components/ProfileModal.jsx
+++ b/front-end/src/components/ProfileModal.jsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { fetchJSON } from '../lib/api.js';
+import Loading from './Loading.jsx';
+
+export default function ProfileModal({ onClose }) {
+  const [profile, setProfile] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchJSON('/user/profile');
+        setProfile(data);
+      } catch {
+        setProfile({});
+      }
+    };
+    load();
+  }, []);
+
+  const handleChange = (key, value) => {
+    setProfile((p) => ({ ...p, [key]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await fetchJSON('/user/profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(profile),
+      });
+      onClose();
+    } catch {
+      setSaving(false);
+    }
+  };
+
+  if (!profile) return (
+    <>
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose}></div>
+      <div className="fixed inset-0 flex items-center justify-center z-50"><Loading className="py-8" /></div>
+    </>
+  );
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose}></div>
+      <div className="fixed inset-0 flex items-center justify-center z-50">
+        <form className="bg-white w-full max-w-md rounded-xl shadow-xl p-6 relative space-y-4" onSubmit={handleSubmit}>
+          <button type="button" className="absolute top-3 right-3 text-slate-400" onClick={onClose}>✕</button>
+          <h3 className="text-xl font-semibold">Profile</h3>
+          <label className="block">
+            <span className="text-sm">War Weight</span>
+            <input type="number" step="0.01" value={profile.risk_weight_war ?? 0} onChange={(e) => handleChange('risk_weight_war', parseFloat(e.target.value))} className="mt-1 w-full border px-2 py-1 rounded" />
+          </label>
+          <label className="block">
+            <span className="text-sm">Idle Weight</span>
+            <input type="number" step="0.01" value={profile.risk_weight_idle ?? 0} onChange={(e) => handleChange('risk_weight_idle', parseFloat(e.target.value))} className="mt-1 w-full border px-2 py-1 rounded" />
+          </label>
+          <label className="block">
+            <span className="text-sm">Deficit Weight</span>
+            <input type="number" step="0.01" value={profile.risk_weight_don_deficit ?? 0} onChange={(e) => handleChange('risk_weight_don_deficit', parseFloat(e.target.value))} className="mt-1 w-full border px-2 py-1 rounded" />
+          </label>
+          <label className="block">
+            <span className="text-sm">Drop Weight</span>
+            <input type="number" step="0.01" value={profile.risk_weight_don_drop ?? 0} onChange={(e) => handleChange('risk_weight_don_drop', parseFloat(e.target.value))} className="mt-1 w-full border px-2 py-1 rounded" />
+          </label>
+          <button type="submit" className="px-4 py-2 rounded bg-slate-800 text-white w-full">{saving ? 'Saving…' : 'Save'}</button>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/migrations/versions/d349998f6174_add_user_profile_model.py
+++ b/migrations/versions/d349998f6174_add_user_profile_model.py
@@ -1,0 +1,28 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'd349998f6174'
+down_revision = 'f9040a4059c4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'user_profiles',
+        sa.Column('id', sa.BigInteger(), nullable=False),
+        sa.Column('user_id', sa.BigInteger(), nullable=False),
+        sa.Column('risk_weight_war', sa.Float(), nullable=False, server_default='0.4'),
+        sa.Column('risk_weight_idle', sa.Float(), nullable=False, server_default='0.35'),
+        sa.Column('risk_weight_don_deficit', sa.Float(), nullable=False, server_default='0.15'),
+        sa.Column('risk_weight_don_drop', sa.Float(), nullable=False, server_default='0.1'),
+        sa.Column('is_leader', sa.Boolean(), nullable=False, server_default='0'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('user_id')
+    )
+
+
+def downgrade():
+    op.drop_table('user_profiles')


### PR DESCRIPTION
## Summary
- add `UserProfile` model and migration
- expose profile API endpoints
- use profile weights for risk calculation
- add profile modal and menu option in the UI
- display last seen instead of clan loyalty ring
- fix last seen timestamps

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68772280b55c832cbd952ba9ee21e54f