### PR TITLE
Add ETag cache validation

### DIFF
--- a/front-end/README.md
+++ b/front-end/README.md
@@ -41,3 +41,11 @@ docker build \
   -t dashboard .
 ```
 
+### Cache invalidation
+
+API responses are cached in `localStorage` along with the `ETag` header returned
+by CloudFront. When a cached entry is used, the last seen `ETag` is sent with
+`If-None-Match` so unchanged content results in a `304` response and the
+timestamp is refreshed. When the content changes, the new payload and `ETag`
+replace the cached version, ensuring users always see the latest data.
+

--- a/front-end/src/lib/api.js
+++ b/front-end/src/lib/api.js
@@ -39,37 +39,73 @@ export async function fetchJSON(path, options = {}) {
 const CACHE_PREFIX = 'cache:';
 const CACHE_TTL = 60 * 1000; // 1 minute
 
+async function requestWithETag(path, options = {}, etag) {
+    const token = localStorage.getItem('token');
+    const headers = {
+        ...(options.headers || {}),
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(etag ? { 'If-None-Match': etag } : {}),
+    };
+    const res = await fetch(`${API_URL}${API_PREFIX}${path}`, { ...options, headers });
+    if (res.status === 401) {
+        localStorage.removeItem('token');
+    }
+    if (res.status === 304) {
+        return { notModified: true, etag: res.headers.get('ETag') || etag, data: null };
+    }
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    return { notModified: false, etag: res.headers.get('ETag') || etag, data };
+}
+
 export async function fetchJSONCached(path, options = {}) {
     const key = `${CACHE_PREFIX}${path}`;
+    let parsed;
     const cached = localStorage.getItem(key);
     if (cached) {
         try {
-            const parsed = JSON.parse(cached);
-            const hasMeta = Object.prototype.hasOwnProperty.call(parsed, 'ts');
-            const ts = hasMeta ? parsed.ts : 0;
-            const data = hasMeta ? parsed.data : parsed;
-            const age = Date.now() - ts;
-            if (hasMeta && age < CACHE_TTL) {
-                fetchJSON(path, options)
-                    .then((fresh) => {
-                        try {
-                            localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data: fresh }));
-                        } catch {
-                            /* ignore */
-                        }
-                    })
-                    .catch(() => {});
-                return data;
-            }
+            parsed = JSON.parse(cached);
         } catch {
             localStorage.removeItem(key);
         }
     }
-    const fresh = await fetchJSON(path, options);
+
+    const hasMeta = parsed && Object.prototype.hasOwnProperty.call(parsed, 'ts');
+    const ts = hasMeta ? parsed.ts : 0;
+    const data = hasMeta ? parsed.data : parsed;
+    const etag = hasMeta ? parsed.etag : null;
+    const age = Date.now() - ts;
+
+    if (hasMeta && age < CACHE_TTL) {
+        requestWithETag(path, options, etag)
+            .then((res) => {
+                try {
+                    if (res.notModified) {
+                        localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data, etag: res.etag }));
+                    } else {
+                        localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data: res.data, etag: res.etag }));
+                    }
+                } catch {
+                    /* ignore */
+                }
+            })
+            .catch(() => {});
+        return data;
+    }
+
+    const res = await requestWithETag(path, options, etag);
+    if (res.notModified) {
+        try {
+            localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data, etag: res.etag }));
+        } catch {
+            /* ignore */
+        }
+        return data;
+    }
     try {
-        localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data: fresh }));
+        localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data: res.data, etag: res.etag }));
     } catch {
         /* ignore */
     }
-    return fresh;
+    return res.data;
 }

--- a/front-end/src/lib/api.test.js
+++ b/front-end/src/lib/api.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchJSONCached, API_URL } from './api.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  localStorage.clear();
+});
+
+describe('fetchJSONCached', () => {
+  it('returns cached data on 304 using ETag', async () => {
+    vi.useFakeTimers();
+    const firstResponse = new Response(JSON.stringify({ foo: 'bar' }), {
+      status: 200,
+      headers: { ETag: 'v1' },
+    });
+    const secondResponse = new Response(null, {
+      status: 304,
+      headers: { ETag: 'v1' },
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(firstResponse)
+      .mockResolvedValueOnce(secondResponse);
+    global.fetch = fetchMock;
+
+    vi.setSystemTime(0);
+    const data1 = await fetchJSONCached('/test');
+    expect(data1).toEqual({ foo: 'bar' });
+
+    vi.setSystemTime(61000);
+    const data2 = await fetchJSONCached('/test');
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      `${API_URL}/api/v1/test`,
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'If-None-Match': 'v1' }),
+      }),
+    );
+    expect(data2).toEqual({ foo: 'bar' });
+  });
+});


### PR DESCRIPTION
## Summary
- use CloudFront `ETag` headers for localStorage cache invalidation
- document cache invalidation in the React app
- test that `fetchJSONCached` sends `If-None-Match` when an ETag is stored

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877290c1ac8832c98b52f61f1bbef24