### PR TITLE
Fix ETag fetch when CloudFront blocks GET bodies

### DIFF
--- a/front-end/src/lib/api.js
+++ b/front-end/src/lib/api.js
@@ -41,12 +41,16 @@ const CACHE_TTL = 60 * 1000; // 1 minute
 
 async function requestWithETag(path, options = {}, etag) {
     const token = localStorage.getItem('token');
+    const cleanOptions = { ...options };
+    if (!cleanOptions.method || cleanOptions.method.toUpperCase() === 'GET') {
+        delete cleanOptions.body;
+    }
     const headers = {
-        ...(options.headers || {}),
+        ...(cleanOptions.headers || {}),
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
         ...(etag ? { 'If-None-Match': etag } : {}),
     };
-    const res = await fetch(`${API_URL}${API_PREFIX}${path}`, { ...options, headers });
+    const res = await fetch(`${API_URL}${API_PREFIX}${path}`, { ...cleanOptions, headers });
     if (res.status === 401) {
         localStorage.removeItem('token');
     }


### PR DESCRIPTION
## Summary
- avoid including `body` for cached GET requests

## Testing
- `ruff check back-end sync coclib db`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687744119c08832cbf9f215d4ad5cb16