### PR TITLE
Fix timezone in snapshot cache

### DIFF
--- a/back-end/app/services/snapshot_service.py
+++ b/back-end/app/services/snapshot_service.py
@@ -161,7 +161,7 @@ async def get_clan(tag: str) -> Optional[ClanDict]:
     tag = normalize_tag(tag)
     cache_key = f"snapshot:clan:{tag}"
     if (cached := cache.get(cache_key)) is not None:
-        cached_ts = datetime.fromisoformat(cached["ts"])
+        cached_ts = datetime.fromisoformat(cached["ts"]).replace(tzinfo=None)
         if datetime.utcnow() - cached_ts <= STALE_AFTER:
             return cached
 
@@ -202,7 +202,7 @@ async def get_player(tag: str) -> Optional[PlayerDict]:
     tag = normalize_tag(tag)
     cache_key = f"snapshot:player:{tag}"
     if (cached := cache.get(cache_key)) is not None:
-        cached_ts = datetime.fromisoformat(cached["ts"])
+        cached_ts = datetime.fromisoformat(cached["ts"]).replace(tzinfo=None)
         if datetime.utcnow() - cached_ts <= STALE_AFTER:
             return cached  # pragma: no cover
 

--- a/sync/services/player_service.py
+++ b/sync/services/player_service.py
@@ -147,7 +147,7 @@ async def get_player_snapshot(tag: str) -> "Optional[PlayerDict]":
     norm_tag = normalize_tag(tag)
     cache_key = f"snapshot:player:{norm_tag}"
     if (cached := cache.get(cache_key)) is not None:
-        cached_ts = datetime.fromisoformat(cached["ts"])
+        cached_ts = datetime.fromisoformat(cached["ts"]).replace(tzinfo=None)
         if datetime.utcnow() - cached_ts <= STALE_AFTER:
             return cached
 

--- a/tests/test_timestamp_parsing.py
+++ b/tests/test_timestamp_parsing.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+
+def test_cache_timestamp_subtraction():
+    ts = datetime.utcnow().isoformat().replace(" ", "T") + "Z"
+    parsed = datetime.fromisoformat(ts).replace(tzinfo=None)
+    assert parsed.tzinfo is None
+    delta = datetime.utcnow() - parsed
+    assert delta.total_seconds() >= 0
+


### PR DESCRIPTION
## Summary
- ensure cached timestamps are parsed as timezone naive
- cover timestamp parsing with unit test

## Testing
- `ruff check back-end sync coclib db`
- `pytest -q`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687746b493d0832ca8bb8198a30903ba