### PR TITLE
Add asset proxy

### DIFF
--- a/back-end/app/api/__init__.py
+++ b/back-end/app/api/__init__.py
@@ -8,6 +8,7 @@ from .player_routes import bp as player_bp
 from .war_routes import bp as war_bp
 from .health_routes import bp as health_bp
 from .user_routes import bp as user_bp
+from .asset_routes import bp as asset_bp
 
 
 def register_blueprints(app: Flask):
@@ -16,3 +17,4 @@ def register_blueprints(app: Flask):
     app.register_blueprint(war_bp)
     app.register_blueprint(health_bp)
     app.register_blueprint(user_bp)
+    app.register_blueprint(asset_bp)

--- a/back-end/app/api/asset_routes.py
+++ b/back-end/app/api/asset_routes.py
@@ -1,0 +1,32 @@
+from flask import Blueprint, request, abort, Response
+import requests
+from urllib.parse import urlparse
+
+from coclib.extensions import cache
+from . import API_PREFIX
+
+bp = Blueprint("assets", __name__, url_prefix=f"{API_PREFIX}/assets")
+
+ALLOWED_HOST = "api-assets.clashofclans.com"
+
+
+@bp.get("/")
+def proxy_asset():
+    url = request.args.get("url", "")
+    if not url:
+        abort(400)
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or parsed.netloc != ALLOWED_HOST:
+        abort(400)
+    cache_key = f"asset:{url}"
+    cached = cache.get(cache_key)
+    if cached:
+        data, content_type = cached
+    else:
+        resp = requests.get(url, timeout=10)
+        if resp.status_code != 200:
+            abort(resp.status_code)
+        data = resp.content
+        content_type = resp.headers.get("Content-Type", "image/png")
+        cache.set(cache_key, (data, content_type), timeout=3600)
+    return Response(data, content_type=content_type)

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -2,6 +2,7 @@ import React, { Suspense, lazy, useEffect, useState } from 'react';
 import Loading from './components/Loading.jsx';
 import PlayerTagForm from './components/PlayerTagForm.jsx';
 import { fetchJSON } from './lib/api.js';
+import { proxyImageUrl } from './lib/assets.js';
 
 const Dashboard = lazy(() => import('./pages/Dashboard.jsx'));
 const ClanSearchModal = lazy(() => import('./components/ClanSearchModal.jsx'));
@@ -177,7 +178,7 @@ export default function App() {
       <header className="banner bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 flex items-center justify-between shadow-md">
         <h1 className="text-lg font-semibold flex items-center gap-2">
           {clanInfo?.badgeUrls && (
-            <img src={clanInfo.badgeUrls.small} alt="badge" className="w-6 h-6" />
+            <img src={proxyImageUrl(clanInfo.badgeUrls.small)} alt="badge" className="w-6 h-6" />
           )}
           <button onClick={() => setShowClanInfo(true)} className="hover:underline">
             {clanInfo?.name || 'Clan Dashboard'}

--- a/front-end/src/components/ClanModal.jsx
+++ b/front-end/src/components/ClanModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { proxyImageUrl } from '../lib/assets.js';
 
 export default function ClanModal({ clan, onClose }) {
   if (!clan) return null;
@@ -10,7 +11,7 @@ export default function ClanModal({ clan, onClose }) {
           <button className="absolute top-3 right-3 text-slate-400" onClick={onClose}>✕</button>
           <div className="flex items-center gap-3">
             {clan.badgeUrls && (
-              <img src={clan.badgeUrls.medium} alt="badge" className="w-12 h-12" />
+              <img src={proxyImageUrl(clan.badgeUrls.medium)} alt="badge" className="w-12 h-12" />
             )}
             <div>
               <h3 className="text-xl font-semibold">{clan.name}</h3>

--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -4,6 +4,7 @@ import RiskRing from './RiskRing.jsx';
 import DonationRing from './DonationRing.jsx';
 import { timeAgo } from '../lib/time.js';
 import { getTownHallIcon } from '../lib/townhall.js';
+import { proxyImageUrl } from '../lib/assets.js';
 
 function Row({ index, style, data }) {
   const { members, openIndex, setOpenIndex, getSize, listRef } = data;
@@ -27,7 +28,7 @@ function Row({ index, style, data }) {
         <div className="flex flex-col">
           <div className="flex items-center gap-2">
             {m.leagueIcon && (
-              <img src={m.leagueIcon} alt="league" className="w-5 h-5" />
+              <img src={proxyImageUrl(m.leagueIcon)} alt="league" className="w-5 h-5" />
             )}
             <img
               src={getTownHallIcon(m.townHallLevel)}

--- a/front-end/src/components/PlayerModal.jsx
+++ b/front-end/src/components/PlayerModal.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { fetchJSONCached } from '../lib/api.js';
+import { proxyImageUrl } from '../lib/assets.js';
 
 import Loading from './Loading.jsx';
 import RiskRing from './RiskRing.jsx';
@@ -39,7 +40,7 @@ export default function PlayerModal({ tag, onClose }) {
             <>
               <h3 className="text-xl font-semibold text-slate-800 flex flex-wrap items-center gap-2">
                 {player.leagueIcon && (
-                  <img src={player.leagueIcon} alt="league" className="w-6 h-6" />
+                  <img src={proxyImageUrl(player.leagueIcon)} alt="league" className="w-6 h-6" />
                 )}
                 <span>{player.name}</span>
                 <span className="text-sm font-normal text-slate-500">{player.tag}</span>

--- a/front-end/src/components/ProfileCard.jsx
+++ b/front-end/src/components/ProfileCard.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import RiskRing from './RiskRing.jsx';
 import { timeAgo } from '../lib/time.js';
 import { getTownHallIcon } from '../lib/townhall.js';
+import { proxyImageUrl } from '../lib/assets.js';
 
 export default function ProfileCard({ member, onClick }) {
   if (!member) return null;
@@ -12,7 +13,7 @@ export default function ProfileCard({ member, onClick }) {
     >
       <div className="flex gap-1 mb-1">
         {member.leagueIcon && (
-          <img src={member.leagueIcon} alt="league" className="w-6 h-6" />
+          <img src={proxyImageUrl(member.leagueIcon)} alt="league" className="w-6 h-6" />
         )}
         <img
           src={getTownHallIcon(member.townHallLevel)}

--- a/front-end/src/lib/assets.js
+++ b/front-end/src/lib/assets.js
@@ -1,0 +1,8 @@
+import { API_URL } from './api.js';
+
+const API_PREFIX = '/api/v1';
+
+export function proxyImageUrl(url) {
+  if (!url) return url;
+  return `${API_URL}${API_PREFIX}/assets?url=${encodeURIComponent(url)}`;
+}

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -8,6 +8,7 @@ import DonationRing from '../components/DonationRing.jsx';
 import MemberAccordionList from '../components/MemberAccordionList.jsx';
 import ProfileCard from '../components/ProfileCard.jsx';
 import { getTownHallIcon } from '../lib/townhall.js';
+import { proxyImageUrl } from '../lib/assets.js';
 
 const PlayerModal = lazy(() => import('../components/PlayerModal.jsx'));
 
@@ -21,7 +22,7 @@ function Stat({icon, iconUrl, label, value, onClick}) {
             {(iconUrl || icon) && (
                 <div className="p-3 rounded-full bg-slate-200">
                     {iconUrl ? (
-                        <img src={iconUrl} alt="icon" className="w-7 h-7" />
+                        <img src={proxyImageUrl(iconUrl)} alt="icon" className="w-7 h-7" />
                     ) : (
                         <i data-lucide={icon} className="w-7 h-7"/>
                     )}
@@ -272,7 +273,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                             <td data-label="Player" className="px-4 py-2 font-medium">
                                                 <span className="flex items-center gap-2">
                                                     {m.leagueIcon && (
-                                                        <img src={m.leagueIcon} alt="league" className="w-5 h-5" />
+                                                        <img src={proxyImageUrl(m.leagueIcon)} alt="league" className="w-5 h-5" />
                                                     )}
                                                     <img
                                                         src={getTownHallIcon(m.townHallLevel)}
@@ -356,7 +357,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                 <div className="flex flex-col">
                                                     <span className="flex items-center gap-2">
                                                         {m.leagueIcon && (
-                                                            <img src={m.leagueIcon} alt="league" className="w-5 h-5" />
+                                                            <img src={proxyImageUrl(m.leagueIcon)} alt="league" className="w-5 h-5" />
                                                         )}
                                                         <img
                                                             src={getTownHallIcon(m.townHallLevel)}


### PR DESCRIPTION
## Summary
- introduce new `/api/v1/assets` endpoint that proxies Clash of Clans images
- add front-end helper to call the proxy
- use proxy for league and badge icons

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68774b183f44832c900ba9cc2c419024