### PR TITLE
Add safe_to_thread wrapper

### DIFF
--- a/back-end/app/services/snapshot_service.py
+++ b/back-end/app/services/snapshot_service.py
@@ -5,7 +5,7 @@ import os
 from datetime import datetime, timedelta
 from typing import Optional, TypedDict
 
-from asyncio import to_thread
+from coclib.utils import safe_to_thread
 import httpx
 from sqlalchemy import func
 
@@ -150,7 +150,7 @@ def _latest_members_sync(clan_tag: str) -> list[dict]:
 async def _attach_members(clan_dict: dict) -> dict:
     """Return a copy of *clan_dict* with memberList included."""
     clan_tag = normalize_tag(clan_dict["tag"])
-    members = await to_thread(_latest_members_sync, clan_tag)
+    members = await safe_to_thread(_latest_members_sync, clan_tag)
     enriched = clan_dict.copy()
     enriched["memberList"] = members
     enriched["members"] = len(members)  # keep count accurate

--- a/coclib/utils.py
+++ b/coclib/utils.py
@@ -1,4 +1,20 @@
 from urllib.parse import quote
+from asyncio import to_thread
+
+
+async def safe_to_thread(func, /, *args, **kwargs):
+    """Run ``func`` in a worker thread.
+
+    Falls back to a synchronous call if the default executor has been shut down
+    during application shutdown.
+    """
+    try:
+        return await to_thread(func, *args, **kwargs)
+    except RuntimeError as exc:  # pragma: no cover - defensive fallback
+        msg = str(exc)
+        if "CurrentThreadExecutor" in msg or "new futures" in msg:
+            return func(*args, **kwargs)
+        raise
 
 
 def normalize_tag(tag: str) -> str:

--- a/sync/services/player_service.py
+++ b/sync/services/player_service.py
@@ -1,4 +1,4 @@
-from asyncio import to_thread
+from coclib.utils import safe_to_thread
 from datetime import datetime, timedelta
 import logging
 import os
@@ -158,11 +158,11 @@ async def get_player_snapshot(tag: str) -> "Optional[PlayerDict]":
             .first()
         )
 
-    row = await to_thread(_latest)
+    row = await safe_to_thread(_latest)
     needs_refresh = row is None or (datetime.utcnow() - row.ts > STALE_AFTER)
     if needs_refresh:
         await _trigger_sync(norm_tag)
-        row = await to_thread(_latest)
+        row = await safe_to_thread(_latest)
         if row is None:
             return None
 

--- a/sync/services/war_service.py
+++ b/sync/services/war_service.py
@@ -1,4 +1,4 @@
-from asyncio import to_thread
+from coclib.utils import safe_to_thread
 from datetime import datetime, timedelta
 import logging
 import os
@@ -63,11 +63,11 @@ async def current_war_snapshot(clan_tag: str) -> "dict | None":
     cache_key = f"snapshot:war:{clan_tag}"
     if (cached := cache.get(cache_key)) is not None:
         return cached
-    row = await to_thread(_last_war_sync, clan_tag)
+    row = await safe_to_thread(_last_war_sync, clan_tag)
     needs_refresh = row is None or (datetime.utcnow() - row.ts > STALE_AFTER)
     if needs_refresh:
         await _trigger_sync(clan_tag)
-        row = await to_thread(_last_war_sync, clan_tag)
+        row = await safe_to_thread(_last_war_sync, clan_tag)
         if row is None:
             return None
     data = row.data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from coclib.utils import normalize_tag, encode_tag
+from coclib.utils import normalize_tag, encode_tag, safe_to_thread
 
 
 def test_normalize_tag_strip_and_upper():
@@ -10,3 +10,17 @@ def test_normalize_tag_strip_and_upper():
 def test_encode_tag_quotes_percent23():
     assert encode_tag('abc') == '%23ABC'
     assert encode_tag('#def') == '%23DEF'
+
+
+@pytest.mark.asyncio
+async def test_safe_to_thread_fallback(monkeypatch):
+    def add(x, y):
+        return x + y
+
+    async def raise_error(*args, **kwargs):
+        raise RuntimeError("CurrentThreadExecutor already quit or is broken")
+
+    import coclib.utils as u
+    monkeypatch.setattr(u, 'to_thread', raise_error)
+    result = await safe_to_thread(add, 1, 2)
+    assert result == 3


### PR DESCRIPTION
## Summary
- guard against shutdown errors by adding safe_to_thread
- use safe_to_thread in services
- test safe_to_thread fallback

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68774babb220832c926ba3ab9377c51f