### PR TITLE
Update service guidelines with testing requirements

### DIFF
--- a/back-end/AGENTS.md
+++ b/back-end/AGENTS.md
@@ -6,5 +6,6 @@ This folder contains the Flask API service. Source code lives inside `app/`.
 - Configuration classes are provided in `coclib.config` and loaded in `run.py`.
 - The database models shared with other services are defined in `coclib/models.py`.
 - Migrations live in the repo root `migrations/` directory; do not place them here.
+- Add a relevant test case for any changes made to this service.
 
 Before opening a pull request run `ruff back-end` to lint the code.

--- a/front-end/AGENTS.md
+++ b/front-end/AGENTS.md
@@ -6,4 +6,5 @@ This directory contains the React dashboard built with Vite.
 - Larger pages should live under `src/pages/`.
 - Shared utilities belong in `src/lib/`.
 - Update import paths to match this structure when adding new code.
+- Add tests for your changes when it makes sense.
 - Before submitting a pull request run `npm install`, `npm test` and `npm run build` to ensure tests and the build succeed.

--- a/sync/AGENTS.md
+++ b/sync/AGENTS.md
@@ -6,5 +6,6 @@ This directory holds the background worker responsible for synchronizing data wi
 - Shared database models and utilities come from the top-level `coclib` package.
 - API blueprints are defined under `sync/api` if needed.
 - Database migrations are stored in the root `migrations/` directory.
+- Add a relevant test case for any changes made to this service.
 
 Run `ruff sync` before submitting a pull request.


### PR DESCRIPTION
## Summary
- document that backend and sync changes must include tests
- recommend adding front-end tests when practical

## Testing
- `ruff check back-end sync coclib db`
- `nox -s lint tests`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687754919378832cae95f294504b9e68