### PR TITLE
Fix asset proxy auth

### DIFF
--- a/back-end/app/__init__.py
+++ b/back-end/app/__init__.py
@@ -37,7 +37,12 @@ def create_app(cfg_cls: type[Config] = Config) -> Flask:
 
     def require_auth():
         path = request.path.rstrip("/")
-        if request.method == "OPTIONS" or path.endswith("/health"):
+        asset_prefix = f"{API_PREFIX}/assets"
+        if (
+            request.method == "OPTIONS"
+            or path.endswith("/health")
+            or path.startswith(asset_prefix)
+        ):
             return
         auth = request.headers.get("Authorization", "")
         if not auth.startswith("Bearer "):

--- a/back-end/app/api/asset_routes.py
+++ b/back-end/app/api/asset_routes.py
@@ -10,7 +10,7 @@ bp = Blueprint("assets", __name__, url_prefix=f"{API_PREFIX}/assets")
 ALLOWED_HOST = "api-assets.clashofclans.com"
 
 
-@bp.get("/")
+@bp.get("/", strict_slashes=False)
 def proxy_asset():
     url = request.args.get("url", "")
     if not url:

--- a/tests/test_asset_proxy.py
+++ b/tests/test_asset_proxy.py
@@ -1,0 +1,31 @@
+import pathlib
+import sys
+from unittest.mock import Mock
+
+from flask.testing import FlaskClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+from app import create_app
+from coclib.config import Config
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    GOOGLE_CLIENT_ID = "dummy"
+
+
+def test_proxy_public(monkeypatch):
+    app = create_app(TestConfig)
+    client: FlaskClient = app.test_client()
+
+    mocked = Mock()
+    mocked.status_code = 200
+    mocked.content = b"img"
+    mocked.headers = {"Content-Type": "image/png"}
+    monkeypatch.setattr("app.api.asset_routes.requests.get", lambda *a, **k: mocked)
+
+    url = "https://api-assets.clashofclans.com/foo.png"
+    resp = client.get(f"/api/v1/assets?url={url}")
+    assert resp.status_code == 200
+    assert resp.data == b"img"
+    assert resp.headers["Content-Type"] == "image/png"


### PR DESCRIPTION
## Summary
- allow unauthenticated access to the `/api/v1/assets` endpoint
- handle trailing slash for asset route
- add regression test

## Testing
- `ruff check back-end`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6877ad3fef08832c9855e1d61cbfd2b3