### PR TITLE
Add service worker refresh for frontend

### DIFF
--- a/front-end/public/sw.js
+++ b/front-end/public/sw.js
@@ -1,0 +1,38 @@
+const CACHE_NAME = 'api-cache-v1';
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  if (url.origin === self.location.origin && url.pathname.startsWith('/api/')) {
+    event.respondWith(staleWhileRevalidate(event.request));
+  }
+});
+
+async function staleWhileRevalidate(request) {
+  const cache = await caches.open(CACHE_NAME);
+  const cached = await cache.match(request);
+  const network = fetch(request)
+    .then(async (response) => {
+      cache.put(request, response.clone());
+      try {
+        const data = await response.clone().json();
+        const clients = await self.clients.matchAll();
+        for (const client of clients) {
+          client.postMessage({ type: 'api-update', url: request.url, data });
+        }
+      } catch {
+        // ignore JSON parse errors
+      }
+      return response;
+    })
+    .catch(() => undefined);
+  if (cached) return cached;
+  return network || Response.error();
+}

--- a/front-end/src/components/Loading.jsx
+++ b/front-end/src/components/Loading.jsx
@@ -1,9 +1,17 @@
 import React from 'react';
 
-export default function Loading({className = ''}) {
+export default function Loading({ className = '', size = 40 }) {
+    const style = {
+        width: size,
+        height: size,
+        borderWidth: Math.max(2, Math.round(size / 5)),
+    };
     return (
         <div className={`flex justify-center items-center ${className}`}>
-            <div className="animate-spin rounded-full h-10 w-10 border-4 border-slate-300 border-t-blue-500"></div>
+            <div
+                className="animate-spin rounded-full border-slate-300 border-t-blue-500"
+                style={style}
+            ></div>
         </div>
     );
 }

--- a/front-end/src/main.jsx
+++ b/front-end/src/main.jsx
@@ -3,6 +3,12 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -48,6 +48,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
     const [members, setMembers] = useState([]);
     const [error, setError] = useState('');
     const [loading, setLoading] = useState(false);
+    const [refreshing, setRefreshing] = useState(false);
 
     const [selected, setSelected] = useState(null);
     const [sortField, setSortField] = useState('');
@@ -104,6 +105,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
         } else {
             setLoading(true);
         }
+        setRefreshing(true);
 
         try {
             const clanData = await fetchJSONCached(`/clan/${encodeURIComponent(clanTag)}`);
@@ -142,6 +144,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
             if (!clan) setError(err.message);
         }
         setLoading(false);
+        setRefreshing(false);
     };
 
     useEffect(() => {
@@ -196,7 +199,10 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
 
 
     return (
-        <div className="max-w-5xl mx-auto space-y-6">
+        <div className="max-w-5xl mx-auto space-y-6 relative">
+            {refreshing && !loading && (
+                <Loading className="absolute top-2 right-2" size={16} />
+            )}
             {showSearchForm && (
                 <form
                     onSubmit={handleSubmit}


### PR DESCRIPTION
## Summary
- register a service worker to manage API caching
- implement stale-while-revalidate logic in the new service worker
- allow `Loading` component to accept a size prop
- show subtle refresh spinner in the dashboard when data updates

## Testing
- `npm install`
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_6877b40cb450832cbf09a2e9daf07b9f