### PR TITLE
Move refresh spinner to resource elements

### DIFF
--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -1,13 +1,14 @@
 import React, { useRef } from 'react';
 import { VariableSizeList as List } from 'react-window';
 import RiskRing from './RiskRing.jsx';
+import Loading from './Loading.jsx';
 import DonationRing from './DonationRing.jsx';
 import { timeAgo } from '../lib/time.js';
 import { getTownHallIcon } from '../lib/townhall.js';
 import { proxyImageUrl } from '../lib/assets.js';
 
 function Row({ index, style, data }) {
-  const { members, openIndex, setOpenIndex, getSize, listRef } = data;
+  const { members, openIndex, setOpenIndex, getSize, listRef, refreshing } = data;
   const m = members[index];
   const open = openIndex === index;
   const toggle = () => {
@@ -35,7 +36,10 @@ function Row({ index, style, data }) {
               alt={`TH${m.townHallLevel}`}
               className="w-5 h-5"
             />
-            <span className="font-medium">{m.name}</span>
+            <span className="font-medium">
+              {m.name}
+              {refreshing && <Loading size={16} className="ml-2 inline-block" />}
+            </span>
             {m.role && (
               <span className="text-xs bg-slate-200 rounded px-1">{m.role}</span>
             )}
@@ -75,7 +79,7 @@ function Row({ index, style, data }) {
   );
 }
 
-export default function MemberAccordionList({ members, height }) {
+export default function MemberAccordionList({ members, height, refreshing = false }) {
   const listRef = useRef();
   const [openIndex, setOpenIndex] = React.useState(null);
   const getSize = (index) => {
@@ -92,7 +96,7 @@ export default function MemberAccordionList({ members, height }) {
       itemCount={members.length}
       itemSize={getSize}
       width="100%"
-      itemData={{ members, openIndex, setOpenIndex, getSize, listRef }}
+      itemData={{ members, openIndex, setOpenIndex, getSize, listRef, refreshing }}
       ref={listRef}
     >
       {Row}

--- a/front-end/src/components/PlayerModal.jsx
+++ b/front-end/src/components/PlayerModal.jsx
@@ -8,7 +8,7 @@ import DonationRing from './DonationRing.jsx';
 import PresenceDot from './PresenceDot.jsx';
 import LoyaltyBadge from './LoyaltyBadge.jsx';
 
-export default function PlayerModal({ tag, onClose }) {
+export default function PlayerModal({ tag, onClose, refreshing = false }) {
   const [player, setPlayer] = useState(null);
   const [error, setError] = useState('');
 
@@ -43,6 +43,7 @@ export default function PlayerModal({ tag, onClose }) {
                   <img src={proxyImageUrl(player.leagueIcon)} alt="league" className="w-6 h-6" />
                 )}
                 <span>{player.name}</span>
+                {refreshing && <Loading size={16} className="ml-2 inline-block" />}
                 <span className="text-sm font-normal text-slate-500">{player.tag}</span>
               </h3>
               <div className="flex flex-wrap justify-center gap-2 mt-4">

--- a/front-end/src/components/ProfileCard.jsx
+++ b/front-end/src/components/ProfileCard.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import RiskRing from './RiskRing.jsx';
+import Loading from './Loading.jsx';
 import { timeAgo } from '../lib/time.js';
 import { getTownHallIcon } from '../lib/townhall.js';
 import { proxyImageUrl } from '../lib/assets.js';
 
-export default function ProfileCard({ member, onClick }) {
+export default function ProfileCard({ member, onClick, refreshing = false }) {
   if (!member) return null;
   return (
     <div
@@ -21,7 +22,10 @@ export default function ProfileCard({ member, onClick }) {
           className="w-6 h-6"
         />
       </div>
-      <p className="font-medium text-center mb-1">{member.name}</p>
+      <p className="font-medium text-center mb-1">
+        {member.name}
+        {refreshing && <Loading size={16} className="ml-2 inline-block" />}
+      </p>
       <RiskRing score={member.risk_score} size={48} />
       <div className="mt-2 text-center space-y-1 w-full">
         <p>TH{member.townHallLevel}</p>

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -200,9 +200,6 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
 
     return (
         <div className="max-w-5xl mx-auto space-y-6 relative">
-            {refreshing && !loading && (
-                <Loading className="absolute top-2 right-2" size={16} />
-            )}
             {showSearchForm && (
                 <form
                     onSubmit={handleSubmit}
@@ -288,6 +285,9 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                         className="w-5 h-5"
                                                     />
                                                     {m.name}
+                                                    {refreshing && !loading && (
+                                                        <Loading size={16} className="ml-2 inline-block" />
+                                                    )}
                                                 </span>
                                             </td>
                                             <td data-label="Tag" className="px-4 py-2 text-slate-500">{m.tag}</td>
@@ -372,6 +372,9 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                             className="w-5 h-5"
                                                         />
                                                         {m.name}
+                                                        {refreshing && !loading && (
+                                                            <Loading size={16} className="ml-2 inline-block" />
+                                                        )}
                                                     </span>
                                                     <span className="text-xs text-slate-500">
                                                         {m.last_seen ? timeAgo(m.last_seen) : '\u2014'}
@@ -410,6 +413,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                         <ProfileCard
                                             key={m.tag}
                                             member={m}
+                                            refreshing={refreshing && !loading}
                                             onClick={() => setSelected(m.tag)}
                                         />
                                     ))}
@@ -417,7 +421,11 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                             )}
                             {activeTab === 'all' && (
                                 <div className="bg-white rounded shadow" style={{ height: listHeight }}>
-                                    <MemberAccordionList members={sortedMembers} height={listHeight} />
+                                    <MemberAccordionList
+                                        members={sortedMembers}
+                                        height={listHeight}
+                                        refreshing={refreshing && !loading}
+                                    />
                                 </div>
                             )}
                         </>
@@ -426,7 +434,11 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
             )}
             {selected && (
                 <Suspense fallback={<Loading className="py-8"/>}>
-                    <PlayerModal tag={selected} onClose={() => setSelected(null)}/>
+                    <PlayerModal
+                        tag={selected}
+                        onClose={() => setSelected(null)}
+                        refreshing={refreshing && !loading}
+                    />
                 </Suspense>
             )}
         </div>


### PR DESCRIPTION
## Summary
- remove global refresh indicator
- show refresh spinner next to elements that are updating

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6877bc9a5594832c817f99be4acb6e65