### PR TITLE
Fix TH17 icon logic and snapshot grace

### DIFF
--- a/back-end/app/services/risk_service.py
+++ b/back-end/app/services/risk_service.py
@@ -40,11 +40,11 @@ def _clamp01(x: float) -> float:
 
 
 def _latest_war_snapshot(history: List[PlayerSnapshot]) -> Optional[PlayerSnapshot]:
-    """Newest snapshot that still contains war info (player was in the roster)."""
-    for snap in reversed(history):          # newest → oldest
-        if snap.war_attacks_used is not None:
-            return snap
-    return None
+    """Snapshot with the most war attacks used (latest if tied)."""
+    war_snaps = [s for s in history if s.war_attacks_used is not None]
+    if not war_snaps:
+        return None
+    return max(war_snaps, key=lambda s: (s.war_attacks_used, s.ts))
 
 def _infer_attack_cap(history: List[PlayerSnapshot]) -> int:
     """Best-guess the max attacks available in the observed war."""
@@ -53,7 +53,7 @@ def _infer_attack_cap(history: List[PlayerSnapshot]) -> int:
         for snap in history
         if snap.war_attacks_used is not None
     )
-    return cap or _WAR_ATTACKS_TOTAL
+    return max(cap, _WAR_ATTACKS_TOTAL)
 
 
 def _clan_has_war(history_map: dict[str, list]) -> bool:

--- a/front-end/src/lib/townhall.js
+++ b/front-end/src/lib/townhall.js
@@ -1,4 +1,9 @@
+const CUSTOM_NAMES = {
+  '17': 'Town_Hall17-5.webp',
+};
+
 export function getTownHallIcon(level) {
   const sanitized = String(level).replace('.', '-');
-  return new URL(`../assets/Town_Hall${sanitized}.webp`, import.meta.url).href;
+  const name = CUSTOM_NAMES[sanitized] ?? `Town_Hall${sanitized}.webp`;
+  return new URL(`../assets/${name}`, import.meta.url).href;
 }

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -399,7 +399,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                 onChange={setActiveTab}
                             />
                             {activeTab === 'top' && (
-                                <div className="flex overflow-x-auto gap-3 pb-2 scroller">
+                                <div className="flex overflow-x-auto gap-3 px-4 py-3 scroller">
                                     {topRisk.map((m) => (
                                         <ProfileCard
                                             key={m.tag}

--- a/tests/test_player_snapshot.py
+++ b/tests/test_player_snapshot.py
@@ -1,0 +1,104 @@
+import sys
+import pathlib
+import asyncio
+from datetime import datetime, timedelta
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "sync"))
+
+from app import create_app
+from coclib.config import Config
+from coclib.extensions import db
+from coclib.models import PlayerSnapshot, Player
+from services.player_service import get_player_snapshot
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    GOOGLE_CLIENT_ID = "dummy"
+
+
+def test_old_war_attacks_returned():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        now = datetime.utcnow()
+        player = Player(tag="ABC", name="Test", data={})
+        ps_old = PlayerSnapshot(
+            id=1,
+            ts=now - timedelta(days=2),
+            player_tag="ABC",
+            name="Test",
+            clan_tag="CLAN",
+            role="member",
+            town_hall=15,
+            trophies=1000,
+            donations=0,
+            donations_received=0,
+            war_attacks_used=2,
+            last_seen=now - timedelta(days=2),
+            data={},
+        )
+        ps_new = PlayerSnapshot(
+            id=2,
+            ts=now - timedelta(days=1),
+            player_tag="ABC",
+            name="Test",
+            clan_tag="CLAN",
+            role="member",
+            town_hall=15,
+            trophies=1000,
+            donations=0,
+            donations_received=0,
+            war_attacks_used=None,
+            last_seen=now - timedelta(days=1),
+            data={},
+        )
+        db.session.add_all([player, ps_old, ps_new])
+        db.session.commit()
+
+        result = asyncio.run(get_player_snapshot("ABC"))
+        assert result["warAttacksUsed"] == 2
+
+
+def test_war_attacks_reset_after_grace():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        now = datetime.utcnow()
+        player = Player(tag="XYZ", name="Again", data={})
+        ps_old = PlayerSnapshot(
+            id=3,
+            ts=now - timedelta(days=10),
+            player_tag="XYZ",
+            name="Again",
+            clan_tag="CLAN",
+            role="member",
+            town_hall=15,
+            trophies=1000,
+            donations=0,
+            donations_received=0,
+            war_attacks_used=2,
+            last_seen=now - timedelta(days=10),
+            data={},
+        )
+        ps_new = PlayerSnapshot(
+            id=4,
+            ts=now - timedelta(days=1),
+            player_tag="XYZ",
+            name="Again",
+            clan_tag="CLAN",
+            role="member",
+            town_hall=15,
+            trophies=1000,
+            donations=0,
+            donations_received=0,
+            war_attacks_used=None,
+            last_seen=now - timedelta(days=1),
+            data={},
+        )
+        db.session.add_all([player, ps_old, ps_new])
+        db.session.commit()
+
+        result = asyncio.run(get_player_snapshot("XYZ"))
+        assert result["warAttacksUsed"] is None

--- a/tests/test_risk_service.py
+++ b/tests/test_risk_service.py
@@ -38,6 +38,6 @@ def test_latest_war_snapshot_and_cap():
         Snap(now, war_attacks_used=0),
     ]
     war_snap = risk_service._latest_war_snapshot(history)
-    assert war_snap is history[-1]
+    assert war_snap is history[1]
     cap = risk_service._infer_attack_cap(history)
-    assert cap in {1, 2}
+    assert cap == 2


### PR DESCRIPTION
## Summary
- handle special Town Hall 17 asset without adding a duplicate file
- add padding so at-risk mobile cards have full highlight
- keep last war attack count for seven days after leaving
- test snapshot grace logic

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6877b28d5ef8832ca8edc2c6dbff2390