### PR TITLE
Fix spinners and close issues

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -246,7 +246,7 @@ export default function App() {
           />
         )}
         {!loadingUser && playerTag && (
-          <Suspense fallback={<Loading className="h-screen" />}>
+          <Suspense fallback={<Loading className="py-20" />}>
             <Dashboard defaultTag={clanTag} showSearchForm={false} onClanLoaded={setClanInfo} />
           </Suspense>
         )}

--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -48,7 +48,11 @@ function Row({ index, style, data }) {
             {m.last_seen ? timeAgo(m.last_seen) : '\u2014'}
           </p>
         </div>
-        {!open && <RiskRing score={m.risk_score} size={32} />}
+        {!open && (refreshing ? (
+          <Loading size={32} />
+        ) : (
+          <RiskRing score={m.risk_score} size={32} />
+        ))}
       </div>
       {open && (
         <div className="text-sm space-y-1 pb-2">
@@ -62,7 +66,11 @@ function Row({ index, style, data }) {
           </div>
           <div className="flex justify-between items-center">
             <span>Days in Clan: {m.loyalty}</span>
-            <RiskRing score={m.risk_score} size={32} />
+            {refreshing ? (
+              <Loading size={32} />
+            ) : (
+              <RiskRing score={m.risk_score} size={32} />
+            )}
           </div>
           {m.risk_breakdown && m.risk_breakdown.length > 0 && (
             <ul className="list-disc list-inside text-xs pt-1">

--- a/front-end/src/components/ProfileCard.jsx
+++ b/front-end/src/components/ProfileCard.jsx
@@ -26,7 +26,11 @@ export default function ProfileCard({ member, onClick, refreshing = false }) {
         {member.name}
         {refreshing && <Loading size={16} className="ml-2 inline-block" />}
       </p>
-      <RiskRing score={member.risk_score} size={48} />
+      {refreshing ? (
+        <Loading size={48} />
+      ) : (
+        <RiskRing score={member.risk_score} size={48} />
+      )}
       <div className="mt-2 text-center space-y-1 w-full">
         <p>TH{member.townHallLevel}</p>
         <p className="text-xs text-slate-500">

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -293,7 +293,11 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                             <td data-label="Days in Clan" className="px-4 py-2 text-center">{m.loyalty}</td>
                                             <td data-label="Score" className="px-4 py-2">
                                                 <div className="flex items-center gap-2">
-                                                    <RiskRing score={m.risk_score} size={40} />
+                                                    {refreshing && !loading ? (
+                                                        <Loading size={40} />
+                                                    ) : (
+                                                        <RiskRing score={m.risk_score} size={40} />
+                                                    )}
                                                     {m.risk_breakdown && m.risk_breakdown.length > 0 && (
                                                         <ul className="list-disc list-inside text-xs">
                                                             {m.risk_breakdown.map((r, i) => (
@@ -391,7 +395,11 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                             </td>
                                             <td data-label="Days in Clan" className="px-3 py-2 text-center hidden sm:table-cell">{m.loyalty}</td>
                                             <td data-label="Risk" className="px-3 py-2 text-center">
-                                                <RiskRing score={m.risk_score} size={36} />
+                                                {refreshing && !loading ? (
+                                                    <Loading size={36} />
+                                                ) : (
+                                                    <RiskRing score={m.risk_score} size={36} />
+                                                )}
                                             </td>
                                         </tr>
                                     ))}


### PR DESCRIPTION
## Summary
- show loading spinners in place of risk rings while refreshing
- shorten dashboard loading state so it doesn't take up the whole screen
- close resolved GitHub issues

## Testing
- `nox -s lint tests`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877d34f6cd4832cb2e2efb585369970