### PR TITLE
Fix duplicate spinner

### DIFF
--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -36,10 +36,7 @@ function Row({ index, style, data }) {
               alt={`TH${m.townHallLevel}`}
               className="w-5 h-5"
             />
-            <span className="font-medium">
-              {m.name}
-              {refreshing && <Loading size={16} className="ml-2 inline-block" />}
-            </span>
+            <span className="font-medium">{m.name}</span>
             {m.role && (
               <span className="text-xs bg-slate-200 rounded px-1">{m.role}</span>
             )}

--- a/front-end/src/components/PlayerModal.jsx
+++ b/front-end/src/components/PlayerModal.jsx
@@ -42,7 +42,6 @@ export default function PlayerModal({ tag, onClose, refreshing = false }) {
                   <img src={proxyImageUrl(player.leagueIcon)} alt="league" className="w-6 h-6" />
                 )}
                 <span>{player.name}</span>
-                {refreshing && <Loading size={16} className="ml-2 inline-block" />}
                 <span className="text-sm font-normal text-slate-500">{player.tag}</span>
               </h3>
               <div className="flex flex-wrap justify-center gap-2 mt-4">

--- a/front-end/src/components/ProfileCard.jsx
+++ b/front-end/src/components/ProfileCard.jsx
@@ -22,10 +22,7 @@ export default function ProfileCard({ member, onClick, refreshing = false }) {
           className="w-6 h-6"
         />
       </div>
-      <p className="font-medium text-center mb-1">
-        {member.name}
-        {refreshing && <Loading size={16} className="ml-2 inline-block" />}
-      </p>
+      <p className="font-medium text-center mb-1">{member.name}</p>
       {refreshing ? (
         <Loading size={48} />
       ) : (

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -284,9 +284,6 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                         className="w-5 h-5"
                                                     />
                                                     {m.name}
-                                                    {refreshing && !loading && (
-                                                        <Loading size={16} className="ml-2 inline-block" />
-                                                    )}
                                                 </span>
                                             </td>
                                             <td data-label="Tag" className="px-4 py-2 text-slate-500">{m.tag}</td>
@@ -375,9 +372,6 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                             className="w-5 h-5"
                                                         />
                                                         {m.name}
-                                                        {refreshing && !loading && (
-                                                            <Loading size={16} className="ml-2 inline-block" />
-                                                        )}
                                                     </span>
                                                     <span className="text-xs text-slate-500">
                                                         {m.last_seen ? timeAgo(m.last_seen) : '\u2014'}


### PR DESCRIPTION
## Summary
- remove duplicate spinner icon from At-Risk lists and modals
- keep only the large spinner that replaces the risk ring

## Testing
- `nox -s lint tests`
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877d6dc7554832c9757f670d76f047b