### PR TITLE
Fix player card to show label icons

### DIFF
--- a/front-end/src/components/PlayerModal.jsx
+++ b/front-end/src/components/PlayerModal.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchJSONCached } from '../lib/api.js';
 import { proxyImageUrl } from '../lib/assets.js';
+import { getTownHallIcon } from '../lib/townhall.js';
 
 import Loading from './Loading.jsx';
 import RiskRing from './RiskRing.jsx';
@@ -44,19 +45,29 @@ export default function PlayerModal({ tag, onClose, refreshing = false }) {
                 <span>{player.name}</span>
                 <span className="text-sm font-normal text-slate-500">{player.tag}</span>
               </h3>
-              <div className="flex flex-wrap justify-center gap-2 mt-4">
-                <span className="px-3 py-1 rounded-full bg-slate-100 text-sm font-medium">
-                  TH{player.townHallLevel}
-                </span>
-                <span className="px-3 py-1 rounded-full bg-slate-100 text-sm font-medium">
-                  {player.trophies}&#160;🏆
-                </span>
-                <span className="px-3 py-1 rounded-full bg-slate-100 text-sm font-medium">
-                  Don&nbsp;{player.donations}
-                </span>
-                <span className="px-3 py-1 rounded-full bg-slate-100 text-sm font-medium">
-                  Rec&nbsp;{player.donationsReceived}
-                </span>
+              <div className="flex flex-wrap justify-center gap-6 mt-4">
+                <div className="flex flex-col items-center">
+                  <img
+                    src={getTownHallIcon(player.townHallLevel)}
+                    alt={`TH${player.townHallLevel}`}
+                    className="w-8 h-8"
+                  />
+                  <p className="text-xs text-slate-500 mt-1">TH{player.townHallLevel}</p>
+                </div>
+                {player.labels?.map((l) => (
+                  <div className="flex flex-col items-center" key={l.id || l.name}>
+                    <img
+                      src={proxyImageUrl(l.iconUrls.small || l.iconUrls.medium)}
+                      alt={l.name}
+                      className="w-8 h-8"
+                    />
+                    <p className="text-xs text-slate-500 mt-1">{l.name}</p>
+                  </div>
+                ))}
+                <div className="flex flex-col items-center">
+                  <span className="text-2xl leading-none">🏆</span>
+                  <p className="text-xs text-slate-500 mt-1">{player.trophies}</p>
+                </div>
               </div>
 
                 <div className="mt-4">

--- a/front-end/src/components/PlayerModal.test.jsx
+++ b/front-end/src/components/PlayerModal.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// Mock API helper
+vi.mock('../lib/api.js', () => ({
+  fetchJSONCached: vi.fn(),
+  API_URL: '',
+}));
+
+import PlayerModal from './PlayerModal.jsx';
+import { fetchJSONCached } from '../lib/api.js';
+
+const samplePlayer = {
+  name: 'Alice',
+  tag: '#AAA',
+  townHallLevel: 12,
+  trophies: 3200,
+  labels: [
+    { id: 1, name: 'Veteran', iconUrls: { small: 'http://example.com/vet.png' } },
+  ],
+  donations: 0,
+  donationsReceived: 0,
+  risk_score: 10,
+  last_seen: '2024-01-01T00:00:00Z',
+  loyalty: 5,
+};
+
+describe('PlayerModal', () => {
+  it('displays labels instead of donation pills', async () => {
+    fetchJSONCached.mockResolvedValue(samplePlayer);
+    render(<PlayerModal tag="AAA" onClose={() => {}} />);
+    await waitFor(() => expect(fetchJSONCached).toHaveBeenCalled());
+    expect(screen.getByAltText('Veteran')).toBeInTheDocument();
+    expect(screen.queryByText(/Don\u00a0/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Rec\u00a0/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- replace donation pills with town hall, label, and trophy icons in PlayerModal
- add regression test for PlayerModal label rendering

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6877e52279c4832caf9be0720b917f1e