### PR TITLE
Fix player badge icons

### DIFF
--- a/back-end/app/services/snapshot_service.py
+++ b/back-end/app/services/snapshot_service.py
@@ -56,6 +56,7 @@ class PlayerDict(TypedDict):
     last_seen: str
     clanTag: str | None
     leagueIcon: str | None
+    labels: list | None
     ts: str
 
 
@@ -87,6 +88,7 @@ def _player_row_to_dict(row: PlayerSnapshot) -> PlayerDict:  # type: ignore[over
         last_seen=(row.last_seen or row.ts).isoformat().replace(" ", "T") + "Z",
         clanTag=row.clan_tag or None,
         leagueIcon=(row.data or {}).get("league", {}).get("iconUrls", {}).get("tiny"),
+        labels=(row.data or {}).get("labels", []),
         ts=row.ts.isoformat().replace(" ", "T") + "Z",
     )
 
@@ -140,6 +142,7 @@ def _latest_members_sync(clan_tag: str) -> list[dict]:
             "warAttacksUsed": ps.war_attacks_used,
             "last_seen": (ps.last_seen or ps.ts).isoformat().replace(" ", "T") + "Z",
             "leagueIcon": (pdata or {}).get("league", {}).get("iconUrls", {}).get("tiny"),
+            "labels": (pdata or {}).get("labels", []),
         }
         for ps, pdata in rows
     ]

--- a/sync/services/player_service.py
+++ b/sync/services/player_service.py
@@ -203,6 +203,8 @@ async def get_player_snapshot(tag: str) -> "Optional[PlayerDict]":
         data["leagueIcon"] = (
             player_row.data.get("league", {}).get("iconUrls", {}).get("tiny")
         )
+        # Include player labels for badge icons (refs #117)
+        data["labels"] = player_row.data.get("labels", [])
 
     cache.set(cache_key, data, timeout=300)
     return data

--- a/tests/test_clan_labels.py
+++ b/tests/test_clan_labels.py
@@ -1,0 +1,63 @@
+import sys
+import pathlib
+import asyncio
+from datetime import datetime
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+
+from app import create_app
+from coclib.config import Config
+from coclib.extensions import db
+from coclib.models import ClanSnapshot, PlayerSnapshot, Player, Clan, LoyaltyMembership
+from app.services import snapshot_service
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    GOOGLE_CLIENT_ID = "dummy"
+
+
+def test_member_labels_in_clan_snapshot():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        now = datetime.utcnow()
+        labels = [
+            {"id": 1, "name": "Veteran", "iconUrls": {"small": "http://example.com/icon.png"}}
+        ]
+        clan = Clan(tag="CLN", data={"badgeUrls": {"small": "b.png"}})
+        cs = ClanSnapshot(
+            id=1,
+            ts=now,
+            clan_tag="CLN",
+            name="Clan",
+            member_count=1,
+            level=10,
+            war_wins=0,
+            war_losses=0,
+            data={},
+        )
+        player = Player(tag="P1", name="Tester", data={"labels": labels, "league": {"iconUrls": {"tiny": "http://e.com/l.png"}}})
+        ps = PlayerSnapshot(
+            id=1,
+            ts=now,
+            player_tag="P1",
+            clan_tag="CLN",
+            name="Tester",
+            role="member",
+            town_hall=15,
+            trophies=0,
+            donations=0,
+            donations_received=0,
+            war_attacks_used=None,
+            last_seen=now,
+            data={},
+        )
+        mem = LoyaltyMembership(id=1, player_tag="P1", clan_tag="CLN", joined_at=now)
+        db.session.add_all([clan, cs, player, ps, mem])
+        db.session.commit()
+
+        data = asyncio.run(snapshot_service.get_clan("CLN"))
+        assert data["memberList"][0]["labels"] == labels
+


### PR DESCRIPTION
## Summary
- include badge labels in clan member data
- ensure player snapshots expose labels
- verify labels appear in clan snapshot

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6877ed8e7100832cb8a5d4ae20616400