### PR TITLE
Fix badge wrapping in profile

### DIFF
--- a/front-end/src/components/PlayerModal.jsx
+++ b/front-end/src/components/PlayerModal.jsx
@@ -45,7 +45,8 @@ export default function PlayerModal({ tag, onClose, refreshing = false }) {
                 <span>{player.name}</span>
                 <span className="text-sm font-normal text-slate-500">{player.tag}</span>
               </h3>
-              <div className="flex flex-wrap justify-center gap-4 mt-4">
+              {/* Keep badges from wrapping onto a second row (#120) */}
+              <div className="flex flex-nowrap overflow-x-auto gap-4 mt-4 justify-center scroller">
                 <div className="flex flex-col items-center w-16">
                   <img
                     src={getTownHallIcon(player.townHallLevel)}

--- a/front-end/src/components/PlayerModal.test.jsx
+++ b/front-end/src/components/PlayerModal.test.jsx
@@ -35,4 +35,13 @@ describe('PlayerModal', () => {
     expect(screen.queryByText(/Don\u00a0/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Rec\u00a0/)).not.toBeInTheDocument();
   });
+
+  it('keeps badges on a single row with horizontal scrolling', async () => {
+    fetchJSONCached.mockResolvedValue(samplePlayer);
+    render(<PlayerModal tag="AAA" onClose={() => {}} />);
+    await waitFor(() => expect(fetchJSONCached).toHaveBeenCalled());
+    const row = screen.getByText('TH12').parentElement.parentElement;
+    expect(row).toHaveClass('flex-nowrap');
+    expect(row).toHaveClass('overflow-x-auto');
+  });
 });


### PR DESCRIPTION
## Summary
- keep player badges on one row with horizontal scrolling
- clarify overflow handling with a code comment
- test badge container layout

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_687823328fb8832c83eb9fce6167a8e4