### PR TITLE
Implement player token verification

### DIFF
--- a/coclib/models.py
+++ b/coclib/models.py
@@ -102,6 +102,7 @@ class User(db.Model):
     email = db.Column(db.String(255), unique=True, nullable=False)
     name = db.Column(db.String(255))
     player_tag = db.Column(db.String(15), index=True)
+    is_verified = db.Column(db.Boolean, nullable=False, default=False)
 
 
 class UserProfile(db.Model):

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -45,6 +45,7 @@ export default function App() {
   });
   const [initials, setInitials] = useState(() => (token ? getInitials(token) : ''));
   const [playerTag, setPlayerTag] = useState(null);
+  const [verified, setVerified] = useState(false);
   const [homeClanTag, setHomeClanTag] = useState(null);
   const [clanTag, setClanTag] = useState(null);
   const [clanInfo, setClanInfo] = useState(null);
@@ -87,6 +88,7 @@ export default function App() {
       try {
         const me = await fetchJSON('/user/me');
         setPlayerTag(me.player_tag);
+        setVerified(me.verified);
         if (me.player_tag) {
           const player = await fetchJSON(`/player/${encodeURIComponent(me.player_tag)}`);
           if (player.clanTag) {
@@ -238,7 +240,7 @@ export default function App() {
       </header>
       <main className="px-2 pt-0 pb-2 sm:px-4 sm:pt-0 sm:pb-4">
         {loadingUser && <Loading className="h-[calc(100vh-4rem)]" />}
-        {!loadingUser && !playerTag && (
+        {!loadingUser && !verified && (
           <PlayerTagForm
             onSaved={(tag) => {
               setPlayerTag(tag);
@@ -269,7 +271,7 @@ export default function App() {
       )}
       {showProfile && (
         <Suspense fallback={<Loading className="h-screen" />}>
-          <ProfileModal onClose={() => setShowProfile(false)} />
+          <ProfileModal onClose={() => setShowProfile(false)} onVerified={() => setVerified(true)} />
         </Suspense>
       )}
     </>

--- a/front-end/src/components/VerifiedBadge.jsx
+++ b/front-end/src/components/VerifiedBadge.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function VerifiedBadge() {
+  return (
+    <span className="px-2 py-1 rounded bg-sky-600 text-white text-xs">Verified</span>
+  );
+}

--- a/front-end/src/components/VerifiedBadge.test.jsx
+++ b/front-end/src/components/VerifiedBadge.test.jsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VerifiedBadge from './VerifiedBadge.jsx';
+
+describe('VerifiedBadge component', () => {
+  it('renders label', () => {
+    render(<VerifiedBadge />);
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+  });
+});

--- a/migrations/versions/8af377ebd2cc_add_is_verified_to_user.py
+++ b/migrations/versions/8af377ebd2cc_add_is_verified_to_user.py
@@ -1,0 +1,24 @@
+"""add is_verified to users
+
+Revision ID: 8af377ebd2cc
+Revises: 53b8863d2dc8
+Create Date: 2025-09-01 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '8af377ebd2cc'
+down_revision = '53b8863d2dc8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('is_verified', sa.Boolean(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_column('is_verified')

--- a/sync/api/__init__.py
+++ b/sync/api/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request, abort
 
 from sync.services import clan_service, player_service, war_service
 
@@ -21,4 +21,14 @@ async def fetch_clan(tag: str):
 async def fetch_war(tag: str):
     data = await war_service.current_war(tag.upper())
     return jsonify(data)
+
+
+@bp.post("/verify/<string:tag>")
+async def verify(tag: str):
+    data = request.get_json(silent=True) or {}
+    token = data.get("token", "")
+    if not token:
+        abort(400)
+    result = await player_service.verify_token(tag.upper(), token)
+    return jsonify(result)
 

--- a/sync/services/player_service.py
+++ b/sync/services/player_service.py
@@ -32,6 +32,12 @@ async def _fetch_player(tag: str) -> dict:
     return await get_client().player(tag)
 
 
+async def verify_token(tag: str, token: str) -> dict:
+    """Verify a player's API token via the Clash of Clans API."""
+    client = get_client()
+    return await client.verify_token(tag, token)
+
+
 def _resolve_last_seen(
     *,
     data: dict,
@@ -210,4 +216,4 @@ async def get_player_snapshot(tag: str) -> "Optional[PlayerDict]":
     return data
 
 
-__all__ = [*globals().get("__all__", []), "get_player_snapshot"]
+__all__ = [*globals().get("__all__", []), "get_player_snapshot", "verify_token"]

--- a/tests/test_user_verification.py
+++ b/tests/test_user_verification.py
@@ -1,0 +1,65 @@
+import pathlib
+import sys
+
+from flask.testing import FlaskClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+from app import create_app
+from coclib.config import Config
+from coclib.extensions import db
+from coclib.models import User
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    GOOGLE_CLIENT_ID = "dummy"
+
+
+def _mock_verify(monkeypatch):
+    monkeypatch.setattr(
+        "app.id_token.verify_oauth2_token",
+        lambda t, req, cid: {"sub": "abc", "email": "u@example.com", "name": "U"},
+    )
+
+
+async def dummy_verify(tag: str, token: str):
+    return {"tag": f"#{tag}", "token": token, "status": "ok"}
+
+
+def test_verify_sets_flag(monkeypatch):
+    _mock_verify(monkeypatch)
+    monkeypatch.setattr("app.api.user_routes._verify_player_token", dummy_verify)
+
+    app = create_app(TestConfig)
+    client: FlaskClient = app.test_client()
+    with app.app_context():
+        db.create_all()
+        db.session.add(User(id=1, sub="abc", email="u@example.com", name="U"))
+        db.session.commit()
+
+    hdrs = {"Authorization": "Bearer t"}
+    resp = client.get("/api/v1/user/me", headers=hdrs)
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/api/v1/user/player-tag",
+        json={"player_tag": "abc"},
+        headers=hdrs,
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/api/v1/user/verify",
+        json={"token": "tok"},
+        headers=hdrs,
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "ok"
+
+    resp = client.post(
+        "/api/v1/user/player-tag",
+        json={"player_tag": "zzz"},
+        headers=hdrs,
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- share CoC API client in `sync` service and use relative imports
- call sync service for verifying player tokens
- expose `/verify/<tag>` endpoint on sync API
- test user verification via sync service

## Testing
- `ruff check back-end sync coclib db`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_68782b076f70832c8a7dcd4dfb09c5bf