### PR TITLE
Implement messages backend (#125)

### DIFF
--- a/coclib/models.py
+++ b/coclib/models.py
@@ -139,3 +139,21 @@ class FeatureFlag(db.Model):
     name = db.Column(db.String(50), unique=True, nullable=False)
 
 
+
+
+class ChatGroup(db.Model):
+    __tablename__ = "chat_groups"
+
+    id = db.Column(db.BigInteger, primary_key=True)
+    name = db.Column(db.String(100))
+
+
+class ChatGroupMember(db.Model):
+    __tablename__ = "chat_group_members"
+
+    group_id = db.Column(db.BigInteger, db.ForeignKey("chat_groups.id"), primary_key=True)
+    user_id = db.Column(db.BigInteger, db.ForeignKey("users.id"), primary_key=True)
+
+    group = db.relationship("ChatGroup", backref=db.backref("members", lazy="dynamic"))
+    user = db.relationship("User", backref=db.backref("chat_groups", lazy="dynamic"))
+

--- a/messages/services/publisher.py
+++ b/messages/services/publisher.py
@@ -1,18 +1,50 @@
+import json
 import logging
+import os
 from datetime import datetime
 
+import boto3
+import httpx
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from coclib.models import ChatGroupMember
 from messages import models
 
 logger = logging.getLogger(__name__)
 
+session = boto3.Session(region_name=os.getenv("AWS_REGION", "us-east-1"))
+dynamodb = session.resource("dynamodb")
+table = dynamodb.Table(os.getenv("MESSAGES_TABLE", "chat_messages"))
+
 
 def verify_group_member(user_id: int, group_id: str) -> bool:
-    """Placeholder group membership check."""
-    return True
+    """Return ``True`` if *user_id* belongs to *group_id*."""
+    row = ChatGroupMember.query.filter_by(user_id=user_id, group_id=int(group_id)).first()
+    return row is not None
+
+
+def _publish_to_appsync(channel: str, payload: dict) -> None:
+    url = os.getenv("APPSYNC_EVENTS_URL")
+    if not url:
+        logger.info("APPSYNC_EVENTS_URL not configured, skipping publish")
+        return
+    region = os.getenv("AWS_REGION", session.region_name or "us-east-1")
+    request = AWSRequest("POST", url, data=json.dumps({"channels": [channel], "message": payload}))
+    SigV4Auth(session.get_credentials(), "appsync", region).add_auth(request)
+    httpx.post(url, content=request.body, headers=dict(request.headers))
 
 
 def publish_message(group_id: str, text: str, user_id: int) -> models.ChatMessage:
-    msg = models.ChatMessage(group_id=group_id, user_id=user_id, text=text, ts=datetime.utcnow())
+    ts = datetime.utcnow()
+    msg = models.ChatMessage(group_id=group_id, user_id=user_id, text=text, ts=ts)
     logger.info("Publishing message: %s", msg)
-    # In real implementation this would publish via AWS AppSync.
+    table.put_item(
+        Item={
+            "group_id": group_id,
+            "ts": ts.isoformat(),
+            "user_id": str(user_id),
+            "text": text,
+        }
+    )
+    _publish_to_appsync(f"/groups/{group_id}", {"text": text, "userId": user_id, "ts": ts.isoformat()})
     return msg

--- a/migrations/versions/b62fb3fd0ef9_add_chat_group_models.py
+++ b/migrations/versions/b62fb3fd0ef9_add_chat_group_models.py
@@ -1,0 +1,35 @@
+"""add chat group models
+
+Revision ID: b62fb3fd0ef9
+Revises: f85f16ec9b8a
+Create Date: 2025-07-17 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'b62fb3fd0ef9'
+down_revision = 'f85f16ec9b8a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'chat_groups',
+        sa.Column('id', sa.BigInteger(), nullable=False),
+        sa.Column('name', sa.String(length=100), nullable=True),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_table(
+        'chat_group_members',
+        sa.Column('group_id', sa.BigInteger(), nullable=False),
+        sa.Column('user_id', sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(['group_id'], ['chat_groups.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('group_id', 'user_id')
+    )
+
+
+def downgrade():
+    op.drop_table('chat_group_members')
+    op.drop_table('chat_groups')


### PR DESCRIPTION
## Summary
- create chat group models and migrations
- store chat messages in DynamoDB and publish via AppSync
- add basic membership check
- expand messages API tests

## Testing
- `ruff check messages`
- `ruff check coclib back-end sync db`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_68786a803178832cbae783ba1788bcdb