### PR TITLE
Add messages service config

### DIFF
--- a/coclib/config.py
+++ b/coclib/config.py
@@ -40,6 +40,8 @@ class Config:
     ).split(",")
 
 
+
+
 class DevelopmentConfig(Config):
     DEBUG = True
     SQLALCHEMY_ECHO = False
@@ -55,4 +57,28 @@ env_configs = {
     "development": DevelopmentConfig,
     "production": Config,
     "testing": TestConfig,
+}
+
+
+class MessagesConfig(Config):
+    """Configuration values specific to the messages service."""
+
+    AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+    MESSAGES_TABLE = os.getenv("MESSAGES_TABLE", "chat_messages")
+    APPSYNC_EVENTS_URL = os.getenv("APPSYNC_EVENTS_URL")
+    PORT = int(os.getenv("PORT", str(Config.PORT)))
+
+
+class MessagesDevelopmentConfig(MessagesConfig, DevelopmentConfig):
+    """Development settings for the messages service."""
+
+
+class MessagesTestConfig(MessagesConfig, TestConfig):
+    """Testing settings for the messages service."""
+
+
+messages_env_configs = {
+    "development": MessagesDevelopmentConfig,
+    "production": MessagesConfig,
+    "testing": MessagesTestConfig,
 }

--- a/messages/app/__init__.py
+++ b/messages/app/__init__.py
@@ -5,7 +5,7 @@ from flask_cors import CORS
 from google.oauth2 import id_token
 from google.auth.transport import requests as google_requests
 
-from coclib.config import Config
+from coclib.config import MessagesConfig
 from coclib.extensions import db, cache, migrate, scheduler
 from coclib.logging_config import configure_logging
 from coclib.models import User
@@ -15,7 +15,7 @@ from .api import bp as messages_bp, API_PREFIX
 logger = logging.getLogger(__name__)
 
 
-def create_app(cfg_cls: type[Config] = Config) -> Flask:
+def create_app(cfg_cls: type[MessagesConfig] = MessagesConfig) -> Flask:
     configure_logging(level=cfg_cls.LOG_LEVEL)
     app = Flask(__name__)
     app.config.from_object(cfg_cls)

--- a/messages/run.py
+++ b/messages/run.py
@@ -3,19 +3,19 @@ import os
 from dotenv import load_dotenv
 
 from asgiref.wsgi import WsgiToAsgi
-from coclib.config import env_configs
+from coclib.config import messages_env_configs
 from messages.app import create_app
 
 load_dotenv()
 
 cfg_name = os.getenv("APP_ENV", "production")
-cfg_cls = env_configs[cfg_name]
+cfg_cls = messages_env_configs[cfg_name]
 
 app = create_app(cfg_cls)
 asgi_app = WsgiToAsgi(app)
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
-    port = int(os.getenv("PORT") or (getattr(cfg_cls, "PORT", None) if getattr(cfg_cls, "PORT", 80) != 80 else 8000))
+    port = cfg_cls.PORT
     logger.info(f"Starting messages service on port {port}")
     app.run(host="0.0.0.0", port=port, debug=getattr(cfg_cls, "DEBUG", False))

--- a/tests/test_messages_api.py
+++ b/tests/test_messages_api.py
@@ -3,13 +3,13 @@ from datetime import datetime
 from flask.testing import FlaskClient
 
 from messages.app import create_app  # type: ignore
-from coclib.config import Config
+from coclib.config import MessagesConfig
 from coclib.extensions import db
 from coclib.models import User, ChatGroup, ChatGroupMember
 from messages import models
 
 
-class TestConfig(Config):
+class TestConfig(MessagesConfig):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     GOOGLE_CLIENT_ID = "dummy"


### PR DESCRIPTION
## Summary
- define `MessagesConfig` and environment variants
- apply messages config in app and runner
- fetch message service settings from Flask config
- update test config

## Testing
- `ruff check messages`
- `ruff check back-end sync coclib db`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6878921b9b04832c8a618ccb1e53a72c