### PR TITLE
Implement chat feature toggle

### DIFF
--- a/front-end/src/components/ChatBadge.jsx
+++ b/front-end/src/components/ChatBadge.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function ChatBadge() {
+  return (
+    <span className="px-2 py-1 rounded bg-purple-600 text-white text-xs">Chat</span>
+  );
+}

--- a/front-end/src/components/ChatBadge.test.jsx
+++ b/front-end/src/components/ChatBadge.test.jsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ChatBadge from './ChatBadge.jsx';
+
+describe('ChatBadge component', () => {
+  it('renders label', () => {
+    render(<ChatBadge />);
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+  });
+});

--- a/migrations/versions/cad1bc3dd940_add_chat_feature_flag.py
+++ b/migrations/versions/cad1bc3dd940_add_chat_feature_flag.py
@@ -1,0 +1,23 @@
+"""add chat feature flag
+
+Revision ID: cad1bc3dd940
+Revises: b62fb3fd0ef9
+Create Date: 2025-10-05 00:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'cad1bc3dd940'
+down_revision = 'b62fb3fd0ef9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    feature_flags = sa.table('feature_flags', sa.column('name', sa.String()))
+    op.bulk_insert(feature_flags, [{'name': 'chat'}])
+
+
+def downgrade():
+    op.execute("delete from feature_flags where name='chat'")


### PR DESCRIPTION
## Summary
- add ChatBadge component and tests
- allow enabling Chat via checkbox in ProfileModal
- persist chat flag via new migration

## Testing
- `ruff check back-end sync coclib db`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_68789ba88f18832c82c081e677d9efee