### PR TITLE
Align messages service with chat module

### DIFF
--- a/messages/app/api/__init__.py
+++ b/messages/app/api/__init__.py
@@ -11,10 +11,10 @@ bp = Blueprint("messages", __name__, url_prefix=f"{API_PREFIX}/chat")
 def publish():
     data = request.get_json(silent=True) or {}
     group_id = data.get("groupId")
-    text = (data.get("text") or "").strip()
-    if not group_id or not text:
+    content = (data.get("text") or "").strip()
+    if not group_id or not content:
         abort(400)
     if not verify_group_member(g.user.id, str(group_id)):
         abort(403)
-    msg = publish_message(str(group_id), text, g.user.id)
+    msg = publish_message(str(group_id), content, g.user.id)
     return jsonify({"status": "ok", "ts": msg.ts.isoformat()})

--- a/messages/models.py
+++ b/messages/models.py
@@ -6,7 +6,7 @@ from datetime import datetime
 class ChatMessage:
     """Simple schema stored in DynamoDB."""
 
-    group_id: str
+    channel: str
     user_id: int
-    text: str
+    content: str
     ts: datetime

--- a/tests/test_messages_api.py
+++ b/tests/test_messages_api.py
@@ -46,7 +46,7 @@ def test_publish_ok(monkeypatch):
     def fake_publish(*args, **kwargs):
         called["args"] = args
         called["kwargs"] = kwargs
-        return models.ChatMessage(group_id="1", user_id=1, text="hi", ts=datetime.utcnow())
+        return models.ChatMessage(channel="1", user_id=1, content="hi", ts=datetime.utcnow())
 
     monkeypatch.setattr("messages.app.api.publish_message", fake_publish)
     app = create_app(TestConfig)


### PR DESCRIPTION
## Summary
- add `channel` and `content` fields to `ChatMessage`
- store chat messages with the same attribute names as the `chat` OpenTofu module
- rename API variable to forward `content`
- adjust tests for the updated dataclass

## Testing
- `ruff check messages`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_68789cd8e018832cbc42b0e697c4ba23