### PR TITLE
Fix chat preference persistence

### DIFF
--- a/front-end/src/components/ProfileModal.jsx
+++ b/front-end/src/components/ProfileModal.jsx
@@ -42,6 +42,7 @@ export default function ProfileModal({ onClose, onVerified }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ features: chatEnabled ? ['chat'] : [], all: false }),
       });
+      window.dispatchEvent(new Event('features-updated'));
       onClose();
     } catch {
       setSaving(false);

--- a/front-end/src/hooks/useFeatures.js
+++ b/front-end/src/hooks/useFeatures.js
@@ -10,15 +10,23 @@ export default function useFeatures(token) {
       return;
     }
     let cancelled = false;
-    fetchJSON('/user/features')
-      .then((res) => {
-        if (!cancelled) setData(res);
-      })
-      .catch(() => {
-        if (!cancelled) setData(null);
-      });
+    const load = () => {
+      fetchJSON('/user/features')
+        .then((res) => {
+          if (!cancelled) setData(res);
+        })
+        .catch(() => {
+          if (!cancelled) setData(null);
+        });
+    };
+    load();
+    const handler = () => {
+      if (!cancelled) load();
+    };
+    window.addEventListener('features-updated', handler);
     return () => {
       cancelled = true;
+      window.removeEventListener('features-updated', handler);
     };
   }, [token]);
 


### PR DESCRIPTION
## Summary
- reload feature flags when updated
- dispatch a `features-updated` event on profile save

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_68793a8911cc832cb7a4d9da9be9a8c2