### PR TITLE
Auto sync chat groups

### DIFF
--- a/sync/coclib/services/loyalty_service.py
+++ b/sync/coclib/services/loyalty_service.py
@@ -4,7 +4,12 @@ from datetime import datetime
 from typing import Dict
 
 from coclib.extensions import db
-from coclib.models import LoyaltyMembership
+from coclib.models import (
+    LoyaltyMembership,
+    ChatGroup,
+    ChatGroupMember,
+    User,
+)
 from coclib.utils import normalize_tag
 
 __all__ = [
@@ -12,6 +17,37 @@ __all__ = [
     "get_player_loyalty",
     "get_clan_loyalty",
 ]
+
+
+def _sync_chat_membership(player_tag: str, clan_tag: str | None) -> None:
+    """Ensure :class:`ChatGroupMember` rows reflect *player_tag*'s clan."""
+
+    user = User.query.filter_by(player_tag=normalize_tag(player_tag)).first()
+    if user is None:
+        return
+
+    if not clan_tag:
+        ChatGroupMember.query.filter_by(user_id=user.id).delete()
+        db.session.commit()
+        return
+
+    clan_tag = normalize_tag(clan_tag)
+    group = ChatGroup.query.filter_by(name=clan_tag).first()
+    if group is None:
+        next_gid = (db.session.execute(db.select(db.func.max(ChatGroup.id))).scalar() or 0) + 1
+        group = ChatGroup(id=next_gid, name=clan_tag)
+        db.session.add(group)
+        db.session.flush()
+
+    ChatGroupMember.query.filter(
+        ChatGroupMember.user_id == user.id,
+        ChatGroupMember.group_id != group.id,
+    ).delete()
+
+    if not ChatGroupMember.query.filter_by(user_id=user.id, group_id=group.id).first():
+        db.session.add(ChatGroupMember(user_id=user.id, group_id=group.id))
+
+    db.session.commit()
 
 
 def ensure_membership(player_tag: str, current_clan_tag: str | None, ts: datetime) -> None:
@@ -37,6 +73,7 @@ def ensure_membership(player_tag: str, current_clan_tag: str | None, ts: datetim
             active.left_at = ts
             db.session.add(active)
             db.session.commit()
+        _sync_chat_membership(player_tag, None)
         return
 
     if active is None or active.clan_tag != current_clan_tag:
@@ -47,13 +84,17 @@ def ensure_membership(player_tag: str, current_clan_tag: str | None, ts: datetim
             db.session.flush()
 
         # Open a new membership row for the new clan
+        next_id = (db.session.execute(db.select(db.func.max(LoyaltyMembership.id))).scalar() or 0) + 1
         new_row = LoyaltyMembership(
+            id=next_id,
             player_tag=player_tag,
             clan_tag=current_clan_tag,
             joined_at=ts,
         )
         db.session.add(new_row)
         db.session.commit()
+
+    _sync_chat_membership(player_tag, current_clan_tag)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chat_membership.py
+++ b/tests/test_chat_membership.py
@@ -1,0 +1,54 @@
+import pathlib
+import sys
+from datetime import datetime, timedelta
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+
+from app import create_app
+from coclib.config import Config
+from coclib.extensions import db
+from coclib.models import User, ChatGroup, ChatGroupMember
+from coclib.services.loyalty_service import ensure_membership
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    GOOGLE_CLIENT_ID = "dummy"
+
+
+def test_chat_membership_added_and_removed():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        user = User(id=1, sub="s", email="u@example.com", name="U", player_tag="P1", is_verified=True)
+        db.session.add(user)
+        db.session.commit()
+
+        now = datetime.utcnow()
+        ensure_membership("P1", "CLN", now)
+
+        group = ChatGroup.query.filter_by(name="CLN").one()
+        assert ChatGroupMember.query.filter_by(user_id=user.id, group_id=group.id).count() == 1
+
+        ensure_membership("P1", None, now + timedelta(minutes=1))
+        assert ChatGroupMember.query.filter_by(user_id=user.id).count() == 0
+
+
+def test_chat_membership_moves_clan():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        user = User(id=1, sub="s", email="u@example.com", name="U", player_tag="P1", is_verified=True)
+        db.session.add(user)
+        db.session.commit()
+
+        now = datetime.utcnow()
+        ensure_membership("P1", "CLN1", now)
+        group1 = ChatGroup.query.filter_by(name="CLN1").one()
+        ensure_membership("P1", "CLN2", now + timedelta(minutes=1))
+        group2 = ChatGroup.query.filter_by(name="CLN2").one()
+
+        assert ChatGroupMember.query.filter_by(user_id=user.id, group_id=group2.id).count() == 1
+        assert ChatGroupMember.query.filter_by(user_id=user.id, group_id=group1.id).count() == 0
+


### PR DESCRIPTION
## Summary
- sync chat group membership with clan membership
- include clan chat group utilities in sync service
- add regression tests

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6879478c1ee0832cb3e349d9746e5947