### PR TITLE
Document AppSync env vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,8 @@ jobs:
       MESSAGES_SERVICE: ${{ secrets.MESSAGES_SERVICE }}
       VITE_API_URL: ${{ secrets.VITE_API_URL }}
       VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+      VITE_APPSYNC_EVENTS_URL: ${{ secrets.VITE_APPSYNC_EVENTS_URL }}
+      VITE_AWS_REGION: ${{ secrets.VITE_AWS_REGION }}
 
     steps:
       - uses: actions/checkout@v3
@@ -72,6 +74,8 @@ jobs:
           npm ci --prefix front-end
           VITE_API_URL=$VITE_API_URL \
           VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID \
+          VITE_APPSYNC_EVENTS_URL=$VITE_APPSYNC_EVENTS_URL \
+          VITE_AWS_REGION=$VITE_AWS_REGION \
           npm run --prefix front-end build
 
       - name: Sync front-end to S3

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -8,6 +8,8 @@ This folder contains a standalone React version of the dashboard. It can be buil
 npm install
 VITE_API_URL=http://localhost:8080 \
 VITE_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com \
+VITE_APPSYNC_EVENTS_URL=https://xxxxx.appsync-realtime-api.us-east-1.amazonaws.com/graphql \
+VITE_AWS_REGION=us-east-1 \
 npm run dev
 ```
 
@@ -26,6 +28,13 @@ when running the dev server. The backend must receive the same value through
 
 Users can opt in to the chat UI via the `/user/features` API which controls feature flags at runtime.
 
+#### Required variables
+
+Set the following variables so the chat UI can connect to AWS AppSync:
+
+- `VITE_APPSYNC_EVENTS_URL` – realtime endpoint returned by Terraform.
+- `VITE_AWS_REGION` – AWS region of the AppSync API.
+
 ## Production build
 
 ```bash
@@ -33,17 +42,11 @@ npm install
 npm run build
 ```
 
-The production build output will be in the `dist/` directory. When building the
-Docker image you can supply build arguments to set the backend URL and Google
-client ID:
-
-```bash
-docker build \
-  --build-arg VITE_API_URL=https://api.example.com \
-  --build-arg VITE_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com \
-  --build-arg VITE_BASE_PATH=/ \
-  -t dashboard .
-```
+The production build output will be in the `dist/` directory. Changes to the
+`main` branch trigger a GitHub Actions workflow which builds the site with the
+same environment variables and syncs the result to an S3 bucket behind
+CloudFront. Cache invalidations are issued automatically so users see the newest
+files on deploy.
 
 ### Cache invalidation
 


### PR DESCRIPTION
## Summary
- detail chat environment variables in front-end README
- show how GitHub Actions deploys static builds to S3
- include AppSync vars in deploy workflow

## Testing
- `nox -s lint tests`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68798daa54dc832cbb14d787de620fb0