### PR TITLE
Implement clan chat tabs and history

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -304,7 +304,7 @@ export default function App() {
         <Suspense fallback={<Loading className="h-screen" />}>
           <ChatDrawer open={showChat} onClose={() => setShowChat(false)}>
             {verified ? (
-              <ChatPanel />
+              <ChatPanel groupId={homeClanTag || '1'} />
             ) : (
               <div className="p-4 h-full overflow-y-auto">Verify your account to chat.</div>
             )}

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -6,6 +6,7 @@ export default function ChatPanel({ groupId = '1' }) {
   const { messages } = useChat(groupId);
   const [text, setText] = useState('');
   const [sending, setSending] = useState(false);
+  const [tab, setTab] = useState('Clan');
   const endRef = useRef(null);
 
   useEffect(() => {
@@ -34,29 +35,46 @@ export default function ChatPanel({ groupId = '1' }) {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex-1 overflow-y-auto space-y-2 p-4">
-        {messages.map((m, idx) => (
-          <div key={idx} className="bg-slate-100 rounded px-2 py-1">
-            {m.content}
-          </div>
+      <div className="flex border-b">
+        {['Clan', 'Friends', 'All'].map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`flex-1 px-3 py-2 ${tab === t ? 'border-b-2 border-blue-600 font-medium' : 'text-slate-600'}`}
+          >
+            {t}
+          </button>
         ))}
-        <div ref={endRef} />
       </div>
-      <form onSubmit={handleSubmit} className="flex gap-2 p-2 border-t">
-        <input
-          className="flex-1 border rounded px-2 py-1"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          placeholder="Type a message…"
-        />
-        <button
-          type="submit"
-          className="px-3 py-1 rounded bg-blue-600 text-white"
-          disabled={sending}
-        >
-          {sending ? 'Sending…' : 'Send'}
-        </button>
-      </form>
+      {tab === 'Clan' ? (
+        <>
+          <div className="flex-1 overflow-y-auto space-y-2 p-4">
+            {messages.map((m, idx) => (
+              <div key={idx} className="bg-slate-100 rounded px-2 py-1">
+                {m.content}
+              </div>
+            ))}
+            <div ref={endRef} />
+          </div>
+          <form onSubmit={handleSubmit} className="flex gap-2 p-2 border-t">
+            <input
+              className="flex-1 border rounded px-2 py-1"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Type a message…"
+            />
+            <button
+              type="submit"
+              className="px-3 py-1 rounded bg-blue-600 text-white"
+              disabled={sending}
+            >
+              {sending ? 'Sending…' : 'Send'}
+            </button>
+          </form>
+        </>
+      ) : (
+        <div className="flex-1 p-4">Coming soon...</div>
+      )}
     </div>
   );
 }

--- a/front-end/src/components/ChatPanel.test.jsx
+++ b/front-end/src/components/ChatPanel.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
@@ -13,5 +13,12 @@ describe('ChatPanel component', () => {
   it('renders input field', () => {
     render(<ChatPanel />);
     expect(screen.getByPlaceholderText('Type a message…')).toBeInTheDocument();
+  });
+
+  it('shows coming soon on Friends tab', () => {
+    render(<ChatPanel />);
+    const friendsTab = screen.getByText('Friends');
+    fireEvent.click(friendsTab);
+    expect(screen.getByText('Coming soon...')).toBeInTheDocument();
   });
 });

--- a/front-end/src/hooks/useChat.js
+++ b/front-end/src/hooks/useChat.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { PubSub } from '@aws-amplify/pubsub';
 import ensurePubSub from '../aws/pubsub.js';
 import useGoogleIdToken from './useGoogleIdToken.js';
+import { fetchJSON } from '../lib/api.js';
 
 export default function useChat(groupId) {
   const token = useGoogleIdToken();
@@ -13,10 +14,19 @@ export default function useChat(groupId) {
 
   useEffect(() => {
     if (!groupId || !token) return;
+    let ignore = false;
+    fetchJSON(`/chat/history/${encodeURIComponent(groupId)}?limit=100`)
+      .then((data) => {
+        if (!ignore) setMessages(data);
+      })
+      .catch(() => {});
     const sub = PubSub.subscribe(`/groups/${groupId}`).subscribe({
       next: (data) => setMessages((m) => [...m, data.value]),
     });
-    return () => sub.unsubscribe();
+    return () => {
+      ignore = true;
+      sub.unsubscribe();
+    };
   }, [groupId, token]);
 
   return { messages };

--- a/messages/app/api/__init__.py
+++ b/messages/app/api/__init__.py
@@ -1,6 +1,10 @@
 from flask import Blueprint, jsonify, request, g, abort
 
-from messages.services.publisher import publish_message, verify_group_member
+from messages.services.publisher import (
+    publish_message,
+    verify_group_member,
+    fetch_recent_messages,
+)
 
 API_PREFIX = "/api/v1"
 
@@ -18,3 +22,20 @@ def publish():
         abort(403)
     msg = publish_message(str(group_id), content, g.user.id)
     return jsonify({"status": "ok", "ts": msg.ts.isoformat()})
+
+
+@bp.get("/history/<group_id>")
+def history(group_id: str):
+    limit_str = request.args.get("limit", "100")
+    try:
+        limit = int(limit_str)
+    except ValueError:
+        limit = 100
+    limit = min(limit, 100)
+    if not verify_group_member(g.user.id, str(group_id)):
+        abort(403)
+    msgs = fetch_recent_messages(str(group_id), limit)
+    return jsonify([
+        {"userId": m.user_id, "content": m.content, "ts": m.ts.isoformat()}
+        for m in msgs
+    ])

--- a/messages/services/publisher.py
+++ b/messages/services/publisher.py
@@ -6,8 +6,9 @@ import boto3
 import httpx
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
+from boto3.dynamodb.conditions import Key
 from flask import current_app
-from coclib.models import ChatGroupMember
+from coclib.models import ChatGroup, ChatGroupMember
 from messages import models
 
 logger = logging.getLogger(__name__)
@@ -15,8 +16,20 @@ logger = logging.getLogger(__name__)
 
 
 def verify_group_member(user_id: int, group_id: str) -> bool:
-    """Return ``True`` if *user_id* belongs to *group_id*."""
-    row = ChatGroupMember.query.filter_by(user_id=user_id, group_id=int(group_id)).first()
+    """Return ``True`` if *user_id* belongs to *group_id*.
+
+    ``group_id`` may be the numeric group identifier or the clan tag
+    associated with the chat group.
+    """
+    try:
+        gid = int(group_id)
+        row = ChatGroupMember.query.filter_by(user_id=user_id, group_id=gid).first()
+    except ValueError:
+        row = (
+            ChatGroupMember.query.join(ChatGroup)
+            .filter(ChatGroupMember.user_id == user_id, ChatGroup.name == group_id.upper())
+            .first()
+        )
     return row is not None
 
 
@@ -67,3 +80,38 @@ def publish_message(channel: str, content: str, user_id: int) -> models.ChatMess
     )
     _publish_to_appsync(channel, user_id, content)
     return msg
+
+
+def fetch_recent_messages(channel: str, limit: int = 100) -> list[models.ChatMessage]:
+    """Return up to ``limit`` recent messages for ``channel`` in chronological order."""
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        limit = 100
+    limit = min(limit, 100)
+
+    region = current_app.config.get("AWS_REGION", "us-east-1")
+    session = boto3.Session(region_name=region)
+    dynamodb = session.resource("dynamodb")
+    table_name = current_app.config.get("MESSAGES_TABLE", "chat_messages")
+    table = dynamodb.Table(table_name)
+
+    resp = table.query(
+        KeyConditionExpression=Key("channel").eq(channel),
+        Limit=limit,
+        ScanIndexForward=False,
+    )
+
+    items = resp.get("Items", [])
+    messages: list[models.ChatMessage] = []
+    for item in reversed(items):
+        ts = datetime.fromisoformat(item["ts"])
+        messages.append(
+            models.ChatMessage(
+                channel=item["channel"],
+                user_id=int(item.get("userId", "0")),
+                content=item.get("content", ""),
+                ts=ts,
+            )
+        )
+    return messages

--- a/tests/test_messages_api.py
+++ b/tests/test_messages_api.py
@@ -65,3 +65,29 @@ def test_publish_ok(monkeypatch):
     assert resp.status_code == 200
     assert called["args"][0] == "1"
 
+
+def test_history_returns_messages(monkeypatch):
+    _mock_verify(monkeypatch)
+    monkeypatch.setattr(
+        "messages.app.api.fetch_recent_messages",
+        lambda gid, limit=100: [
+            models.ChatMessage(channel="1", user_id=1, content="hi", ts=datetime.utcnow())
+        ],
+    )
+    app = create_app(TestConfig)
+    client: FlaskClient = app.test_client()
+    with app.app_context():
+        db.create_all()
+        db.session.add_all([
+            User(id=1, sub="abc", email="u@example.com", name="U"),
+            ChatGroup(id=1, name="g"),
+            ChatGroupMember(group_id=1, user_id=1),
+        ])
+        db.session.commit()
+
+    hdrs = {"Authorization": "Bearer t"}
+    resp = client.get("/api/v1/chat/history/1", headers=hdrs)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data[0]["content"] == "hi"
+


### PR DESCRIPTION
## Summary
- add chat tabs with Clan, Friends and All
- fetch last 100 messages for clan chat
- pass clan tag as chat groupId
- allow verifying group membership by clan tag
- expose history endpoint in messages API
- update and add tests for new behaviour

## Testing
- `ruff check back-end sync messages coclib db`
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6879f1f327f4832ca3d2e3a3526b3d92