### PR TITLE
Fix missing auth headers for websocket

### DIFF
--- a/front-end/src/aws/graphqlClient.js
+++ b/front-end/src/aws/graphqlClient.js
@@ -1,8 +1,8 @@
-import {Amplify} from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import { generateClient } from 'aws-amplify/api';
 
 
-let cached = {token: null, client: null};
+let cached = { token: null, client: null };
 
 export function getGraphQLClient(token) {
     if (!token) throw new Error('getGraphQLClient: token is required');
@@ -14,7 +14,15 @@ export function getGraphQLClient(token) {
                 endpoint: import.meta.env.VITE_APPSYNC_EVENTS_URL,
                 region: import.meta.env.VITE_AWS_REGION,
                 defaultAuthMode: 'oidc',
-                oidcProvider: {getToken: async () => token},
+                // Read the latest token for every request so websocket
+                // connections include fresh credentials.
+                oidcProvider: {
+                    getToken: async () => {
+                        const current = localStorage.getItem('token') || token;
+                        console.log('GraphQL WS auth token:', current);
+                        return current;
+                    },
+                },
             },
         },
     });


### PR DESCRIPTION
## Summary
- return auth token for every websocket request
- log the token during connection for debugging

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687b02d9f2b0832c816fbed22b01fbe2