### PR TITLE
Log commit hash on dashboard load

### DIFF
--- a/front-end/README.md
+++ b/front-end/README.md
@@ -40,6 +40,10 @@ npm install
 npm run build
 ```
 
+The build script automatically injects the current git commit hash into the
+bundle using the `VITE_COMMIT_HASH` environment variable. The application logs
+this commit hash to the browser console on page load.
+
 The production build output will be in the `dist/` directory. When building the
 Docker image you can supply build arguments to set the backend URL and Google
 client ID:

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "VITE_COMMIT_HASH=$(git rev-parse --short HEAD) vite build",
     "preview": "vite preview",
     "test": "vitest run"
   },

--- a/front-end/src/main.jsx
+++ b/front-end/src/main.jsx
@@ -3,6 +3,11 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 
+// Log the commit hash when the application loads to aid debugging
+if (import.meta.env.VITE_COMMIT_HASH) {
+  console.log('Build commit:', import.meta.env.VITE_COMMIT_HASH);
+}
+
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/sw.js');


### PR DESCRIPTION
## Summary
- show the build commit in the browser console
- inject the git commit hash during the build
- document the new behavior

## Testing
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687b0d289888832c926d3450313a8fa9