### PR TITLE
Fix WebSocket support for messages service

### DIFF
--- a/messages/run.py
+++ b/messages/run.py
@@ -2,9 +2,10 @@ import logging
 import os
 from dotenv import load_dotenv
 
-from asgiref.wsgi import WsgiToAsgi
+from socketio import ASGIApp
 from coclib.config import messages_env_configs
-from messages.app import create_app
+from messages.app import create_app, socketio
+from messages.app.api import API_PREFIX
 
 load_dotenv()
 
@@ -12,7 +13,7 @@ cfg_name = os.getenv("APP_ENV", "production")
 cfg_cls = messages_env_configs[cfg_name]
 
 app = create_app(cfg_cls)
-asgi_app = WsgiToAsgi(app)
+asgi_app = ASGIApp(socketio.server, other_asgi_app=app, socketio_path=f"{API_PREFIX}/chat/socket.io")
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- serve Flask-SocketIO through ASGI instead of WsgiToAsgi

## Testing
- `ruff check messages`
- `ruff check back-end sync coclib db`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_687b3c97dc6c832cab06e45ce75e4c98