### PR TITLE
Fix messages cors and add smoke to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
         run: pip install nox
 
       - name: Run nox
-        run: nox -s lint tests
+        run: nox -s lint tests smoke
 
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3

--- a/messages/requirements.txt
+++ b/messages/requirements.txt
@@ -44,6 +44,7 @@ ruff==0.12.2
 s3transfer==0.10.4
 six==1.17.0
 sniffio==1.3.1
+starlette==0.37.2
 SQLAlchemy==2.0.41
 typing_extensions==4.14.1
 tzlocal==5.3.1

--- a/messages/run.py
+++ b/messages/run.py
@@ -4,6 +4,7 @@ from dotenv import load_dotenv
 
 from socketio import ASGIApp
 from asgiref.wsgi import WsgiToAsgi
+from starlette.middleware.cors import CORSMiddleware
 from coclib.config import messages_env_configs
 from messages.app import create_app, socketio
 
@@ -17,6 +18,12 @@ asgi_app = ASGIApp(
     socketio.server,
     other_asgi_app=WsgiToAsgi(app),
     socketio_path="socket.io",
+)
+asgi_app = CORSMiddleware(
+    asgi_app,
+    allow_origins=app.config["CORS_ORIGINS"],
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 logger = logging.getLogger(__name__)
 

--- a/tests/test_messages_cors.py
+++ b/tests/test_messages_cors.py
@@ -1,0 +1,46 @@
+import os
+import asyncio
+import httpx
+from httpx import ASGITransport
+from starlette.middleware.cors import CORSMiddleware
+from asgiref.wsgi import WsgiToAsgi
+from socketio import ASGIApp
+
+os.environ['GOOGLE_CLIENT_ID'] = 'dummy'
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['COC_API_TOKEN'] = 'dummy'
+
+from coclib.config import MessagesConfig
+from messages.app import create_app, socketio
+
+def test_socketio_cors_header():
+    async def run_test():
+        class TestConfig(MessagesConfig):
+            TESTING = True
+            SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+            GOOGLE_CLIENT_ID = "dummy"
+
+        app = create_app(TestConfig)
+        asgi_app = ASGIApp(
+            socketio.server,
+            other_asgi_app=WsgiToAsgi(app),
+            socketio_path="socket.io",
+        )
+        asgi_app = CORSMiddleware(
+            asgi_app,
+            allow_origins=app.config["CORS_ORIGINS"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+        transport = ASGITransport(app=asgi_app)
+        async with httpx.AsyncClient(transport=transport, base_url='http://testserver') as client:
+            resp = await client.options(
+                '/socket.io/?EIO=4&transport=polling&t=1',
+                headers={
+                    'Origin': 'https://dev.clan-boards.com',
+                    'Access-Control-Request-Method': 'POST',
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.headers.get('Access-Control-Allow-Origin') == 'https://dev.clan-boards.com'
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- allow CORS in the messages ASGI app
- run smoke tests in CI
- add regression test for socket.io CORS headers

## Testing
- `ruff check back-end sync coclib db messages`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bccb343f0832ca37502be17595478