### PR TITLE
Fix CORS for messages service

### DIFF
--- a/messages/app/__init__.py
+++ b/messages/app/__init__.py
@@ -29,7 +29,11 @@ def create_app(cfg_cls: type[MessagesConfig] = MessagesConfig) -> Flask:
     if not client_id:
         raise RuntimeError("GOOGLE_CLIENT_ID environment variable is required")
 
-    CORS(app, resources={r"/*": {"origins": app.config["CORS_ORIGINS"]}})
+    CORS(
+        app,
+        resources={r"/*": {"origins": app.config["CORS_ORIGINS"]}},
+        supports_credentials=True,
+    )
     socketio.init_app(
         app,
         cors_allowed_origins=app.config["CORS_ORIGINS"],

--- a/messages/run.py
+++ b/messages/run.py
@@ -24,6 +24,7 @@ asgi_app = CORSMiddleware(
     allow_origins=app.config["CORS_ORIGINS"],
     allow_methods=["*"],
     allow_headers=["*"],
+    allow_credentials=True,
 )
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- enable credentials when setting CORS for the messages Flask app
- allow credentials with Starlette's CORS middleware

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_687bd9e1e7e0832cb5c09092eea6f084