### PR TITLE
Fix messages-java build by using Gradle wrapper

### DIFF
--- a/messages-java/Dockerfile
+++ b/messages-java/Dockerfile
@@ -1,9 +1,9 @@
 FROM eclipse-temurin:21-jdk-jammy AS build
-RUN apt-get update && apt-get install -y gradle && rm -rf /var/lib/apt/lists/*
 WORKDIR /workspace
 COPY messages-java/ ./messages-java
 WORKDIR /workspace/messages-java
-RUN gradle bootJar --no-daemon
+RUN chmod +x gradlew
+RUN ./gradlew bootJar --no-daemon
 
 FROM eclipse-temurin:21-jre-jammy
 WORKDIR /opt/app


### PR DESCRIPTION
## Summary
- update messages-java Dockerfile to rely on the project's gradle wrapper

## Testing
- `nox -s lint tests`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687bfa56e868832c8353e2e55050c023