### PR TITLE
Add player info beneath chat messages

### DIFF
--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { fetchJSONCached } from '../lib/api.js';
+import { proxyImageUrl } from '../lib/assets.js';
+
+export default function ChatMessage({ message }) {
+  const { userId, content } = message;
+  const [info, setInfo] = useState(null);
+
+  useEffect(() => {
+    let ignore = false;
+    if (!userId) return;
+    fetchJSONCached(`/player/${encodeURIComponent(userId)}`)
+      .then((data) => {
+        if (!ignore) {
+          setInfo({ name: data.name, icon: data.leagueIcon });
+        }
+      })
+      .catch(() => {});
+    return () => {
+      ignore = true;
+    };
+  }, [userId]);
+
+  return (
+    <div className="bg-slate-100 rounded px-2 py-1">
+      {content}
+      {info && (
+        <div className="flex items-center gap-1 text-xs text-slate-500 mt-1">
+          {info.icon && (
+            <img
+              src={proxyImageUrl(info.icon)}
+              alt="league"
+              className="w-4 h-4"
+            />
+          )}
+          <span>{info.name}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front-end/src/components/ChatMessage.test.jsx
+++ b/front-end/src/components/ChatMessage.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('../lib/api.js', () => ({
+  fetchJSONCached: vi.fn(),
+}));
+vi.mock('../lib/assets.js', () => ({
+  proxyImageUrl: (url) => url,
+}));
+
+import ChatMessage from './ChatMessage.jsx';
+import { fetchJSONCached } from '../lib/api.js';
+
+const sample = { name: 'Alice', leagueIcon: 'http://ex/icon.png' };
+
+describe('ChatMessage', () => {
+  it('displays player name and icon', async () => {
+    fetchJSONCached.mockResolvedValue(sample);
+    render(<ChatMessage message={{ userId: 'AAA', content: 'hi' }} />);
+    await waitFor(() => expect(fetchJSONCached).toHaveBeenCalled());
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByAltText('league')).toHaveAttribute('src', sample.leagueIcon);
+  });
+});

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { fetchJSON } from '../lib/api.js';
 import useChat from '../hooks/useChat.js';
+import ChatMessage from './ChatMessage.jsx';
 
 export default function ChatPanel({ groupId = '1' }) {
   const { messages } = useChat(groupId);
@@ -51,9 +52,7 @@ export default function ChatPanel({ groupId = '1' }) {
         <>
           <div className="flex-1 overflow-y-auto space-y-2 p-4">
             {messages.map((m, idx) => (
-              <div key={idx} className="bg-slate-100 rounded px-2 py-1">
-                {m.content}
-              </div>
+              <ChatMessage key={m.ts || idx} message={m} />
             ))}
             <div ref={endRef} />
           </div>


### PR DESCRIPTION
## Summary
- display chat messages via new `ChatMessage` component
- fetch player name and league icon for each message
- test that chat messages render player info

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687c070169f0832caa562f6081ea40e8