### PR TITLE
Fix CORS for chat service

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/config/CorsConfig.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package com.clanboards.messages.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/**")
+                        .allowedOrigins("*")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowCredentials(false);
+            }
+        };
+    }
+}

--- a/messages-java/src/main/java/com/clanboards/messages/config/WebSocketConfig.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/WebSocketConfig.java
@@ -17,6 +17,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/api/v1/chat/socket").setAllowedOriginPatterns("*").withSockJS();
+        registry.addEndpoint("/api/v1/chat/socket")
+                .setAllowedOriginPatterns("*")
+                .setAllowedOrigins("*")
+                .withSockJS();
     }
 }


### PR DESCRIPTION
## Summary
- add global CORS configuration to messages-java
- permit all origins for the websocket endpoint

## Testing
- `./gradlew test`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c0c38ccc0832cb0e057cae41c3697