### PR TITLE
Fix player lookups for chat

### DIFF
--- a/back-end/app/api/player_routes.py
+++ b/back-end/app/api/player_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, abort
 from coclib.services.player_service import get_player_snapshot
 from coclib.services.loyalty_service import get_player_loyalty
 from ..services.risk_service import get_history, score_breakdown
@@ -11,6 +11,8 @@ bp = Blueprint("player", __name__, url_prefix=f"{API_PREFIX}/player")
 async def player_profile(tag: str):
     norm_tag = tag.upper().lstrip("#")
     data = await get_player_snapshot(norm_tag)
+    if data is None:
+        abort(404)
     data["loyalty"] = get_player_loyalty(norm_tag)
 
     history = await get_history(norm_tag, 30)

--- a/coclib/services/player_service.py
+++ b/coclib/services/player_service.py
@@ -65,6 +65,8 @@ async def get_player(tag: str, war_attacks_used: int | None = None) -> dict:
         return cached
 
     data = await _fetch_player(tag)
+    if "tag" not in data:
+        raise RuntimeError("player-not-found")
     upsert_player(data)
 
     now = datetime.utcnow()

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -304,7 +304,7 @@ export default function App() {
         <Suspense fallback={<Loading className="h-screen" />}>
           <ChatDrawer open={showChat} onClose={() => setShowChat(false)}>
             {verified ? (
-              <ChatPanel groupId={homeClanTag || '1'} />
+              <ChatPanel groupId={homeClanTag || '1'} userId={playerTag || ''} />
             ) : (
               <div className="p-4 h-full overflow-y-auto">Verify your account to chat.</div>
             )}

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -3,7 +3,7 @@ import { fetchJSON } from '../lib/api.js';
 import useChat from '../hooks/useChat.js';
 import ChatMessage from './ChatMessage.jsx';
 
-export default function ChatPanel({ groupId = '1' }) {
+export default function ChatPanel({ groupId = '1', userId = '' }) {
   const { messages } = useChat(groupId);
   const [text, setText] = useState('');
   const [sending, setSending] = useState(false);
@@ -26,7 +26,7 @@ export default function ChatPanel({ groupId = '1' }) {
       await fetchJSON('/chat/publish', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ groupId, text: trimmed }),
+        body: JSON.stringify({ groupId, userId, text: trimmed }),
       });
       setText('');
     } catch (err) {

--- a/front-end/src/hooks/useChat.js
+++ b/front-end/src/hooks/useChat.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 import useGoogleIdToken from './useGoogleIdToken.js';
-import { fetchJSON } from '../lib/api.js';
+import { API_URL, fetchJSON } from '../lib/api.js';
 
 export default function useChat(groupId) {
   const token = useGoogleIdToken();
@@ -29,7 +29,7 @@ export default function useChat(groupId) {
 
       if (ignore) return;
       console.log('Connecting socket for group', groupId);
-      const base = import.meta.env.VITE_API_URL || window.location.origin;
+      const base = API_URL || window.location.origin;
       client = new Client({
         webSocketFactory: () => new SockJS(`${base}/api/v1/chat/socket`),
         onConnect: () => {

--- a/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
@@ -22,7 +22,7 @@ public class ChatController {
 
     @PostMapping("/publish")
     public ResponseEntity<Map<String, String>> publish(@RequestBody PublishRequest req) {
-        ChatMessage msg = chatService.publish(req.groupId(), req.text(), "0");
+        ChatMessage msg = chatService.publish(req.groupId(), req.text(), req.userId());
         messaging.convertAndSend("/topic/chat/" + req.groupId(), Map.of(
                 "channel", msg.channel(),
                 "userId", msg.userId(),
@@ -46,5 +46,5 @@ public class ChatController {
         return ResponseEntity.ok(body);
     }
 
-    public static record PublishRequest(String groupId, String text) {}
+    public static record PublishRequest(String groupId, String text, String userId) {}
 }

--- a/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
@@ -30,12 +30,12 @@ class ChatControllerTest {
     @Test
     void publishReturnsOk() throws Exception {
         Instant ts = Instant.parse("2024-01-01T00:00:00Z");
-        Mockito.when(chatService.publish("1", "hi", "0"))
-                .thenReturn(new ChatMessage("1", "0", "hi", ts));
+        Mockito.when(chatService.publish("1", "hi", "u"))
+                .thenReturn(new ChatMessage("1", "u", "hi", ts));
 
         mvc.perform(post("/api/v1/chat/publish")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"groupId\":\"1\",\"text\":\"hi\"}"))
+                .content("{\"groupId\":\"1\",\"text\":\"hi\",\"userId\":\"u\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("ok"))
                 .andExpect(jsonPath("$.ts").value(ts.toString()));

--- a/tests/test_player_route.py
+++ b/tests/test_player_route.py
@@ -1,0 +1,43 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+from app import create_app
+from coclib.config import Config
+from coclib.extensions import db
+from coclib.models import User
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    GOOGLE_CLIENT_ID = "dummy"
+
+
+def _mock_verify(monkeypatch):
+    monkeypatch.setattr(
+        "app.id_token.verify_oauth2_token",
+        lambda t, req, cid: {"sub": "abc", "email": "u@example.com", "name": "U"},
+    )
+
+
+def test_player_not_found_returns_404(monkeypatch):
+    async def dummy(tag: str):
+        return None
+
+    monkeypatch.setattr(
+        "coclib.services.player_service.get_player_snapshot",
+        dummy,
+    )
+    _mock_verify(monkeypatch)
+    app = create_app(TestConfig)
+    client = app.test_client()
+    with app.app_context():
+        db.create_all()
+        db.session.add(User(id=1, sub="abc", email="u@example.com", name="U", player_tag="AAA"))
+        db.session.commit()
+    resp = client.get(
+        "/api/v1/player/UNKNOWN",
+        headers={"Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- avoid storing invalid chat player IDs by sending tag from the frontend
- ensure chat websocket URL is built correctly
- respond with 404 when a player is missing
- pass userId through publish API and tests
- test player route for missing tag

## Testing
- `nox -s tests`
- `./gradlew test`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c12021d60832cb293c893d5b6fef6