### PR TITLE
Fix CORS error for chat service

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/config/WebSocketConfig.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/WebSocketConfig.java
@@ -19,7 +19,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/api/v1/chat/socket")
                 .setAllowedOriginPatterns("*")
-                .setAllowedOrigins("*")
                 .withSockJS();
     }
 }


### PR DESCRIPTION
## Summary
- adjust websocket CORS config to use `setAllowedOriginPatterns` only

## Testing
- `./gradlew test`
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687c195532a8832cba5cb80dc9d7a6a9