### PR TITLE
Fix chat message player fetch

### DIFF
--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -3,13 +3,13 @@ import { fetchJSONCached } from '../lib/api.js';
 import { proxyImageUrl } from '../lib/assets.js';
 
 export default function ChatMessage({ message }) {
-  const { userId, content } = message;
+  const { playerTag, content } = message;
   const [info, setInfo] = useState(null);
 
   useEffect(() => {
     let ignore = false;
-    if (!userId) return;
-    fetchJSONCached(`/player/${encodeURIComponent(userId)}`)
+    if (!playerTag) return;
+    fetchJSONCached(`/player/${encodeURIComponent(playerTag)}`)
       .then((data) => {
         if (!ignore) {
           setInfo({ name: data.name, icon: data.leagueIcon });
@@ -19,7 +19,7 @@ export default function ChatMessage({ message }) {
     return () => {
       ignore = true;
     };
-  }, [userId]);
+  }, [playerTag]);
 
   return (
     <div className="bg-slate-100 rounded px-2 py-1">

--- a/front-end/src/components/ChatMessage.test.jsx
+++ b/front-end/src/components/ChatMessage.test.jsx
@@ -17,8 +17,12 @@ const sample = { name: 'Alice', leagueIcon: 'http://ex/icon.png' };
 describe('ChatMessage', () => {
   it('displays player name and icon', async () => {
     fetchJSONCached.mockResolvedValue(sample);
-    render(<ChatMessage message={{ userId: 'AAA', content: 'hi' }} />);
-    await waitFor(() => expect(fetchJSONCached).toHaveBeenCalled());
+    render(
+      <ChatMessage message={{ userId: 'UID', playerTag: 'AAA', content: 'hi' }} />
+    );
+    await waitFor(() =>
+      expect(fetchJSONCached).toHaveBeenCalledWith('/player/AAA')
+    );
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.getByAltText('league')).toHaveAttribute('src', sample.leagueIcon);
   });


### PR DESCRIPTION
## Summary
- use `playerTag` when fetching player data in chat messages
- update tests for correct API usage

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687c29f10e08832cb58d043dbbff6fdd