### PR TITLE
Fix chat player info regression

### DIFF
--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -3,13 +3,13 @@ import { fetchJSONCached } from '../lib/api.js';
 import { proxyImageUrl } from '../lib/assets.js';
 
 export default function ChatMessage({ message }) {
-  const { userId, content } = message;
+  const { userId: playerTag, content } = message;
   const [info, setInfo] = useState(null);
 
   useEffect(() => {
     let ignore = false;
-    if (!userId) return;
-    fetchJSONCached(`/player/${encodeURIComponent(userId)}`)
+    if (!playerTag) return;
+    fetchJSONCached(`/player/${encodeURIComponent(playerTag)}`)
       .then((data) => {
         if (!ignore) {
           setInfo({ name: data.name, icon: data.leagueIcon });
@@ -19,7 +19,7 @@ export default function ChatMessage({ message }) {
     return () => {
       ignore = true;
     };
-  }, [userId]);
+  }, [playerTag]);
 
   return (
     <div className="bg-slate-100 rounded px-2 py-1">


### PR DESCRIPTION
## Summary
- restore player info in `ChatMessage` by aliasing `userId` to `playerTag`
- update unit test for existing message shape

## Testing
- `nox -s lint tests`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c29f10e08832cb58d043dbbff6fdd