### PR TITLE
Improve mobile PWA layout

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -11,6 +11,7 @@
         "@stomp/stompjs": "^7.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.23.0",
         "react-window": "^1.8.8",
         "sockjs-client": "^1.6.1"
       },
@@ -950,6 +951,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2433,6 +2443,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-window": {

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0",
     "react-window": "^1.8.8",
     "@stomp/stompjs": "^7.1.1",
     "sockjs-client": "^1.6.1"

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,16 +1,18 @@
 import React, { Suspense, lazy, useEffect, useState } from 'react';
+import { BrowserRouter as Router, Routes, Route, Navigate, Link } from 'react-router-dom';
 import Loading from './components/Loading.jsx';
 import PlayerTagForm from './components/PlayerTagForm.jsx';
 import { fetchJSON } from './lib/api.js';
 import { proxyImageUrl } from './lib/assets.js';
 import useFeatures from './hooks/useFeatures.js';
+import BottomNav from './components/BottomNav.jsx';
 
 const Dashboard = lazy(() => import('./pages/Dashboard.jsx'));
-const ClanSearchModal = lazy(() => import('./components/ClanSearchModal.jsx'));
 const ClanModal = lazy(() => import('./components/ClanModal.jsx'));
-const ProfileModal = lazy(() => import('./components/ProfileModal.jsx'));
-const ChatDrawer = lazy(() => import('./components/ChatDrawer.jsx'));
-const ChatPanel = lazy(() => import('./components/ChatPanel.jsx'));
+const DashboardPage = lazy(() => import('./pages/Dashboard.jsx'));
+const ChatPage = lazy(() => import('./pages/ChatPage.jsx'));
+const CommunityPage = lazy(() => import('./pages/Community.jsx'));
+const AccountPage = lazy(() => import('./pages/Account.jsx'));
 
 function isTokenExpired(tok) {
   try {
@@ -54,10 +56,7 @@ export default function App() {
   const [clanInfo, setClanInfo] = useState(null);
   const [showClanInfo, setShowClanInfo] = useState(false);
   const [loadingUser, setLoadingUser] = useState(false);
-  const [showSearch, setShowSearch] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
-  const [showProfile, setShowProfile] = useState(false);
-  const [showChat, setShowChat] = useState(false);
   const { enabled: hasFeature } = useFeatures(token);
   const chatAllowed = hasFeature('chat');
   const menuRef = React.useRef(null);
@@ -194,12 +193,9 @@ export default function App() {
   }
 
   return (
-    <>
+    <Router>
       <header className="banner bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 flex items-center justify-between shadow-md">
         <h1 className="text-lg font-semibold flex items-center gap-2">
-          {clanInfo?.badgeUrls && (
-            <img src={proxyImageUrl(clanInfo.badgeUrls.small)} alt="badge" className="w-6 h-6" />
-          )}
           <button onClick={() => setShowClanInfo(true)} className="hover:underline">
             {clanInfo?.name || 'Clan Dashboard'}
           </button>
@@ -213,20 +209,7 @@ export default function App() {
               <i data-lucide="arrow-left" className="w-5 h-5" />
             </button>
           )}
-          <button
-            className="p-2 rounded hover:bg-slate-700"
-            onClick={() => setShowSearch(true)}
-          >
-            <i data-lucide="search" className="w-5 h-5" />
-          </button>
-          {chatAllowed && (
-            <button
-              className="p-2 rounded hover:bg-slate-700"
-              onClick={() => setShowChat(true)}
-            >
-              <i data-lucide="message-circle" className="w-5 h-5" />
-            </button>
-          )}
+          {chatAllowed && null}
           <div className="relative" ref={menuRef}>
             <button
               className="w-8 h-8 rounded-full bg-slate-700 flex items-center justify-center text-sm font-medium uppercase hover:bg-slate-600"
@@ -237,15 +220,13 @@ export default function App() {
             </button>
             {showMenu && (
               <div className="absolute right-0 mt-2 w-28 bg-white text-slate-700 rounded shadow-lg z-10">
-                <button
+                <Link
+                  to="/account"
                   className="block w-full text-left px-3 py-2 hover:bg-slate-100"
-                  onClick={() => {
-                    setShowMenu(false);
-                    setShowProfile(true);
-                  }}
+                  onClick={() => setShowMenu(false)}
                 >
-                  Profile
-                </button>
+                  Account
+                </Link>
                 <button
                   className="block w-full text-left px-3 py-2 hover:bg-slate-100"
                   onClick={() => {
@@ -275,42 +256,22 @@ export default function App() {
         )}
         {!loadingUser && playerTag && (
           <Suspense fallback={<Loading className="py-20" />}>
-            <Dashboard defaultTag={clanTag} showSearchForm={false} onClanLoaded={setClanInfo} />
+            <Routes>
+              <Route path="/" element={<DashboardPage defaultTag={clanTag} showSearchForm={false} onClanLoaded={setClanInfo} />} />
+              <Route path="/chat" element={<ChatPage verified={verified} groupId={homeClanTag || '1'} userId={playerTag || ''} />} />
+              <Route path="/community" element={<CommunityPage verified={verified} groupId={homeClanTag || '1'} userId={playerTag || ''} onClanSelect={(c) => setClanTag(c.tag)} />} />
+              <Route path="/account" element={<AccountPage onVerified={() => setVerified(true)} />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
           </Suspense>
         )}
       </main>
-      {showSearch && (
-        <Suspense fallback={<Loading className="h-screen" />}>
-          <ClanSearchModal
-            onClose={() => setShowSearch(false)}
-            onClanLoaded={(c) => {
-              setClanTag(c.tag);
-              setShowSearch(false);
-            }}
-          />
-        </Suspense>
-      )}
+      <BottomNav clanIcon={clanInfo?.badgeUrls?.small} />
       {showClanInfo && (
         <Suspense fallback={<Loading className="h-screen" />}>
           <ClanModal clan={clanInfo} onClose={() => setShowClanInfo(false)} />
         </Suspense>
       )}
-      {showProfile && (
-        <Suspense fallback={<Loading className="h-screen" />}>
-          <ProfileModal onClose={() => setShowProfile(false)} onVerified={() => setVerified(true)} />
-        </Suspense>
-      )}
-      {chatAllowed && showChat && (
-        <Suspense fallback={<Loading className="h-screen" />}>
-          <ChatDrawer open={showChat} onClose={() => setShowChat(false)}>
-            {verified ? (
-              <ChatPanel groupId={homeClanTag || '1'} userId={playerTag || ''} />
-            ) : (
-              <div className="p-4 h-full overflow-y-auto">Verify your account to chat.</div>
-            )}
-          </ChatDrawer>
-        </Suspense>
-      )}
-    </>
+    </Router>
   );
 }

--- a/front-end/src/components/BottomNav.jsx
+++ b/front-end/src/components/BottomNav.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import { proxyImageUrl } from '../lib/assets.js';
+
+export default function BottomNav({ clanIcon }) {
+  const items = [
+    { to: '/', label: 'Home', icon: 'shield' },
+    { to: '/chat', label: 'Chat', icon: 'message-circle' },
+    { to: '/community', label: 'Community', icon: 'users' },
+    { to: '/account', label: 'Account', icon: 'user' },
+  ];
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t flex sm:hidden z-50">
+      {items.map((item) => (
+        <NavLink
+          key={item.to}
+          to={item.to}
+          end={item.to === '/'}
+          className={({ isActive }) =>
+            `flex-1 py-2 text-center flex flex-col items-center ${isActive ? 'text-blue-600' : 'text-slate-600'}`
+          }
+        >
+          {item.to === '/' && clanIcon ? (
+            <img src={proxyImageUrl(clanIcon)} alt="clan" className="w-5 h-5" />
+          ) : (
+            <i data-lucide={item.icon} className="w-5 h-5" />
+          )}
+          <span className="text-xs mt-1">{item.label}</span>
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/front-end/src/components/BottomNav.test.jsx
+++ b/front-end/src/components/BottomNav.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import BottomNav from './BottomNav.jsx';
+
+describe('BottomNav', () => {
+  it('renders basic nav items', () => {
+    render(
+      <MemoryRouter>
+        <BottomNav />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+    expect(screen.getByText('Community')).toBeInTheDocument();
+    expect(screen.getByText('Account')).toBeInTheDocument();
+  });
+});

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -1,5 +1,5 @@
 #root {
-    padding: 0 0.5rem 0.5rem;
+    padding: 0 0.5rem 4rem;
     background: linear-gradient(to bottom right, #f1f5f9, #e2e8f0);
     min-height: 100vh;
 }

--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useState } from 'react';
+import { fetchJSON } from '../lib/api.js';
+import Loading from '../components/Loading.jsx';
+import VerifiedBadge from '../components/VerifiedBadge.jsx';
+import ChatBadge from '../components/ChatBadge.jsx';
+
+export default function Account({ onVerified }) {
+  const [profile, setProfile] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [token, setToken] = useState('');
+  const [chatEnabled, setChatEnabled] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchJSON('/user/profile');
+        setProfile(data);
+        const features = await fetchJSON('/user/features');
+        setChatEnabled(features.all || features.features.includes('chat'));
+      } catch {
+        setProfile({});
+      }
+    };
+    load();
+  }, []);
+
+  const handleChange = (key, value) => {
+    setProfile((p) => ({ ...p, [key]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await fetchJSON('/user/profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(profile),
+      });
+      await fetchJSON('/user/features', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ features: chatEnabled ? ['chat'] : [], all: false }),
+      });
+      window.dispatchEvent(new Event('features-updated'));
+    } catch {
+      setSaving(false);
+      return;
+    }
+    setSaving(false);
+  };
+
+  if (!profile) return <Loading className="py-20" />;
+
+  return (
+    <form className="max-w-md mx-auto space-y-4" onSubmit={handleSubmit}>
+      <h3 className="text-xl font-semibold flex items-center gap-2">
+        Profile
+        {profile.verified && <VerifiedBadge />}
+        {chatEnabled && <ChatBadge />}
+      </h3>
+      <label className="block">
+        <span className="text-sm">War Weight</span>
+        <input
+          type="number"
+          step="0.01"
+          value={profile.risk_weight_war ?? 0}
+          onChange={(e) => handleChange('risk_weight_war', parseFloat(e.target.value))}
+          className="mt-1 w-full border px-2 py-1 rounded"
+        />
+      </label>
+      <label className="block">
+        <span className="text-sm">Idle Weight</span>
+        <input
+          type="number"
+          step="0.01"
+          value={profile.risk_weight_idle ?? 0}
+          onChange={(e) => handleChange('risk_weight_idle', parseFloat(e.target.value))}
+          className="mt-1 w-full border px-2 py-1 rounded"
+        />
+      </label>
+      <label className="block">
+        <span className="text-sm">Deficit Weight</span>
+        <input
+          type="number"
+          step="0.01"
+          value={profile.risk_weight_don_deficit ?? 0}
+          onChange={(e) => handleChange('risk_weight_don_deficit', parseFloat(e.target.value))}
+          className="mt-1 w-full border px-2 py-1 rounded"
+        />
+      </label>
+      <label className="block">
+        <span className="text-sm">Drop Weight</span>
+        <input
+          type="number"
+          step="0.01"
+          value={profile.risk_weight_don_drop ?? 0}
+          onChange={(e) => handleChange('risk_weight_don_drop', parseFloat(e.target.value))}
+          className="mt-1 w-full border px-2 py-1 rounded"
+        />
+      </label>
+      <label className="inline-flex items-center gap-2">
+        <input type="checkbox" checked={chatEnabled} onChange={(e) => setChatEnabled(e.target.checked)} />
+        <span className="text-sm">Enable Chat</span>
+      </label>
+      {!profile.verified && (
+        <>
+          <label className="block">
+            <span className="text-sm">API Token</span>
+            <input value={token} onChange={(e) => setToken(e.target.value)} className="mt-1 w-full border px-2 py-1 rounded" />
+          </label>
+          <button
+            type="button"
+            onClick={async () => {
+              setSaving(true);
+              try {
+                await fetchJSON('/user/verify', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ token }),
+                });
+                setProfile((p) => ({ ...p, verified: true }));
+                onVerified && onVerified();
+              } catch {
+                /* ignore */
+              }
+              setSaving(false);
+            }}
+            className="px-4 py-2 rounded bg-slate-800 text-white w-full"
+          >
+            {saving ? 'Verifying…' : 'Verify'}
+          </button>
+        </>
+      )}
+      <button type="submit" className="px-4 py-2 rounded bg-slate-800 text-white w-full">
+        {saving ? 'Saving…' : 'Save'}
+      </button>
+    </form>
+  );
+}

--- a/front-end/src/pages/ChatPage.jsx
+++ b/front-end/src/pages/ChatPage.jsx
@@ -1,0 +1,16 @@
+import React, { Suspense, lazy } from 'react';
+import Loading from '../components/Loading.jsx';
+
+const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
+
+export default function ChatPage({ verified, groupId, userId }) {
+  return (
+    <Suspense fallback={<Loading className="py-20" />}>
+      {verified ? (
+        <ChatPanel groupId={groupId} userId={userId} />
+      ) : (
+        <div className="p-4">Verify your account to chat.</div>
+      )}
+    </Suspense>
+  );
+}

--- a/front-end/src/pages/Community.jsx
+++ b/front-end/src/pages/Community.jsx
@@ -1,0 +1,39 @@
+import React, { useState, lazy, Suspense } from 'react';
+import MobileTabs from '../components/MobileTabs.jsx';
+import Loading from '../components/Loading.jsx';
+
+const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
+const Dashboard = lazy(() => import('./Dashboard.jsx'));
+
+export default function Community({ verified, groupId, userId, onClanSelect }) {
+  const [tab, setTab] = useState('chat');
+
+  return (
+    <div>
+      <MobileTabs
+        tabs={[
+          { label: 'Chat', value: 'chat' },
+          { label: 'Scouting', value: 'scouting' },
+          { label: 'Stats', value: 'stats' },
+        ]}
+        active={tab}
+        onChange={setTab}
+      />
+      {tab === 'chat' && (
+        <Suspense fallback={<Loading className="py-20" />}>
+          {verified ? (
+            <ChatPanel groupId={groupId} userId={userId} />
+          ) : (
+            <div className="p-4">Verify your account to chat.</div>
+          )}
+        </Suspense>
+      )}
+      {tab === 'scouting' && <div className="p-4">Coming soon...</div>}
+      {tab === 'stats' && (
+        <Suspense fallback={<Loading className="py-20" />}>
+          <Dashboard showSearchForm={true} onClanLoaded={onClanSelect} />
+        </Suspense>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add mobile bottom navigation bar
- create dedicated Chat, Community and Account pages
- route pages using React Router
- push search into Community Stats tab
- tweak layout padding for navigation bar

## Testing
- `npm test --silent`
- `npm run build --silent`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_687c4447367c832c92fc17b042869abb