### PR TITLE
Fix chat panel overflow on mobile

### DIFF
--- a/front-end/src/pages/ChatPage.jsx
+++ b/front-end/src/pages/ChatPage.jsx
@@ -5,12 +5,14 @@ const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
 
 export default function ChatPage({ verified, groupId, userId }) {
   return (
-    <Suspense fallback={<Loading className="py-20" />}>
-      {verified ? (
-        <ChatPanel groupId={groupId} userId={userId} />
-      ) : (
-        <div className="p-4">Verify your account to chat.</div>
-      )}
-    </Suspense>
+    <div className="h-[calc(100dvh-8rem)] sm:h-[calc(100dvh-4rem)]">
+      <Suspense fallback={<Loading className="py-20" />}>
+        {verified ? (
+          <ChatPanel groupId={groupId} userId={userId} />
+        ) : (
+          <div className="p-4">Verify your account to chat.</div>
+        )}
+      </Suspense>
+    </div>
   );
 }

--- a/front-end/src/pages/Community.jsx
+++ b/front-end/src/pages/Community.jsx
@@ -9,7 +9,7 @@ export default function Community({ verified, groupId, userId, onClanSelect }) {
   const [tab, setTab] = useState('chat');
 
   return (
-    <div>
+    <div className="h-[calc(100dvh-8rem)] sm:h-[calc(100dvh-4rem)] flex flex-col overflow-hidden">
       <MobileTabs
         tabs={[
           { label: 'Chat', value: 'chat' },
@@ -19,21 +19,23 @@ export default function Community({ verified, groupId, userId, onClanSelect }) {
         active={tab}
         onChange={setTab}
       />
-      {tab === 'chat' && (
-        <Suspense fallback={<Loading className="py-20" />}>
-          {verified ? (
-            <ChatPanel groupId={groupId} userId={userId} />
-          ) : (
-            <div className="p-4">Verify your account to chat.</div>
-          )}
-        </Suspense>
-      )}
-      {tab === 'scouting' && <div className="p-4">Coming soon...</div>}
-      {tab === 'stats' && (
-        <Suspense fallback={<Loading className="py-20" />}>
-          <Dashboard showSearchForm={true} onClanLoaded={onClanSelect} />
-        </Suspense>
-      )}
+      <div className="flex-1 min-h-0">
+        {tab === 'chat' && (
+          <Suspense fallback={<Loading className="py-20" />}>
+            {verified ? (
+              <ChatPanel groupId={groupId} userId={userId} />
+            ) : (
+              <div className="p-4">Verify your account to chat.</div>
+            )}
+          </Suspense>
+        )}
+        {tab === 'scouting' && <div className="p-4">Coming soon...</div>}
+        {tab === 'stats' && (
+          <Suspense fallback={<Loading className="py-20" />}>
+            <Dashboard showSearchForm={true} onClanLoaded={onClanSelect} />
+          </Suspense>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- prevent ChatPage from expanding beyond viewport
- confine chat in Community page

## Testing
- `nox -s lint tests`
- `ruff check back-end sync coclib db`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c570c85ec832cadac43ee8272690d