### PR TITLE
Fix chat refresh path and mobile layout

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy, useEffect, useState } from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate, Link } from 'react-router-dom';
+import { HashRouter as Router, Routes, Route, Navigate, Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import Loading from './components/Loading.jsx';
 import PlayerTagForm from './components/PlayerTagForm.jsx';

--- a/front-end/src/pages/ChatPage.jsx
+++ b/front-end/src/pages/ChatPage.jsx
@@ -5,7 +5,7 @@ const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
 
 export default function ChatPage({ verified, groupId, userId }) {
   return (
-    <div className="h-[calc(100dvh-8rem)] sm:h-[calc(100dvh-4rem)]">
+    <div className="h-[calc(100vh-8rem)] sm:h-[calc(100vh-4rem)] flex flex-col overflow-hidden">
       <Suspense fallback={<Loading className="py-20" />}>
         {verified ? (
           <ChatPanel groupId={groupId} userId={userId} />


### PR DESCRIPTION
## Summary
- use HashRouter so refreshes don't hit the backend `/chat` API
- adjust ChatPage container height

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_687c5fcee2bc832cb3d7a7f1980f5987