### PR TITLE
Cache remote icons in IndexedDB

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -4,7 +4,6 @@ import { ArrowLeft } from 'lucide-react';
 import Loading from './components/Loading.jsx';
 import PlayerTagForm from './components/PlayerTagForm.jsx';
 import { fetchJSON } from './lib/api.js';
-import { proxyImageUrl } from './lib/assets.js';
 import useFeatures from './hooks/useFeatures.js';
 import BottomNav from './components/BottomNav.jsx';
 import DesktopNav from './components/DesktopNav.jsx';

--- a/front-end/src/components/BottomNav.jsx
+++ b/front-end/src/components/BottomNav.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { Shield, MessageCircle, Users, User } from 'lucide-react';
-import { proxyImageUrl } from '../lib/assets.js';
+import CachedImage from './CachedImage.jsx';
 
 export default function BottomNav({ clanIcon }) {
   const items = [
@@ -23,7 +23,7 @@ export default function BottomNav({ clanIcon }) {
           }
         >
           {item.to === '/' && clanIcon ? (
-            <img src={proxyImageUrl(clanIcon)} alt="clan" className="w-5 h-5" />
+            <CachedImage src={clanIcon} alt="clan" className="w-5 h-5" />
           ) : (
             React.createElement(item.icon, { className: 'w-5 h-5' })
           )}

--- a/front-end/src/components/CachedImage.jsx
+++ b/front-end/src/components/CachedImage.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import useCachedIcon from '../hooks/useCachedIcon.js';
+
+export default function CachedImage({ src, ...props }) {
+  const url = useCachedIcon(src);
+  return <img src={url} {...props} />;
+}

--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { fetchJSONCached } from '../lib/api.js';
-import { proxyImageUrl } from '../lib/assets.js';
+import CachedImage from './CachedImage.jsx';
 
 export default function ChatMessage({ message }) {
   const { userId, content } = message;
@@ -27,11 +27,7 @@ export default function ChatMessage({ message }) {
       {info && (
         <div className="flex items-center gap-1 text-xs text-slate-500 mt-1">
           {info.icon && (
-            <img
-              src={proxyImageUrl(info.icon)}
-              alt="league"
-              className="w-4 h-4"
-            />
+            <CachedImage src={info.icon} alt="league" className="w-4 h-4" />
           )}
           <span>{info.name}</span>
         </div>

--- a/front-end/src/components/ChatMessage.test.jsx
+++ b/front-end/src/components/ChatMessage.test.jsx
@@ -5,8 +5,8 @@ import { vi } from 'vitest';
 vi.mock('../lib/api.js', () => ({
   fetchJSONCached: vi.fn(),
 }));
-vi.mock('../lib/assets.js', () => ({
-  proxyImageUrl: (url) => url,
+vi.mock('../hooks/useCachedIcon.js', () => ({
+  default: (url) => url,
 }));
 
 import ChatMessage from './ChatMessage.jsx';

--- a/front-end/src/components/ClanModal.jsx
+++ b/front-end/src/components/ClanModal.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { proxyImageUrl } from '../lib/assets.js';
+import CachedImage from './CachedImage.jsx';
 
 export default function ClanModal({ clan, onClose }) {
   if (!clan) return null;
@@ -11,7 +11,7 @@ export default function ClanModal({ clan, onClose }) {
           <button className="absolute top-3 right-3 text-slate-400" onClick={onClose}>✕</button>
           <div className="flex items-center gap-3">
             {clan.badgeUrls && (
-              <img src={proxyImageUrl(clan.badgeUrls.medium)} alt="badge" className="w-12 h-12" />
+              <CachedImage src={clan.badgeUrls.medium} alt="badge" className="w-12 h-12" />
             )}
             <div>
               <h3 className="text-xl font-semibold">{clan.name}</h3>

--- a/front-end/src/components/DesktopNav.jsx
+++ b/front-end/src/components/DesktopNav.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { Shield, MessageCircle, Users, User } from 'lucide-react';
-import { proxyImageUrl } from '../lib/assets.js';
+import CachedImage from './CachedImage.jsx';
 
 export default function DesktopNav({ clanIcon }) {
   const items = [
@@ -23,7 +23,7 @@ export default function DesktopNav({ clanIcon }) {
           }
         >
           {item.to === '/' && clanIcon ? (
-            <img src={proxyImageUrl(clanIcon)} alt="clan" className="w-4 h-4" />
+            <CachedImage src={clanIcon} alt="clan" className="w-4 h-4" />
           ) : (
             React.createElement(item.icon, { className: 'w-4 h-4' })
           )}

--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -5,7 +5,7 @@ import Loading from './Loading.jsx';
 import DonationRing from './DonationRing.jsx';
 import { timeAgo } from '../lib/time.js';
 import { getTownHallIcon } from '../lib/townhall.js';
-import { proxyImageUrl } from '../lib/assets.js';
+import CachedImage from './CachedImage.jsx';
 
 function Row({ index, style, data }) {
   const { members, openIndex, setOpenIndex, getSize, listRef, refreshing } = data;
@@ -29,7 +29,7 @@ function Row({ index, style, data }) {
         <div className="flex flex-col">
           <div className="flex items-center gap-2">
             {m.leagueIcon && (
-              <img src={proxyImageUrl(m.leagueIcon)} alt="league" className="w-5 h-5" />
+              <CachedImage src={m.leagueIcon} alt="league" className="w-5 h-5" />
             )}
             <img
               src={getTownHallIcon(m.townHallLevel)}

--- a/front-end/src/components/PlayerModal.jsx
+++ b/front-end/src/components/PlayerModal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { fetchJSONCached } from '../lib/api.js';
-import { proxyImageUrl } from '../lib/assets.js';
+import CachedImage from './CachedImage.jsx';
 import { getTownHallIcon } from '../lib/townhall.js';
 
 import Loading from './Loading.jsx';
@@ -40,7 +40,7 @@ export default function PlayerModal({ tag, onClose, refreshing = false }) {
             <>
               <h3 className="text-xl font-semibold text-slate-800 flex flex-wrap items-center gap-2">
                 {player.leagueIcon && (
-                  <img src={proxyImageUrl(player.leagueIcon)} alt="league" className="w-6 h-6" />
+                  <CachedImage src={player.leagueIcon} alt="league" className="w-6 h-6" />
                 )}
                 <span>{player.name}</span>
                 <span className="text-sm font-normal text-slate-500">{player.tag}</span>
@@ -57,8 +57,8 @@ export default function PlayerModal({ tag, onClose, refreshing = false }) {
                 </div>
                 {player.labels?.map((l) => (
                   <div className="flex flex-col items-center w-16" key={l.id || l.name}>
-                    <img
-                      src={proxyImageUrl(l.iconUrls.small || l.iconUrls.medium)}
+                    <CachedImage
+                      src={l.iconUrls.small || l.iconUrls.medium}
                       alt={l.name}
                       className="w-8 h-8"
                     />

--- a/front-end/src/components/ProfileCard.jsx
+++ b/front-end/src/components/ProfileCard.jsx
@@ -3,7 +3,7 @@ import RiskRing from './RiskRing.jsx';
 import Loading from './Loading.jsx';
 import { timeAgo } from '../lib/time.js';
 import { getTownHallIcon } from '../lib/townhall.js';
-import { proxyImageUrl } from '../lib/assets.js';
+import CachedImage from './CachedImage.jsx';
 
 export default function ProfileCard({ member, onClick, refreshing = false }) {
   if (!member) return null;
@@ -14,7 +14,7 @@ export default function ProfileCard({ member, onClick, refreshing = false }) {
     >
       <div className="flex gap-1 mb-1">
         {member.leagueIcon && (
-          <img src={proxyImageUrl(member.leagueIcon)} alt="league" className="w-6 h-6" />
+          <CachedImage src={member.leagueIcon} alt="league" className="w-6 h-6" />
         )}
         <img
           src={getTownHallIcon(member.townHallLevel)}

--- a/front-end/src/hooks/useCachedIcon.js
+++ b/front-end/src/hooks/useCachedIcon.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { proxyImageUrl, fetchCachedIcon } from '../lib/assets.js';
+
+export default function useCachedIcon(url) {
+  const [src, setSrc] = useState(() => proxyImageUrl(url));
+
+  useEffect(() => {
+    if (!url) return;
+    let ignore = false;
+    let objectUrl;
+    fetchCachedIcon(url)
+      .then((blob) => {
+        if (ignore || !blob) return;
+        objectUrl = URL.createObjectURL(blob);
+        setSrc(objectUrl);
+      })
+      .catch(() => {});
+    return () => {
+      ignore = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [url]);
+
+  return src;
+}

--- a/front-end/src/lib/assets.js
+++ b/front-end/src/lib/assets.js
@@ -1,4 +1,5 @@
 import { API_URL } from './api.js';
+import { getIconCache, putIconCache } from './db.js';
 
 const API_PREFIX = '/api/v1';
 
@@ -6,4 +7,18 @@ export function proxyImageUrl(url) {
   if (!url) return url;
   if (!/^https?:\/\//i.test(url)) return url;
   return `${API_URL}${API_PREFIX}/assets?url=${encodeURIComponent(url)}`;
+}
+
+export async function fetchCachedIcon(url) {
+  if (!url || !/^https?:\/\//i.test(url)) return undefined;
+  const proxied = proxyImageUrl(url);
+  const cached = await getIconCache(proxied);
+  if (cached) {
+    return cached.blob;
+  }
+  const res = await fetch(proxied);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const blob = await res.blob();
+  await putIconCache({ url: proxied, blob });
+  return blob;
 }

--- a/front-end/src/lib/assets.test.js
+++ b/front-end/src/lib/assets.test.js
@@ -1,6 +1,15 @@
-import { describe, it, expect } from 'vitest';
-import { proxyImageUrl } from './assets.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { proxyImageUrl, fetchCachedIcon } from './assets.js';
+import { getIconCache } from './db.js';
 import { API_URL } from './api.js';
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase('coc-cache');
+    req.onsuccess = req.onerror = req.onblocked = () => resolve();
+  });
+});
 
 describe('proxyImageUrl', () => {
   it('returns same value for empty or relative urls', () => {
@@ -13,5 +22,27 @@ describe('proxyImageUrl', () => {
     const url = 'https://api-assets.clashofclans.com/foo.png';
     const proxied = `${API_URL}/api/v1/assets?url=${encodeURIComponent(url)}`;
     expect(proxyImageUrl(url)).toBe(proxied);
+  });
+});
+
+describe('fetchCachedIcon', () => {
+  it('fetches and caches icons', async () => {
+    const url = 'https://api-assets.clashofclans.com/icon.png';
+    const proxied = `${API_URL}/api/v1/assets?url=${encodeURIComponent(url)}`;
+    const blob = new Blob(['img'], { type: 'image/png' });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(blob, { status: 200 }));
+    global.fetch = fetchMock;
+
+    const data1 = await fetchCachedIcon(url);
+    expect(fetchMock).toHaveBeenCalledWith(proxied);
+    expect(typeof data1.size).toBe('number');
+
+    fetchMock.mockClear();
+    const data2 = await fetchCachedIcon(url);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(typeof data2.size).toBe('number');
+
+    const cached = await getIconCache(proxied);
+    expect(typeof cached.blob.size).toBe('number');
   });
 });

--- a/front-end/src/lib/db.js
+++ b/front-end/src/lib/db.js
@@ -1,12 +1,16 @@
 import { openDB } from 'idb';
 
-const dbPromise = openDB('coc-cache', 1, {
-  upgrade(db) {
-    if (!db.objectStoreNames.contains('api')) {
+const dbPromise = openDB('coc-cache', 3, {
+  upgrade(db, oldVersion, newVersion, transaction) {
+    if (oldVersion < 1) {
       db.createObjectStore('api', { keyPath: 'path' });
-    }
-    if (!db.objectStoreNames.contains('clans')) {
       db.createObjectStore('clans', { keyPath: 'key' });
+    }
+    if (oldVersion < 2) {
+      db.createObjectStore('icons', { keyPath: 'url' });
+    }
+    if (oldVersion < 3 && oldVersion >= 2) {
+      transaction.objectStore('icons').clear();
     }
   },
 });
@@ -25,4 +29,12 @@ export async function getClanCache(key) {
 
 export async function putClanCache(record) {
   return (await dbPromise).put('clans', record);
+}
+
+export async function getIconCache(url) {
+  return (await dbPromise).get('icons', url);
+}
+
+export async function putIconCache(record) {
+  return (await dbPromise).put('icons', record);
 }

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -9,7 +9,7 @@ import DonationRing from '../components/DonationRing.jsx';
 import MemberAccordionList from '../components/MemberAccordionList.jsx';
 import ProfileCard from '../components/ProfileCard.jsx';
 import { getTownHallIcon } from '../lib/townhall.js';
-import { proxyImageUrl } from '../lib/assets.js';
+import CachedImage from '../components/CachedImage.jsx';
 import { Users } from 'lucide-react';
 
 const winStreakIcon = new URL('../assets/win-streak.svg', import.meta.url).href;
@@ -32,7 +32,7 @@ function Stat({icon, iconUrl, label, value, onClick}) {
             {(iconUrl || icon) && (
                 <div className="p-3 rounded-full bg-slate-200">
                     {iconUrl ? (
-                        <img src={proxyImageUrl(iconUrl)} alt="icon" className="w-7 h-7" />
+                        <CachedImage src={iconUrl} alt="icon" className="w-7 h-7" />
                     ) : (
                         Icon ? React.createElement(Icon, { className: 'w-7 h-7' }) : null
                     )}
@@ -271,7 +271,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                             <td data-label="Player" className="px-4 py-2 font-medium">
                                                 <span className="flex items-center gap-2">
                                                     {m.leagueIcon && (
-                                                        <img src={proxyImageUrl(m.leagueIcon)} alt="league" className="w-5 h-5" />
+                                                        <CachedImage src={m.leagueIcon} alt="league" className="w-5 h-5" />
                                                     )}
                                                     <img
                                                         src={getTownHallIcon(m.townHallLevel)}
@@ -359,7 +359,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                 <div className="flex flex-col">
                                                     <span className="flex items-center gap-2">
                                                         {m.leagueIcon && (
-                                                            <img src={proxyImageUrl(m.leagueIcon)} alt="league" className="w-5 h-5" />
+                                                            <CachedImage src={m.leagueIcon} alt="league" className="w-5 h-5" />
                                                         )}
                                                         <img
                                                             src={getTownHallIcon(m.townHallLevel)}


### PR DESCRIPTION
## Summary
- store downloaded icons in the `icons` object store using Blob data
- add object URL creation in `useCachedIcon`
- upgrade the IndexedDB schema and clear old icon data
- update tests for blob caching

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687c6a186d58832cb00ce872098ba453