### PR TITLE
Fix PWA tabs and assets

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -60,6 +60,14 @@ export default function App() {
   const [showMenu, setShowMenu] = useState(false);
   const { enabled: hasFeature } = useFeatures(token);
   const chatAllowed = hasFeature('chat');
+  const handleLogout = () => {
+    window.google?.accounts.id.disableAutoSelect();
+    localStorage.removeItem('token');
+    setToken(null);
+    setPlayerTag(null);
+    setClanTag(null);
+    setShowMenu(false);
+  };
   const menuRef = React.useRef(null);
 
   useEffect(() => {
@@ -208,7 +216,7 @@ export default function App() {
             </button>
           )}
           {chatAllowed && null}
-          <div className="relative" ref={menuRef}>
+          <div className="relative hidden sm:block" ref={menuRef}>
             <button
               className="w-8 h-8 rounded-full bg-slate-700 flex items-center justify-center text-sm font-medium uppercase hover:bg-slate-600"
               onClick={() => setShowMenu((v) => !v)}
@@ -227,14 +235,7 @@ export default function App() {
                 </Link>
                 <button
                   className="block w-full text-left px-3 py-2 hover:bg-slate-100"
-                  onClick={() => {
-                    window.google?.accounts.id.disableAutoSelect();
-                    localStorage.removeItem('token');
-                    setToken(null);
-                    setPlayerTag(null);
-                    setClanTag(null);
-                    setShowMenu(false);
-                  }}
+                  onClick={handleLogout}
                 >
                   Logout
                 </button>
@@ -259,7 +260,16 @@ export default function App() {
               <Route path="/" element={<DashboardPage defaultTag={clanTag} showSearchForm={false} onClanLoaded={setClanInfo} />} />
               <Route path="/chat" element={<ChatPage verified={verified} groupId={homeClanTag || '1'} userId={playerTag || ''} />} />
               <Route path="/community" element={<CommunityPage verified={verified} groupId={homeClanTag || '1'} userId={playerTag || ''} onClanSelect={(c) => setClanTag(c.tag)} />} />
-              <Route path="/account" element={<AccountPage onVerified={() => setVerified(true)} />} />
+              <Route
+                path="/account"
+                element={
+                  <AccountPage
+                    onVerified={() => setVerified(true)}
+                    initials={initials}
+                    onLogout={handleLogout}
+                  />
+                }
+              />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           </Suspense>

--- a/front-end/src/components/MobileTabs.jsx
+++ b/front-end/src/components/MobileTabs.jsx
@@ -2,16 +2,16 @@ import React from 'react';
 
 export default function MobileTabs({ tabs, active, onChange }) {
   return (
-    <div className="flex justify-center gap-2 mb-4">
+    <div className="flex border-b mb-4">
       {tabs.map((t) => (
         <button
           key={t.value}
           onClick={() => onChange(t.value)}
           className={
-            'px-3 py-1 rounded-full text-sm ' +
+            'flex-1 px-4 py-2 text-sm border-b-2 ' +
             (active === t.value
-              ? 'bg-slate-800 text-white'
-              : 'bg-slate-200 text-slate-700')
+              ? 'border-blue-600 text-blue-600'
+              : 'border-transparent text-slate-600')
           }
         >
           {t.label}

--- a/front-end/src/lib/assets.js
+++ b/front-end/src/lib/assets.js
@@ -9,16 +9,18 @@ export function proxyImageUrl(url) {
   return `${API_URL}${API_PREFIX}/assets?url=${encodeURIComponent(url)}`;
 }
 
+const ICON_TTL = 30 * 60 * 1000; // 30 minutes
+
 export async function fetchCachedIcon(url) {
   if (!url || !/^https?:\/\//i.test(url)) return undefined;
   const proxied = proxyImageUrl(url);
   const cached = await getIconCache(proxied);
-  if (cached) {
+  if (cached && Date.now() - (cached.ts || 0) < ICON_TTL) {
     return cached.blob;
   }
   const res = await fetch(proxied);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const blob = await res.blob();
-  await putIconCache({ url: proxied, blob });
+  await putIconCache({ url: proxied, blob, ts: Date.now() });
   return blob;
 }

--- a/front-end/src/lib/db.js
+++ b/front-end/src/lib/db.js
@@ -16,25 +16,49 @@ const dbPromise = openDB('coc-cache', 3, {
 });
 
 export async function getApiCache(path) {
-  return (await dbPromise).get('api', path);
+  try {
+    return (await dbPromise).get('api', path);
+  } catch {
+    return undefined;
+  }
 }
 
 export async function putApiCache(record) {
-  return (await dbPromise).put('api', record);
+  try {
+    return (await dbPromise).put('api', record);
+  } catch {
+    return undefined;
+  }
 }
 
 export async function getClanCache(key) {
-  return (await dbPromise).get('clans', key);
+  try {
+    return (await dbPromise).get('clans', key);
+  } catch {
+    return undefined;
+  }
 }
 
 export async function putClanCache(record) {
-  return (await dbPromise).put('clans', record);
+  try {
+    return (await dbPromise).put('clans', record);
+  } catch {
+    return undefined;
+  }
 }
 
 export async function getIconCache(url) {
-  return (await dbPromise).get('icons', url);
+  try {
+    return (await dbPromise).get('icons', url);
+  } catch {
+    return undefined;
+  }
 }
 
 export async function putIconCache(record) {
-  return (await dbPromise).put('icons', record);
+  try {
+    return (await dbPromise).put('icons', record);
+  } catch {
+    return undefined;
+  }
 }

--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -4,7 +4,7 @@ import Loading from '../components/Loading.jsx';
 import VerifiedBadge from '../components/VerifiedBadge.jsx';
 import ChatBadge from '../components/ChatBadge.jsx';
 
-export default function Account({ onVerified }) {
+export default function Account({ onVerified, initials = '', onLogout }) {
   const [profile, setProfile] = useState(null);
   const [saving, setSaving] = useState(false);
   const [token, setToken] = useState('');
@@ -54,6 +54,11 @@ export default function Account({ onVerified }) {
 
   return (
     <form className="max-w-md mx-auto space-y-4" onSubmit={handleSubmit}>
+      <div className="flex justify-center sm:hidden">
+        <div className="w-12 h-12 rounded-full bg-slate-700 text-white flex items-center justify-center text-lg font-medium">
+          {initials}
+        </div>
+      </div>
       <h3 className="text-xl font-semibold flex items-center gap-2">
         Profile
         {profile.verified && <VerifiedBadge />}
@@ -134,6 +139,13 @@ export default function Account({ onVerified }) {
       )}
       <button type="submit" className="px-4 py-2 rounded bg-slate-800 text-white w-full">
         {saving ? 'Saving…' : 'Save'}
+      </button>
+      <button
+        type="button"
+        onClick={onLogout}
+        className="px-4 py-2 rounded bg-red-600 text-white w-full"
+      >
+        Logout
       </button>
     </form>
   );

--- a/front-end/src/pages/Community.jsx
+++ b/front-end/src/pages/Community.jsx
@@ -2,17 +2,15 @@ import React, { useState, lazy, Suspense } from 'react';
 import MobileTabs from '../components/MobileTabs.jsx';
 import Loading from '../components/Loading.jsx';
 
-const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
 const Dashboard = lazy(() => import('./Dashboard.jsx'));
 
 export default function Community({ verified, groupId, userId, onClanSelect }) {
-  const [tab, setTab] = useState('chat');
+  const [tab, setTab] = useState('scouting');
 
   return (
     <div className="h-[calc(100dvh-8rem)] sm:h-[calc(100dvh-4rem)] flex flex-col overflow-hidden">
       <MobileTabs
         tabs={[
-          { label: 'Chat', value: 'chat' },
           { label: 'Scouting', value: 'scouting' },
           { label: 'Stats', value: 'stats' },
         ]}
@@ -20,15 +18,6 @@ export default function Community({ verified, groupId, userId, onClanSelect }) {
         onChange={setTab}
       />
       <div className="flex-1 min-h-0">
-        {tab === 'chat' && (
-          <Suspense fallback={<Loading className="py-20" />}>
-            {verified ? (
-              <ChatPanel groupId={groupId} userId={userId} />
-            ) : (
-              <div className="p-4">Verify your account to chat.</div>
-            )}
-          </Suspense>
-        )}
         {tab === 'scouting' && <div className="p-4">Coming soon...</div>}
         {tab === 'stats' && (
           <Suspense fallback={<Loading className="py-20" />}>


### PR DESCRIPTION
## Summary
- store icon cache with a 30 min TTL
- convert Community pills to tabs and drop Chat tab
- move profile badge to Account page with logout button
- hide mobile profile menu
- guard indexedDB failures

## Testing
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_687c71de6bb4832c9bfb12e392938da5