### PR TITLE
UI fixes for mobile view

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -180,7 +180,7 @@ export default function App() {
   if (!token) {
     return (
       <>
-        <header className="banner bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 text-center shadow-md">
+        <header className="banner bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 text-center shadow-md sticky top-0 z-50">
           <h1 className="text-lg font-semibold">Clan Dashboard</h1>
         </header>
         <div className="flex justify-center items-center h-[calc(100vh-4rem)] p-2 sm:p-4">
@@ -192,7 +192,7 @@ export default function App() {
 
   return (
     <Router>
-      <header className="banner bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 flex items-center justify-between shadow-md">
+      <header className="banner bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 flex items-center justify-between shadow-md sticky top-0 z-50">
         <h1 className="text-lg font-semibold flex items-center gap-2">
           <button onClick={() => setShowClanInfo(true)} className="hover:underline">
             {clanInfo?.name || 'Clan Dashboard'}

--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -24,7 +24,7 @@ function Row({ index, style, data }) {
     }
   };
   return (
-    <div style={{ ...style, overflow: 'hidden' }} className="border-b px-3" onClick={toggle}>
+    <div style={{ ...style, overflow: 'hidden' }} className="relative border-b px-3" onClick={toggle}>
       <div className="flex justify-between items-center py-2">
         <div className="flex flex-col">
           <div className="flex items-center gap-2">
@@ -45,17 +45,22 @@ function Row({ index, style, data }) {
             {m.last_seen ? timeAgo(m.last_seen) : '\u2014'}
           </p>
         </div>
-        {!open && (refreshing ? (
-          <Loading size={32} />
-        ) : (
-          <RiskRing score={m.risk_score} size={32} />
-        ))}
+        {!open && <RiskRing score={m.risk_score} size={32} />}
+        {refreshing && (
+          <div className="absolute top-2 right-3">
+            <Loading size={16} />
+          </div>
+        )}
       </div>
       {open && (
         <div className="text-sm space-y-1 pb-2">
           <div className="flex justify-between">
+            <span>Tag: {m.tag}</span>
+            <span>Role: {m.role || '—'}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>TH: {m.townHallLevel}</span>
             <span>Trophies: {m.trophies}</span>
-            <span>Last Seen: {m.last_seen ? timeAgo(m.last_seen) : '—'}</span>
           </div>
           <div className="flex justify-between items-center">
             <span>Don/Rec: {m.donations}/{m.donationsReceived}</span>
@@ -63,11 +68,11 @@ function Row({ index, style, data }) {
           </div>
           <div className="flex justify-between items-center">
             <span>Days in Clan: {m.loyalty}</span>
-            {refreshing ? (
-              <Loading size={32} />
-            ) : (
-              <RiskRing score={m.risk_score} size={32} />
-            )}
+            <RiskRing score={m.risk_score} size={32} />
+          </div>
+          <div className="flex justify-between">
+            <span>Last Seen:</span>
+            <span>{m.last_seen ? timeAgo(m.last_seen) : '—'}</span>
           </div>
           {m.risk_breakdown && m.risk_breakdown.length > 0 && (
             <ul className="list-disc list-inside text-xs pt-1">
@@ -91,7 +96,7 @@ export default function MemberAccordionList({ members, height, refreshing = fals
     const m = members[index];
     const base = 56;
     if (openIndex !== index) return base;
-    const lines = (m.risk_breakdown?.length || 0) + 3; // three base rows
+    const lines = (m.risk_breakdown?.length || 0) + 6; // six base rows
     return base + 24 + lines * 20;
   };
 

--- a/front-end/src/components/ProfileCard.jsx
+++ b/front-end/src/components/ProfileCard.jsx
@@ -9,9 +9,14 @@ export default function ProfileCard({ member, onClick, refreshing = false }) {
   if (!member) return null;
   return (
     <div
-      className="bg-white rounded shadow ring-2 ring-rose-200 px-4 py-3 flex flex-col items-center text-sm cursor-pointer w-40 shrink-0"
+      className="relative bg-white rounded shadow ring-2 ring-rose-200 px-4 py-3 flex flex-col items-center text-sm cursor-pointer w-40 shrink-0"
       onClick={onClick}
     >
+      {refreshing && (
+        <div className="absolute top-2 right-2">
+          <Loading size={16} />
+        </div>
+      )}
       <div className="flex gap-1 mb-1">
         {member.leagueIcon && (
           <CachedImage src={member.leagueIcon} alt="league" className="w-6 h-6" />
@@ -23,11 +28,7 @@ export default function ProfileCard({ member, onClick, refreshing = false }) {
         />
       </div>
       <p className="font-medium text-center mb-1">{member.name}</p>
-      {refreshing ? (
-        <Loading size={48} />
-      ) : (
-        <RiskRing score={member.risk_score} size={48} />
-      )}
+      <RiskRing score={member.risk_score} size={48} />
       <div className="mt-2 text-center space-y-1 w-full">
         <p>TH{member.townHallLevel}</p>
         <p className="text-xs text-slate-500">


### PR DESCRIPTION
## Summary
- make header sticky so banner stays visible
- show small spinner on player cards instead of replacing risk ring
- match data shown for all members dropdown to at-risk table

## Testing
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c79318094832cb69a5ad09de32309