### PR TITLE
Fix chat message loading and layout

### DIFF
--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -1,37 +1,24 @@
-import React, { useEffect, useState } from 'react';
-import { fetchJSONCached } from '../lib/api.js';
+import React from 'react';
 import CachedImage from './CachedImage.jsx';
 
-export default function ChatMessage({ message }) {
-  const { userId, content } = message;
-  const [info, setInfo] = useState(null);
-
-  useEffect(() => {
-    let ignore = false;
-    if (!userId) return;
-    fetchJSONCached(`/player/${encodeURIComponent(userId)}`)
-      .then((data) => {
-        if (!ignore) {
-          setInfo({ name: data.name, icon: data.leagueIcon });
-        }
-      })
-      .catch(() => {});
-    return () => {
-      ignore = true;
-    };
-  }, [userId]);
+export default function ChatMessage({ message, info, isSelf }) {
+  const { content } = message;
 
   return (
-    <div className="bg-slate-100 rounded px-2 py-1">
-      {content}
-      {info && (
-        <div className="flex items-center gap-1 text-xs text-slate-500 mt-1">
-          {info.icon && (
-            <CachedImage src={info.icon} alt="league" className="w-4 h-4" />
-          )}
-          <span>{info.name}</span>
-        </div>
-      )}
+    <div className={`flex ${isSelf ? 'justify-end' : 'justify-start'}`}>
+      <div
+        className={`max-w-[80%] rounded px-2 py-1 ${isSelf ? 'bg-blue-100' : 'bg-slate-100'}`}
+      >
+        {content}
+        {info && (
+          <div className="flex items-center gap-1 text-xs text-slate-500 mt-1">
+            {info.icon && (
+              <CachedImage src={info.icon} alt="league" className="w-4 h-4" />
+            )}
+            <span>{info.name}</span>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/front-end/src/components/ChatMessage.test.jsx
+++ b/front-end/src/components/ChatMessage.test.jsx
@@ -1,25 +1,18 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { vi } from 'vitest';
 
-vi.mock('../lib/api.js', () => ({
-  fetchJSONCached: vi.fn(),
-}));
 vi.mock('../hooks/useCachedIcon.js', () => ({
   default: (url) => url,
 }));
 
 import ChatMessage from './ChatMessage.jsx';
-import { fetchJSONCached } from '../lib/api.js';
 
-const sample = { name: 'Alice', leagueIcon: 'http://ex/icon.png' };
+const sample = { name: 'Alice', icon: 'http://ex/icon.png' };
 
 describe('ChatMessage', () => {
-  it('displays player name and icon', async () => {
-    fetchJSONCached.mockResolvedValue(sample);
-    render(<ChatMessage message={{ userId: 'AAA', content: 'hi' }} />);
-    await waitFor(() => expect(fetchJSONCached).toHaveBeenCalled());
+  it('displays player name and icon', () => {
+    render(<ChatMessage message={{ content: 'hi' }} info={sample} />);
     expect(screen.getByText('Alice')).toBeInTheDocument();
-    expect(screen.getByAltText('league')).toHaveAttribute('src', sample.leagueIcon);
+    expect(screen.getByAltText('league')).toHaveAttribute('src', sample.icon);
   });
 });

--- a/front-end/src/components/ChatPanel.test.jsx
+++ b/front-end/src/components/ChatPanel.test.jsx
@@ -5,7 +5,7 @@ import { vi } from 'vitest';
 vi.mock('../hooks/useChat.js', () => ({
   default: () => ({ messages: [] }),
 }));
-vi.mock('../lib/api.js', () => ({ fetchJSON: vi.fn() }));
+vi.mock('../lib/api.js', () => ({ fetchJSON: vi.fn(), fetchJSONCached: vi.fn() }));
 
 import ChatPanel from './ChatPanel.jsx';
 


### PR DESCRIPTION
## Summary
- load player info for chat messages via IndexedDB cache
- hide messages until their player data is ready
- show loading indicator while fetching player data
- align chat bubbles left/right based on sender
- update tests

## Testing
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687c852f9a1c832cb5fa4f80ea91fec3