### PR TITLE
Fix mobile UI layout quirks

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -226,6 +226,7 @@ export default function App() {
                   onClick={() => {
                     window.google?.accounts.id.disableAutoSelect();
                     localStorage.removeItem('token');
+                    window.location.hash = '#/';
                     setToken(null);
                     setPlayerTag(null);
                     setClanTag(null);
@@ -241,7 +242,7 @@ export default function App() {
       </header>
       <DesktopNav clanIcon={clanInfo?.badgeUrls?.small} />
       <main className="px-2 pt-0 pb-2 sm:px-4 sm:pt-0 sm:pb-4">
-        {loadingUser && <Loading className="h-[calc(100vh-4rem)]" />}
+        {loadingUser && <Loading className="h-[calc(100dvh-4rem)]" />}
         {!loadingUser && !playerTag && (
           <PlayerTagForm
             onSaved={(tag) => {

--- a/front-end/src/components/PlayerTagForm.jsx
+++ b/front-end/src/components/PlayerTagForm.jsx
@@ -28,7 +28,7 @@ export default function PlayerTagForm({ onSaved }) {
   };
 
   return (
-    <div className="flex justify-center items-center h-[calc(100vh-4rem)]">
+    <div className="flex justify-center items-center h-[calc(100dvh-4rem)]">
       <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow space-y-4 w-full max-w-sm">
         <p className="font-medium text-slate-700">Enter your player tag</p>
         <input

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -1,7 +1,7 @@
 #root {
     padding: 0 0.5rem 4rem;
     background: linear-gradient(to bottom right, #f1f5f9, #e2e8f0);
-    min-height: 100vh;
+    min-height: 100dvh;
 }
 
 body {

--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -140,6 +140,7 @@ export default function Account({ onVerified }) {
         onClick={() => {
           window.google?.accounts.id.disableAutoSelect();
           localStorage.removeItem('token');
+          window.location.hash = '#/';
           window.location.reload();
         }}
         className="px-4 py-2 rounded bg-red-600 text-white w-full"

--- a/front-end/src/pages/ChatPage.jsx
+++ b/front-end/src/pages/ChatPage.jsx
@@ -5,7 +5,7 @@ const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
 
 export default function ChatPage({ verified, groupId, userId }) {
   return (
-    <div className="h-[calc(100vh-8rem)] sm:h-[calc(100vh-4rem)] flex flex-col overflow-hidden">
+    <div className="h-[calc(100dvh-8rem)] sm:h-[calc(100dvh-4rem)] flex flex-col overflow-hidden">
       <Suspense fallback={<Loading className="py-20" />}>
         {verified ? (
           <ChatPanel groupId={groupId} userId={userId} />

--- a/front-end/src/pages/Login.jsx
+++ b/front-end/src/pages/Login.jsx
@@ -8,6 +8,7 @@ export default function Login() {
         client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
         callback: (res) => {
           localStorage.setItem('token', res.credential);
+          window.location.hash = '#/';
           window.location.reload();
         },
       });
@@ -28,7 +29,7 @@ export default function Login() {
   }, []);
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-[100dvh] flex flex-col">
       <header className="banner bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 text-center shadow-md">
         <h1 className="text-lg font-semibold">Clan Dashboard</h1>
       </header>


### PR DESCRIPTION
## Summary
- stabilize viewport heights by using `100dvh`
- ensure login and logout always return to home
- keep sticky tabs in chat/community pages

## Testing
- `nox -s lint tests`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c8bc62168832cb4c903017b108f60