### PR TITLE
Fix account UX and banner height

### DIFF
--- a/front-end/index.html
+++ b/front-end/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="google-signin-client_id" content="%VITE_GOOGLE_CLIENT_ID%" />
-    <meta name="theme-color" content="#1e3a8a" />
+    <meta name="theme-color" content="#2563eb" />
     <title>Clan Dashboard</title>
     <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -174,7 +174,7 @@ export default function App() {
   useEffect(() => {
     const meta = document.querySelector('meta[name="theme-color"]');
     if (meta) {
-      meta.setAttribute('content', '#1e3a8a');
+      meta.setAttribute('content', '#2563eb');
     }
   }, []);
 

--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -53,56 +53,70 @@ export default function Account({ onVerified }) {
   if (!profile) return <Loading className="py-20" />;
 
   return (
-    <form className="max-w-md mx-auto space-y-4" onSubmit={handleSubmit}>
+    <form className="max-w-md mx-auto space-y-6 pt-4" onSubmit={handleSubmit}>
       <h3 className="text-xl font-semibold flex items-center gap-2">
         Profile
         {profile.verified && <VerifiedBadge />}
         {chatEnabled && <ChatBadge />}
       </h3>
-      <label className="block">
-        <span className="text-sm">War Weight</span>
-        <input
-          type="number"
-          step="0.01"
-          value={profile.risk_weight_war ?? 0}
-          onChange={(e) => handleChange('risk_weight_war', parseFloat(e.target.value))}
-          className="mt-1 w-full border px-2 py-1 rounded"
-        />
-      </label>
-      <label className="block">
-        <span className="text-sm">Idle Weight</span>
-        <input
-          type="number"
-          step="0.01"
-          value={profile.risk_weight_idle ?? 0}
-          onChange={(e) => handleChange('risk_weight_idle', parseFloat(e.target.value))}
-          className="mt-1 w-full border px-2 py-1 rounded"
-        />
-      </label>
-      <label className="block">
-        <span className="text-sm">Deficit Weight</span>
-        <input
-          type="number"
-          step="0.01"
-          value={profile.risk_weight_don_deficit ?? 0}
-          onChange={(e) => handleChange('risk_weight_don_deficit', parseFloat(e.target.value))}
-          className="mt-1 w-full border px-2 py-1 rounded"
-        />
-      </label>
-      <label className="block">
-        <span className="text-sm">Drop Weight</span>
-        <input
-          type="number"
-          step="0.01"
-          value={profile.risk_weight_don_drop ?? 0}
-          onChange={(e) => handleChange('risk_weight_don_drop', parseFloat(e.target.value))}
-          className="mt-1 w-full border px-2 py-1 rounded"
-        />
-      </label>
-      <label className="inline-flex items-center gap-2">
-        <input type="checkbox" checked={chatEnabled} onChange={(e) => setChatEnabled(e.target.checked)} />
-        <span className="text-sm">Enable Chat</span>
-      </label>
+      <div className="space-y-4">
+        <h4 className="text-lg font-medium">Risk Weights</h4>
+        <label className="block">
+          <span className="text-sm">War Weight: {profile.risk_weight_war ?? 0}</span>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            value={profile.risk_weight_war ?? 0}
+            onChange={(e) => handleChange('risk_weight_war', parseFloat(e.target.value))}
+            className="mt-1 w-full"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm">Idle Weight: {profile.risk_weight_idle ?? 0}</span>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            value={profile.risk_weight_idle ?? 0}
+            onChange={(e) => handleChange('risk_weight_idle', parseFloat(e.target.value))}
+            className="mt-1 w-full"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm">Deficit Weight: {profile.risk_weight_don_deficit ?? 0}</span>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            value={profile.risk_weight_don_deficit ?? 0}
+            onChange={(e) => handleChange('risk_weight_don_deficit', parseFloat(e.target.value))}
+            className="mt-1 w-full"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm">Drop Weight: {profile.risk_weight_don_drop ?? 0}</span>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            value={profile.risk_weight_don_drop ?? 0}
+            onChange={(e) => handleChange('risk_weight_don_drop', parseFloat(e.target.value))}
+            className="mt-1 w-full"
+          />
+        </label>
+      </div>
+      <div className="space-y-2">
+        <h4 className="text-lg font-medium">Features</h4>
+        <label className="inline-flex items-center gap-2">
+          <input type="checkbox" checked={chatEnabled} onChange={(e) => setChatEnabled(e.target.checked)} />
+          <span className="text-sm">Enable Chat</span>
+        </label>
+      </div>
       {!profile.verified && (
         <>
           <label className="block">

--- a/front-end/src/pages/ChatPage.jsx
+++ b/front-end/src/pages/ChatPage.jsx
@@ -5,7 +5,7 @@ const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
 
 export default function ChatPage({ verified, groupId, userId }) {
   return (
-    <div className="h-[calc(100dvh-8rem)] sm:h-[calc(100dvh-4rem)] flex flex-col overflow-hidden">
+    <div className="h-[calc(100dvh-4rem)] flex flex-col overflow-hidden">
       <Suspense fallback={<Loading className="py-20" />}>
         {verified ? (
           <ChatPanel groupId={groupId} userId={userId} />

--- a/front-end/src/pages/Community.jsx
+++ b/front-end/src/pages/Community.jsx
@@ -8,7 +8,7 @@ export default function Community({ verified, groupId, userId, defaultClanTag })
   const [tab, setTab] = useState('scouting');
 
   return (
-    <div className="h-[calc(100dvh-8rem)] sm:h-[calc(100dvh-4rem)] flex flex-col overflow-hidden">
+    <div className="h-[calc(100dvh-4rem)] flex flex-col overflow-hidden">
       <Tabs
         tabs={[
           { label: 'Scouting', value: 'scouting' },


### PR DESCRIPTION
## Summary
- adjust Chat and Community page heights
- revamp account page preferences with sliders
- clarify feature flag settings on account page
- give account form breathing room
- match PWA theme color with banner

## Testing
- `ruff check back-end sync coclib db`
- `npm install`
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687c91a0b93c832cb462e4772d6466d0