### PR TITLE
Fix mobile layout issues

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -189,7 +189,10 @@ export default function App() {
   return (
     <Router>
       <header className="banner bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 flex items-center justify-between shadow-md sticky top-0 z-50">
-        <h1 className="flex flex-col leading-tight" onClick={() => setShowClanInfo(true)}>
+        <h1
+          className="flex flex-row items-center gap-1 sm:flex-col sm:items-start sm:gap-0 sm:order-first order-last text-right"
+          onClick={() => setShowClanInfo(true)}
+        >
           <span className="text-lg font-semibold">Clan Boards</span>
           <span className="text-sm hover:underline">{clanInfo?.name || 'Clan Dashboard'}</span>
         </h1>

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -74,7 +74,7 @@ export default function ChatPanel({ groupId = '1', userId = '' }) {
   };
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full overflow-hidden">
       <div className="flex border-b sticky top-0 bg-white z-10">
         {['Clan', 'Friends', 'All'].map((t) => (
           <button
@@ -88,7 +88,7 @@ export default function ChatPanel({ groupId = '1', userId = '' }) {
       </div>
       {tab === 'Clan' ? (
         <>
-          <div className="flex-1 overflow-y-auto space-y-2 p-4">
+          <div className="flex-1 overflow-y-auto min-h-0 space-y-2 p-4">
             {loading ? (
               <div className="py-20">
                 <Loading />

--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -10,6 +10,7 @@ export default function Account({ onVerified }) {
   const [saving, setSaving] = useState(false);
   const [token, setToken] = useState('');
   const [chatEnabled, setChatEnabled] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
 
   const totalWeight =
     (profile?.risk_weight_war || 0) +
@@ -69,11 +70,19 @@ export default function Account({ onVerified }) {
       <div className="space-y-4">
         <h4 className="text-lg font-medium flex items-center gap-1">
           Risk Weights
-          <Info
-            className="w-4 h-4 text-slate-200"
-            title="Adjust how each factor influences the Risk tab"
-          />
+          <button
+            type="button"
+            onClick={() => setShowInfo((v) => !v)}
+            className="p-1"
+          >
+            <Info className="w-4 h-4 text-slate-600" />
+          </button>
         </h4>
+        {showInfo && (
+          <p className="text-xs text-slate-600">
+            Adjust how each factor influences the Risk tab
+          </p>
+        )}
         <label className="block">
           <span className="text-sm">War Weight: {Math.round((profile.risk_weight_war ?? 0) * 100)}%</span>
           <input

--- a/front-end/src/pages/ChatPage.jsx
+++ b/front-end/src/pages/ChatPage.jsx
@@ -5,7 +5,7 @@ const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
 
 export default function ChatPage({ verified, groupId, userId }) {
   return (
-    <div className="h-[calc(100dvh-4rem)] flex flex-col">
+    <div className="h-[calc(100dvh-4rem)] flex flex-col overflow-hidden">
       <Suspense fallback={<Loading className="py-20" />}>
         {verified ? (
           <ChatPanel groupId={groupId} userId={userId} />


### PR DESCRIPTION
## Summary
- keep tabs visible and messages scrollable on chat page
- adjust banner layout on mobile
- make info icon usable

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687c99e2b018832c8d6d9c259821dcb2