### PR TITLE
Enable paginated chat history

### DIFF
--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -5,7 +5,7 @@ import ChatMessage from './ChatMessage.jsx';
 import Loading from './Loading.jsx';
 
 export default function ChatPanel({ groupId = '1', userId = '' }) {
-  const { messages } = useChat(groupId);
+  const { messages, loadMore, hasMore } = useChat(groupId);
   const [text, setText] = useState('');
   const [sending, setSending] = useState(false);
   const [tab, setTab] = useState('Clan');
@@ -89,6 +89,14 @@ export default function ChatPanel({ groupId = '1', userId = '' }) {
       {tab === 'Clan' ? (
         <>
           <div className="flex-1 overflow-y-auto min-h-0 space-y-2 p-4">
+            {hasMore && !loading && (
+              <button
+                onClick={loadMore}
+                className="block mx-auto mb-2 text-sm text-blue-600 underline"
+              >
+                Load earlier messages
+              </button>
+            )}
             {loading ? (
               <div className="py-20">
                 <Loading />

--- a/front-end/src/components/ChatPanel.test.jsx
+++ b/front-end/src/components/ChatPanel.test.jsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
 vi.mock('../hooks/useChat.js', () => ({
-  default: () => ({ messages: [] }),
+  default: () => ({ messages: [], loadMore: vi.fn(), hasMore: false }),
 }));
 vi.mock('../lib/api.js', () => ({ fetchJSON: vi.fn(), fetchJSONCached: vi.fn() }));
 

--- a/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -35,8 +36,13 @@ public class ChatController {
     @GetMapping("/history/{groupId}")
     public ResponseEntity<List<Map<String, String>>> history(
             @PathVariable String groupId,
-            @RequestParam(defaultValue = "100") int limit) {
-        List<ChatMessage> msgs = chatService.history(groupId, Math.min(limit, 100));
+            @RequestParam(defaultValue = "20") int limit,
+            @RequestParam(required = false) String before) {
+        List<ChatMessage> msgs = chatService.history(
+                groupId,
+                Math.min(limit, 100),
+                before != null ? Instant.parse(before) : null
+        );
         List<Map<String, String>> body = msgs.stream()
                 .map(m -> Map.of(
                         "userId", m.userId(),

--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -43,11 +43,22 @@ public class ChatService {
     }
 
     public List<ChatMessage> history(String groupId, int limit) {
+        return history(groupId, limit, null);
+    }
+
+    public List<ChatMessage> history(String groupId, int limit, Instant before) {
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":c", AttributeValue.fromS(groupId));
+        String expr = "channel = :c";
+        if (before != null) {
+            expr += " and ts < :b";
+            values.put(":b", AttributeValue.fromS(before.toString()));
+        }
+
         QueryRequest req = QueryRequest.builder()
                 .tableName(tableName)
-                .keyConditionExpression("channel = :c")
-                .expressionAttributeValues(Map.of(
-                        ":c", AttributeValue.fromS(groupId)))
+                .keyConditionExpression(expr)
+                .expressionAttributeValues(values)
                 .limit(limit)
                 .scanIndexForward(false)
                 .build();

--- a/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
@@ -45,7 +45,8 @@ class ChatControllerTest {
     void historyReturnsMessages() throws Exception {
         Instant ts = Instant.parse("2024-01-01T00:00:00Z");
         List<ChatMessage> msgs = List.of(new ChatMessage("1", "0", "hi", ts));
-        Mockito.when(chatService.history("1", 2)).thenReturn(msgs);
+        Mockito.when(chatService.history(Mockito.eq("1"), Mockito.eq(2), Mockito.isNull()))
+                .thenReturn(msgs);
 
         mvc.perform(get("/api/v1/chat/history/1?limit=2"))
                 .andExpect(status().isOk())

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -31,7 +31,7 @@ class ChatServiceTest {
         QueryResponse resp = QueryResponse.builder().items(List.of(item)).build();
         Mockito.when(dynamoDb.query(Mockito.any(QueryRequest.class))).thenReturn(resp);
 
-        List<ChatMessage> msgs = service.history("1", 1);
+        List<ChatMessage> msgs = service.history("1", 1, null);
         Instant expected = LocalDateTime.parse(ts).toInstant(ZoneOffset.UTC);
         assertEquals(1, msgs.size());
         assertEquals(expected, msgs.get(0).ts());
@@ -56,7 +56,7 @@ class ChatServiceTest {
         QueryResponse resp = QueryResponse.builder().items(List.of(item2, item1)).build();
         Mockito.when(dynamoDb.query(Mockito.any(QueryRequest.class))).thenReturn(resp);
 
-        List<ChatMessage> msgs = service.history("1", 2);
+        List<ChatMessage> msgs = service.history("1", 2, null);
         assertEquals(2, msgs.size());
         assertEquals("first", msgs.get(0).content());
         assertEquals("second", msgs.get(1).content());


### PR DESCRIPTION
## Summary
- add optional `before` param to ChatService
- update ChatController to expose cursor-based history
- adjust tests for new pagination signature
- load chat history in pages on the front-end
- add Load earlier messages button

## Testing
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687c9c8596f0832caaff79bd516cb34f