### PR TITLE
Fix mobile chat layout

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { Suspense, lazy, useEffect, useState } from 'react';
 import { HashRouter as Router, Routes, Route, Navigate, Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
+import CachedImage from './components/CachedImage.jsx';
 import Loading from './components/Loading.jsx';
 import PlayerTagForm from './components/PlayerTagForm.jsx';
 import { fetchJSON } from './lib/api.js';
@@ -194,10 +195,18 @@ export default function App() {
           onClick={() => setShowClanInfo(true)}
         >
           <span className="text-lg font-semibold">Clan Boards</span>
-          <span className="text-sm hover:underline hidden sm:block">{clanInfo?.name || 'Clan Dashboard'}</span>
+          <span className="flex items-center gap-1 text-sm hover:underline hidden sm:flex">
+            {clanInfo?.badgeUrls?.small && (
+              <CachedImage src={clanInfo.badgeUrls.small} alt="clan" className="w-4 h-4" />
+            )}
+            {clanInfo?.name || 'Clan Dashboard'}
+          </span>
         </h1>
         <div className="flex items-center gap-3">
-          <span className="text-sm hover:underline sm:hidden" onClick={() => setShowClanInfo(true)}>
+          <span className="flex items-center gap-1 text-sm hover:underline sm:hidden" onClick={() => setShowClanInfo(true)}>
+            {clanInfo?.badgeUrls?.small && (
+              <CachedImage src={clanInfo.badgeUrls.small} alt="clan" className="w-4 h-4" />
+            )}
             {clanInfo?.name || 'Clan Dashboard'}
           </span>
           {homeClanTag && clanTag !== homeClanTag && (

--- a/front-end/src/components/BottomNav.jsx
+++ b/front-end/src/components/BottomNav.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { Shield, MessageCircle, Users, User } from 'lucide-react';
-import CachedImage from './CachedImage.jsx';
+import { Home, MessageCircle, Users, User } from 'lucide-react';
 
 export default function BottomNav({ clanIcon }) {
   const items = [
-    { to: '/', label: 'Home', icon: Shield },
+    { to: '/', label: 'Home', icon: Home },
     { to: '/chat', label: 'Chat', icon: MessageCircle },
     { to: '/community', label: 'Community', icon: Users },
     { to: '/account', label: 'Account', icon: User },
@@ -22,11 +21,7 @@ export default function BottomNav({ clanIcon }) {
             `flex-1 py-2 text-center flex flex-col items-center ${isActive ? 'text-blue-600' : 'text-slate-600'}`
           }
         >
-          {item.to === '/' && clanIcon ? (
-            <CachedImage src={clanIcon} alt="clan" className="w-5 h-5" />
-          ) : (
-            React.createElement(item.icon, { className: 'w-5 h-5' })
-          )}
+          {React.createElement(item.icon, { className: 'w-5 h-5' })}
           <span className="text-xs mt-1">{item.label}</span>
         </NavLink>
       ))}

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -74,7 +74,7 @@ export default function ChatPanel({ groupId = '1', userId = '' }) {
   };
 
   return (
-    <div className="flex flex-col h-full overflow-hidden">
+    <div className="flex flex-col h-full">
       <div className="flex border-b sticky top-0 bg-white z-10">
         {['Clan', 'Friends', 'All'].map((t) => (
           <button
@@ -88,7 +88,7 @@ export default function ChatPanel({ groupId = '1', userId = '' }) {
       </div>
       {tab === 'Clan' ? (
         <>
-          <div className="flex-1 overflow-y-auto min-h-0 space-y-2 p-4">
+          <div className="flex-1 overflow-y-auto min-h-0 space-y-2 p-4 pt-4">
             {hasMore && !loading && (
               <button
                 onClick={loadMore}

--- a/front-end/src/pages/ChatPage.jsx
+++ b/front-end/src/pages/ChatPage.jsx
@@ -5,7 +5,7 @@ const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
 
 export default function ChatPage({ verified, groupId, userId }) {
   return (
-    <div className="h-[calc(100dvh-4rem)] flex flex-col overflow-hidden">
+    <div className="h-[calc(100dvh-4rem)] flex flex-col overflow-y-auto">
       <Suspense fallback={<Loading className="py-20" />}>
         {verified ? (
           <ChatPanel groupId={groupId} userId={userId} />


### PR DESCRIPTION
## Summary
- adjust banner to show clan badge next to clan name
- use home icon in mobile bottom nav
- improve ChatPage scroll behavior on mobile
- add spacing for load earlier messages button

## Testing
- `npm --prefix front-end install`
- `npm --prefix front-end test`
- `npm --prefix front-end run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687ca494c114832c8dc9fcb6215500bd