### PR TITLE
Fix overscroll artifact in mobile pages

### DIFF
--- a/front-end/src/pages/ChatPage.jsx
+++ b/front-end/src/pages/ChatPage.jsx
@@ -5,7 +5,7 @@ const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
 
 export default function ChatPage({ verified, groupId, userId }) {
   return (
-    <div className="h-[calc(100dvh-4rem)] flex flex-col overflow-y-auto">
+    <div className="h-[calc(100dvh-4rem)] flex flex-col overflow-y-auto overscroll-y-contain">
       <Suspense fallback={<Loading className="py-20" />}>
         {verified ? (
           <ChatPanel groupId={groupId} userId={userId} />

--- a/front-end/src/pages/Community.jsx
+++ b/front-end/src/pages/Community.jsx
@@ -8,7 +8,7 @@ export default function Community({ verified, groupId, userId, defaultClanTag })
   const [tab, setTab] = useState('scouting');
 
   return (
-    <div className="h-[calc(100dvh-4rem)] flex flex-col overflow-hidden">
+    <div className="h-[calc(100dvh-4rem)] flex flex-col overflow-hidden overscroll-y-contain">
       <Tabs
         tabs={[
           { label: 'Scouting', value: 'scouting' },


### PR DESCRIPTION
## Summary
- add `overscroll-y-contain` to ChatPage and Community

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687d062de484832c827720db603ba498