### PR TITLE
Fix member list mobile spacing

### DIFF
--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -55,7 +55,7 @@ function Row({ index, style, data }) {
       </div>
       {open && (
         <div className="pb-2">
-          <PlayerSummary tag={m.tag} />
+          <PlayerSummary tag={m.tag} showHeader={false} scrollBadges={false} />
         </div>
       )}
     </div>
@@ -68,8 +68,8 @@ export default function MemberAccordionList({ members, height, refreshing = fals
   const getSize = (index) => {
     const base = 56;
     if (openIndex !== index) return base;
-    // Expanded summary content is roughly 360px tall
-    return base + 360;
+    // Expanded summary content is roughly 300px tall
+    return base + 300;
   };
 
   return (

--- a/front-end/src/components/PlayerSummary.jsx
+++ b/front-end/src/components/PlayerSummary.jsx
@@ -8,7 +8,7 @@ import DonationRing from './DonationRing.jsx';
 import PresenceDot from './PresenceDot.jsx';
 import LoyaltyBadge from './LoyaltyBadge.jsx';
 
-export default function PlayerSummary({ tag }) {
+export default function PlayerSummary({ tag, showHeader = true, scrollBadges = true }) {
   const [player, setPlayer] = useState(null);
   const [error, setError] = useState('');
 
@@ -30,14 +30,20 @@ export default function PlayerSummary({ tag }) {
 
   return (
     <>
-      <h3 className="text-lg font-semibold text-slate-800 flex flex-wrap items-center gap-2">
-        {player.leagueIcon && (
-          <CachedImage src={player.leagueIcon} alt="league" className="w-6 h-6" />
-        )}
-        <span>{player.name}</span>
-        <span className="text-sm font-normal text-slate-500">{player.tag}</span>
-      </h3>
-      <div className="flex flex-nowrap overflow-x-auto gap-4 mt-4 justify-center scroller">
+      {showHeader && (
+        <h3 className="text-lg font-semibold text-slate-800 flex flex-wrap items-center gap-2">
+          {player.leagueIcon && (
+            <CachedImage src={player.leagueIcon} alt="league" className="w-6 h-6" />
+          )}
+          <span>{player.name}</span>
+          <span className="text-sm font-normal text-slate-500">{player.tag}</span>
+        </h3>
+      )}
+      <div
+        className={`flex gap-4 mt-4 justify-center ${
+          scrollBadges ? 'flex-nowrap overflow-x-auto scroller' : 'flex-wrap'
+        }`}
+      >
         <div className="flex flex-col items-center w-16">
           <img
             src={getTownHallIcon(player.townHallLevel)}

--- a/front-end/src/components/PlayerSummary.test.jsx
+++ b/front-end/src/components/PlayerSummary.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('../lib/api.js', () => ({
+  fetchJSONCached: vi.fn(),
+  API_URL: '',
+}));
+
+import PlayerSummary from './PlayerSummary.jsx';
+import { fetchJSONCached } from '../lib/api.js';
+
+const samplePlayer = {
+  name: 'Alice',
+  tag: '#AAA',
+  townHallLevel: 12,
+  trophies: 3200,
+  labels: [
+    { id: 1, name: 'Veteran', iconUrls: { small: 'http://example.com/vet.png' } },
+  ],
+  donations: 0,
+  donationsReceived: 0,
+  risk_score: 10,
+  last_seen: '2024-01-01T00:00:00Z',
+  loyalty: 5,
+};
+
+describe('PlayerSummary', () => {
+  it('omits header when disabled and wraps badges', async () => {
+    fetchJSONCached.mockResolvedValue(samplePlayer);
+    render(<PlayerSummary tag="AAA" showHeader={false} scrollBadges={false} />);
+    await waitFor(() => expect(fetchJSONCached).toHaveBeenCalled());
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+    const row = screen.getByText('TH12').parentElement.parentElement;
+    expect(row).toHaveClass('flex-wrap');
+    expect(row).not.toHaveClass('overflow-x-auto');
+  });
+});


### PR DESCRIPTION
## Summary
- tweak accordion to hide header and wrap badges
- adjust expanded row height for consistent spacing
- support compact mode in `PlayerSummary`
- add test for new PlayerSummary options

## Testing
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d17f36c34832cb1087b77b54b85e7