### PR TITLE
Add risk priority presets

### DIFF
--- a/front-end/src/components/ProfileModal.jsx
+++ b/front-end/src/components/ProfileModal.jsx
@@ -4,6 +4,7 @@ import { fetchJSON } from '../lib/api.js';
 import Loading from './Loading.jsx';
 import VerifiedBadge from './VerifiedBadge.jsx';
 import ChatBadge from './ChatBadge.jsx';
+import RiskPrioritySelect, { PRESETS } from './RiskPrioritySelect.jsx';
 
 export default function ProfileModal({ onClose, onVerified }) {
   const [profile, setProfile] = useState(null);
@@ -11,11 +12,7 @@ export default function ProfileModal({ onClose, onVerified }) {
   const [token, setToken] = useState('');
   const [chatEnabled, setChatEnabled] = useState(false);
 
-  const totalWeight =
-    (profile?.risk_weight_war || 0) +
-    (profile?.risk_weight_idle || 0) +
-    (profile?.risk_weight_don_deficit || 0) +
-    (profile?.risk_weight_don_drop || 0);
+
 
   useEffect(() => {
     const load = async () => {
@@ -75,65 +72,18 @@ export default function ProfileModal({ onClose, onVerified }) {
             {chatEnabled && <ChatBadge />}
           </h3>
           <h4 className="text-lg font-medium flex items-center gap-1">
-            Risk Weights
+            Risk Priority
             <Info
               className="w-4 h-4 text-slate-500"
-              title="Adjust how each factor influences the Risk tab"
+              title="Choose a preset to adjust how members are ranked by risk"
             />
           </h4>
-          <label className="block">
-            <span className="text-sm">War Weight</span>
-            <input
-              type="number"
-              step="1"
-              min="0"
-              max="100"
-              value={Math.round((profile.risk_weight_war ?? 0) * 100)}
-              onChange={(e) => handleChange('risk_weight_war', parseFloat(e.target.value) / 100)}
-              className="mt-1 w-full border px-2 py-1 rounded"
-            />
-          </label>
-          <label className="block">
-            <span className="text-sm">Idle Weight</span>
-            <input
-              type="number"
-              step="1"
-              min="0"
-              max="100"
-              value={Math.round((profile.risk_weight_idle ?? 0) * 100)}
-              onChange={(e) => handleChange('risk_weight_idle', parseFloat(e.target.value) / 100)}
-              className="mt-1 w-full border px-2 py-1 rounded"
-            />
-          </label>
-          <label className="block">
-            <span className="text-sm">Deficit Weight</span>
-            <input
-              type="number"
-              step="1"
-              min="0"
-              max="100"
-              value={Math.round((profile.risk_weight_don_deficit ?? 0) * 100)}
-              onChange={(e) => handleChange('risk_weight_don_deficit', parseFloat(e.target.value) / 100)}
-              className="mt-1 w-full border px-2 py-1 rounded"
-            />
-          </label>
-          <label className="block">
-            <span className="text-sm">Drop Weight</span>
-          <input
-            type="number"
-            step="1"
-            min="0"
-            max="100"
-            value={Math.round((profile.risk_weight_don_drop ?? 0) * 100)}
-            onChange={(e) => handleChange('risk_weight_don_drop', parseFloat(e.target.value) / 100)}
-            className="mt-1 w-full border px-2 py-1 rounded"
+          <RiskPrioritySelect
+            weights={profile}
+            onSelect={(w) => {
+              Object.entries(w).forEach(([k, v]) => handleChange(k, v));
+            }}
           />
-        </label>
-        {Math.round(totalWeight * 100) !== 100 && (
-          <div className="text-red-500 text-sm" role="alert">
-            Weights should total 100%
-          </div>
-        )}
           <label className="inline-flex items-center gap-2">
             <input type="checkbox" checked={chatEnabled} onChange={(e) => setChatEnabled(e.target.checked)} />
             <span className="text-sm">Enable Chat</span>

--- a/front-end/src/components/RiskPrioritySelect.jsx
+++ b/front-end/src/components/RiskPrioritySelect.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+export const PRESETS = {
+  balanced: {
+    label: 'Balanced',
+    weights: {
+      risk_weight_war: 0.4,
+      risk_weight_idle: 0.35,
+      risk_weight_don_deficit: 0.15,
+      risk_weight_don_drop: 0.1,
+    },
+  },
+  war: {
+    label: 'War Focused',
+    weights: {
+      risk_weight_war: 0.6,
+      risk_weight_idle: 0.25,
+      risk_weight_don_deficit: 0.1,
+      risk_weight_don_drop: 0.05,
+    },
+  },
+  donor: {
+    label: 'Donation Focused',
+    weights: {
+      risk_weight_war: 0.3,
+      risk_weight_idle: 0.25,
+      risk_weight_don_deficit: 0.35,
+      risk_weight_don_drop: 0.1,
+    },
+  },
+  idle: {
+    label: 'Idle Focused',
+    weights: {
+      risk_weight_war: 0.2,
+      risk_weight_idle: 0.6,
+      risk_weight_don_deficit: 0.1,
+      risk_weight_don_drop: 0.1,
+    },
+  },
+};
+
+export function getPreset(weights) {
+  for (const [key, preset] of Object.entries(PRESETS)) {
+    const w = preset.weights;
+    if (
+      Math.abs(w.risk_weight_war - weights.risk_weight_war) < 0.01 &&
+      Math.abs(w.risk_weight_idle - weights.risk_weight_idle) < 0.01 &&
+      Math.abs(w.risk_weight_don_deficit - weights.risk_weight_don_deficit) < 0.01 &&
+      Math.abs(w.risk_weight_don_drop - weights.risk_weight_don_drop) < 0.01
+    ) {
+      return key;
+    }
+  }
+  return 'balanced';
+}
+
+export default function RiskPrioritySelect({ weights, onSelect }) {
+  const preset = getPreset(weights);
+  return (
+    <label className="block">
+      <span className="text-sm">Risk Priority</span>
+      <select
+        className="mt-1 w-full border px-2 py-1 rounded"
+        value={preset}
+        onChange={(e) => onSelect(PRESETS[e.target.value].weights)}
+      >
+        {Object.entries(PRESETS).map(([key, p]) => (
+          <option key={key} value={key}>
+            {p.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/front-end/src/components/RiskPrioritySelect.test.jsx
+++ b/front-end/src/components/RiskPrioritySelect.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import RiskPrioritySelect, { PRESETS } from './RiskPrioritySelect.jsx';
+
+describe('RiskPrioritySelect', () => {
+  it('calls onSelect with weights for selected preset', () => {
+    const handler = vi.fn();
+    render(
+      <RiskPrioritySelect
+        weights={PRESETS.balanced.weights}
+        onSelect={handler}
+      />
+    );
+    fireEvent.change(screen.getByLabelText('Risk Priority'), {
+      target: { value: 'war' },
+    });
+    expect(handler).toHaveBeenCalledWith(PRESETS.war.weights);
+  });
+});

--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -4,6 +4,7 @@ import { fetchJSON } from '../lib/api.js';
 import Loading from '../components/Loading.jsx';
 import VerifiedBadge from '../components/VerifiedBadge.jsx';
 import ChatBadge from '../components/ChatBadge.jsx';
+import RiskPrioritySelect, { PRESETS } from '../components/RiskPrioritySelect.jsx';
 
 export default function Account({ onVerified }) {
   const [profile, setProfile] = useState(null);
@@ -12,11 +13,7 @@ export default function Account({ onVerified }) {
   const [chatEnabled, setChatEnabled] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
 
-  const totalWeight =
-    (profile?.risk_weight_war || 0) +
-    (profile?.risk_weight_idle || 0) +
-    (profile?.risk_weight_don_deficit || 0) +
-    (profile?.risk_weight_don_drop || 0);
+
 
   useEffect(() => {
     const load = async () => {
@@ -69,7 +66,7 @@ export default function Account({ onVerified }) {
       </h3>
       <div className="space-y-4">
         <h4 className="text-lg font-medium flex items-center gap-1">
-          Risk Weights
+          Risk Priority
           <button
             type="button"
             onClick={() => setShowInfo((v) => !v)}
@@ -80,62 +77,15 @@ export default function Account({ onVerified }) {
         </h4>
         {showInfo && (
           <p className="text-xs text-slate-600">
-            Adjust how each factor influences the Risk tab
+            Choose a preset to adjust how members are ranked by risk
           </p>
         )}
-        <label className="block">
-          <span className="text-sm">War Weight: {Math.round((profile.risk_weight_war ?? 0) * 100)}%</span>
-          <input
-            type="range"
-            min="0"
-            max="100"
-            step="1"
-            value={Math.round((profile.risk_weight_war ?? 0) * 100)}
-            onChange={(e) => handleChange('risk_weight_war', parseFloat(e.target.value) / 100)}
-            className="mt-1 w-full"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm">Idle Weight: {Math.round((profile.risk_weight_idle ?? 0) * 100)}%</span>
-          <input
-            type="range"
-            min="0"
-            max="100"
-            step="1"
-            value={Math.round((profile.risk_weight_idle ?? 0) * 100)}
-            onChange={(e) => handleChange('risk_weight_idle', parseFloat(e.target.value) / 100)}
-            className="mt-1 w-full"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm">Deficit Weight: {Math.round((profile.risk_weight_don_deficit ?? 0) * 100)}%</span>
-          <input
-            type="range"
-            min="0"
-            max="100"
-            step="1"
-            value={Math.round((profile.risk_weight_don_deficit ?? 0) * 100)}
-            onChange={(e) => handleChange('risk_weight_don_deficit', parseFloat(e.target.value) / 100)}
-            className="mt-1 w-full"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm">Drop Weight: {Math.round((profile.risk_weight_don_drop ?? 0) * 100)}%</span>
-          <input
-            type="range"
-            min="0"
-            max="100"
-            step="1"
-            value={Math.round((profile.risk_weight_don_drop ?? 0) * 100)}
-            onChange={(e) => handleChange('risk_weight_don_drop', parseFloat(e.target.value) / 100)}
-            className="mt-1 w-full"
-          />
-        </label>
-        {Math.round(totalWeight * 100) !== 100 && (
-          <div className="text-red-500 text-sm" role="alert">
-            Weights should total 100%
-          </div>
-        )}
+        <RiskPrioritySelect
+          weights={profile}
+          onSelect={(w) => {
+            Object.entries(w).forEach(([k, v]) => handleChange(k, v));
+          }}
+        />
       </div>
       <div className="space-y-2">
         <h4 className="text-lg font-medium">Features</h4>


### PR DESCRIPTION
## Summary
- add a `RiskPrioritySelect` component with default weight presets
- update Account page and Profile modal to use the new selector
- test selecting a preset

## Testing
- `npm install`
- `npm test`
- `npm run build`
- `ruff check back-end sync coclib db`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687d1fdfc5b4832c82aa39c22f580e9a