### PR TITLE
Fix member list crash

### DIFF
--- a/front-end/src/components/ErrorBoundary.jsx
+++ b/front-end/src/components/ErrorBoundary.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    if (this.props.onError) {
+      this.props.onError(error, info);
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback || null;
+    }
+    return this.props.children;
+  }
+}

--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -74,17 +74,17 @@ export default function MemberAccordionList({ members, height, refreshing = fals
   const [openIndex, setOpenIndex] = React.useState(null);
   const [sizes, setSizes] = React.useState(() => members.map(() => 56));
 
-  const setSize = (idx, size) =>
+  const setSize = React.useCallback((idx, size) => {
     setSizes((s) => {
+      if (s[idx] === size) return s;
       const next = [...s];
-      if (next[idx] !== size) {
-        next[idx] = size;
-        listRef.current?.resetAfterIndex(idx);
-      }
+      next[idx] = size;
+      listRef.current?.resetAfterIndex(idx);
       return next;
     });
+  }, []);
 
-  const getSize = (index) => sizes[index] || 56;
+  const getSize = React.useCallback((index) => sizes[index] || 56, [sizes]);
 
   React.useEffect(() => {
     setSizes(members.map(() => 56));

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -7,6 +7,7 @@ import MobileTabs from '../components/MobileTabs.jsx';
 import RiskRing from '../components/RiskRing.jsx';
 import DonationRing from '../components/DonationRing.jsx';
 import MemberAccordionList from '../components/MemberAccordionList.jsx';
+import ErrorBoundary from '../components/ErrorBoundary.jsx';
 import ProfileCard from '../components/ProfileCard.jsx';
 import { getTownHallIcon } from '../lib/townhall.js';
 import CachedImage from '../components/CachedImage.jsx';
@@ -318,6 +319,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                             </div>
                             <h2 className="text-xl font-semibold text-slate-700">All Members</h2>
                             <div className="overflow-x-auto shadow bg-white rounded">
+                                <ErrorBoundary fallback={<p className="p-4">Unable to display members.</p>}>
                                 <table className="mobile-table min-w-full text-xs sm:text-sm" id="membersTable">
                                     <thead className="bg-slate-50 text-left text-slate-600">
                                     <tr>
@@ -406,6 +408,7 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                     ))}
                                     </tbody>
                                 </table>
+                                </ErrorBoundary>
                             </div>
                         </>
                     ) : (
@@ -429,11 +432,13 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                             )}
                             {activeTab === 'all' && (
                                 <div className="bg-white rounded shadow" style={{ height: listHeight }}>
-                                    <MemberAccordionList
-                                        members={sortedMembers}
-                                        height={listHeight}
-                                        refreshing={refreshing && !loading}
-                                    />
+                                    <ErrorBoundary fallback={<p className="p-4">Unable to display members.</p>}>
+                                        <MemberAccordionList
+                                            members={sortedMembers}
+                                            height={listHeight}
+                                            refreshing={refreshing && !loading}
+                                        />
+                                    </ErrorBoundary>
                                 </div>
                             )}
                         </>


### PR DESCRIPTION
## Summary
- prevent infinite re-renders in MemberAccordionList by memoizing callbacks
- wrap member lists with error boundaries
- create reusable `ErrorBoundary` component

## Testing
- `npm --prefix front-end test`
- `npm --prefix front-end run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687d22880898832ca97f42ee6a1e3820