### PR TITLE
Fix mobile accordion details

### DIFF
--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -26,13 +26,28 @@ function Row({ index, style, data }) {
     }
   };
   useLayoutEffect(() => {
-    if (rowRef.current) {
-      setSize(index, rowRef.current.offsetHeight);
+    if (!rowRef.current) return;
+    const el = rowRef.current;
+    setSize(index, el.offsetHeight);
+    listRef.current?.scrollToItem(index);
+    let observer;
+    if (typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(() => {
+        setSize(index, el.offsetHeight);
+        listRef.current?.scrollToItem(index);
+      });
+      observer.observe(el);
     }
+    return () => observer?.disconnect();
   }, [open, index, setSize]);
 
   return (
-    <div ref={rowRef} style={{ ...style, overflow: 'hidden' }} className="relative border-b px-3" onClick={toggle}>
+    <div
+      ref={rowRef}
+      style={{ ...style, overflow: open ? 'visible' : 'hidden' }}
+      className="relative border-b px-3"
+      onClick={toggle}
+    >
       <div className="flex justify-between items-center py-2">
         <div className="flex flex-col">
           <div className="flex items-center gap-2">

--- a/front-end/src/components/MemberAccordionList.test.jsx
+++ b/front-end/src/components/MemberAccordionList.test.jsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('../lib/api.js', () => ({
+  fetchJSONCached: vi.fn(),
+  API_URL: '',
+}));
+
+import MemberAccordionList from './MemberAccordionList.jsx';
+import { fetchJSONCached } from '../lib/api.js';
+
+const samplePlayer = {
+  name: 'Alice',
+  tag: '#AAA',
+  townHallLevel: 12,
+  trophies: 3200,
+  labels: [
+    { id: 1, name: 'Veteran', iconUrls: { small: 'http://example.com/vet.png' } },
+  ],
+  donations: 0,
+  donationsReceived: 0,
+  risk_score: 10,
+  last_seen: '2024-01-01T00:00:00Z',
+  loyalty: 5,
+};
+
+const sampleMember = {
+  name: 'Alice',
+  tag: '#AAA',
+  townHallLevel: 12,
+  trophies: 3200,
+  role: 'Leader',
+  donations: 0,
+  donationsReceived: 0,
+  risk_score: 10,
+  last_seen: '2024-01-01T00:00:00Z',
+  loyalty: 5,
+};
+
+describe('MemberAccordionList', () => {
+  it('renders player summary when expanded', async () => {
+    fetchJSONCached.mockResolvedValue(samplePlayer);
+    render(<MemberAccordionList members={[sampleMember]} height={400} />);
+    screen.getByText('Alice').click();
+    await waitFor(() => expect(fetchJSONCached).toHaveBeenCalled());
+    expect(screen.getByText('Member Health')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- update MemberAccordionList rows to keep expanded content visible
- scroll rows into view when height changes

## Testing
- `npm test --silent`
- `npm run build --silent`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_687d284da708832c971586532df76492