### PR TITLE
Fix accordion overlap on members list

### DIFF
--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -28,17 +28,21 @@ function Row({ index, style, data }) {
   useLayoutEffect(() => {
     if (!rowRef.current) return;
     const el = rowRef.current;
-    setSize(index, el.scrollHeight);
-    listRef.current?.scrollToItem(index);
-    let observer;
+    const update = () => {
+      setSize(index, el.scrollHeight);
+      listRef.current?.scrollToItem(index);
+    };
+    update();
+    let cleanup = null;
     if (typeof ResizeObserver !== 'undefined') {
-      observer = new ResizeObserver(() => {
-        setSize(index, el.scrollHeight);
-        listRef.current?.scrollToItem(index);
-      });
+      const observer = new ResizeObserver(update);
       observer.observe(el);
+      cleanup = () => observer.disconnect();
+    } else {
+      const id = setInterval(update, 100);
+      cleanup = () => clearInterval(id);
     }
-    return () => observer?.disconnect();
+    return cleanup;
   }, [open, index, setSize]);
 
   return (


### PR DESCRIPTION
## Summary
- ensure member accordion rows resize properly even without ResizeObserver

## Testing
- `nox -s lint tests`
- `npm test --silent`
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_e_687d384c311c832c9d3b1459630ffcdc