### PR TITLE
Fix mobile profile overlap

### DIFF
--- a/front-end/src/components/MemberAccordionList.jsx
+++ b/front-end/src/components/MemberAccordionList.jsx
@@ -48,7 +48,11 @@ function Row({ index, style, data }) {
   return (
     <div
       ref={rowRef}
-      style={{ ...style, overflow: open ? 'visible' : 'hidden' }}
+      style={{
+        ...style,
+        overflow: open ? 'visible' : 'hidden',
+        zIndex: open ? 1 : "auto",
+      }}
       className="relative border-b px-3"
       onClick={toggle}
     >


### PR DESCRIPTION
## Summary
- keep MemberAccordionList rows above others when expanded

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687d416cc4d8832ca5b844a2519b9390