### PR TITLE
Fix chat toggle reset on verification

### DIFF
--- a/front-end/src/components/ProfileModal.jsx
+++ b/front-end/src/components/ProfileModal.jsx
@@ -35,6 +35,11 @@ export default function ProfileModal({ onClose, onVerified }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setSaving(true);
+    if (chatEnabled && !profile.verified) {
+      alert('You must verify your account to enable chat.');
+      setSaving(false);
+      return;
+    }
     try {
       await fetchJSON('/user/profile', {
         method: 'POST',
@@ -96,12 +101,21 @@ export default function ProfileModal({ onClose, onVerified }) {
               </label>
               <button type="button" onClick={async () => {
                 setSaving(true);
-                try {
+              try {
                   await fetchJSON('/user/verify', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ token }),
                   });
+                  await fetchJSON('/user/features', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                      features: chatEnabled ? ['chat'] : [],
+                      all: false,
+                    }),
+                  });
+                  window.dispatchEvent(new Event('features-updated'));
                   setProfile((p) => ({ ...p, verified: true }));
                   onVerified && onVerified();
                 } catch {

--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -36,6 +36,11 @@ export default function Account({ onVerified }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setSaving(true);
+    if (chatEnabled && !profile.verified) {
+      alert('You must verify your account to enable chat.');
+      setSaving(false);
+      return;
+    }
     try {
       await fetchJSON('/user/profile', {
         method: 'POST',
@@ -110,6 +115,15 @@ export default function Account({ onVerified }) {
                   headers: { 'Content-Type': 'application/json' },
                   body: JSON.stringify({ token }),
                 });
+                await fetchJSON('/user/features', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    features: chatEnabled ? ['chat'] : [],
+                    all: false,
+                  }),
+                });
+                window.dispatchEvent(new Event('features-updated'));
                 setProfile((p) => ({ ...p, verified: true }));
                 onVerified && onVerified();
               } catch {


### PR DESCRIPTION
## Summary
- update Account page to save feature flags when verifying
- update ProfileModal to persist chat toggle during verification
- alert user when enabling chat without verifying

## Testing
- `nox -s lint tests`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ecbebd0b8832c9b60181fc2a84cfd