### PR TITLE
Replace direct API calls with coc.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ Without the JavaScript origin entry Google will return a `redirect_uri_mismatch`
 
 Clan and player records are stored exactly as returned by the [Clash of Clans API](https://developer.clashofclans.com/#/documentation). Icon URLs such as clan badges and league emblems can be read directly from the JSON data in the database. See the official documentation for the object schema and available image sizes.
 
+This project now uses the [coc.py](https://cocpy.readthedocs.io/) client library for all Clash of Clans API access.
+

--- a/back-end/requirements.txt
+++ b/back-end/requirements.txt
@@ -20,7 +20,7 @@ h11==0.16.0
 h2==4.2.0
 hpack==4.1.0
 httpcore==1.0.9
-httpx==0.28.1
+coc.py==3.9.1
 hyperframe==6.1.0
 idna==3.10
 importlib_metadata==8.7.0

--- a/coclib/services/clan_service.py
+++ b/coclib/services/clan_service.py
@@ -18,7 +18,7 @@ STALE_AFTER = timedelta(seconds=int(os.getenv("SNAPSHOT_MAX_AGE", "600")))
 
 
 async def fetch_clan(tag: str) -> dict:
-    client = get_client()
+    client = await get_client()
     return await client.clan(tag)
 
 
@@ -78,7 +78,7 @@ async def get_clan(tag: str) -> dict:
         # Schedule a full get_player() to also write a snapshot
         member_tasks.append(get_player(member["tag"]))
     if member_tasks:
-        # Run them concurrently; httpx handles connection pooling.
+        # Run them concurrently; coc.py handles connection pooling.
         await gather(*member_tasks)
 
     db.session.commit()

--- a/coclib/services/coc_client.py
+++ b/coclib/services/coc_client.py
@@ -3,7 +3,8 @@ import logging
 from functools import wraps
 from datetime import datetime, timedelta
 import os
-import httpx
+
+import coc
 
 from coclib.utils import encode_tag
 
@@ -13,7 +14,6 @@ _last_reset = datetime.utcnow()
 _req_count = 0
 _lock = asyncio.Lock()
 
-COC_BASE = os.getenv("COC_BASE", "https://api.clashofclans.com/v1")
 COC_TOKEN = os.getenv("COC_API_TOKEN")
 COC_REQS_PER_DAY = int(os.getenv("COC_REQS_PER_DAY", "5000"))
 
@@ -35,69 +35,60 @@ def rate_limited(fn):
 
 
 class CoCClient:
-    def __init__(self, base: str, token: str):
-        self.base = base
-        self.headers = {"Authorization": f"Bearer {token}"}
+    def __init__(self, token: str):
+        self._client = coc.Client(raw_attribute=True)
+        self._login_task = asyncio.create_task(self._client.login_with_tokens(token))
 
-    async def request(self, method: str, path: str, **kwargs):
-        async with httpx.AsyncClient(
-            base_url=self.base,
-            headers=self.headers,
-            timeout=10,
-            http2=True,
-        ) as client:
-            resp = await client.request(method, path, **kwargs)
-
-            if resp.status_code in (403, 404) and method == "GET":
-                try:
-                    payload = resp.json()
-                    reason = payload.get("reason", "")
-                except ValueError:
-                    reason = ""
-                if resp.status_code == 403 and reason.startswith("accessDenied"):
-                    logger.warning("Access denied for %s: %s", path, reason)
-                    return {"state": "accessDenied"}
-                return {"state": "notInWar"}
-
-            resp.raise_for_status()
-            return resp.json()
-
-    async def get(self, path: str):
-        return await self.request("GET", path)
+    async def _ready(self) -> None:
+        if self._login_task is not None:
+            await self._login_task
+            self._login_task = None
 
     @rate_limited
     async def clan(self, tag: str):
-        return await self.get(f"/clans/{encode_tag(tag)}")
+        await self._ready()
+        data = await self._client.get_clan(encode_tag(tag))
+        return getattr(data, "_raw_data", data)
 
     @rate_limited
     async def clan_members(self, tag: str):
-        return await self.get(f"/clans/{encode_tag(tag)}/members")
+        await self._ready()
+        members = await self._client.get_members(encode_tag(tag))
+        return [getattr(m, "_raw_data", m) for m in members]
 
     @rate_limited
     async def player(self, tag: str):
-        return await self.get(f"/players/{encode_tag(tag)}")
+        await self._ready()
+        data = await self._client.get_player(encode_tag(tag))
+        return getattr(data, "_raw_data", data)
 
     @rate_limited
     async def current_war(self, tag: str):
-        return await self.get(f"/clans/{encode_tag(tag)}/currentwar")
+        await self._ready()
+        war = await self._client.get_current_war(encode_tag(tag))
+        if war is None:
+            return {"state": "notInWar"}
+        return getattr(war, "_raw_data", war)
 
     @rate_limited
     async def capital_raid_seasons(self, tag: str):
-        return await self.get(f"/clans/{encode_tag(tag)}/capitalraidseasons")
+        await self._ready()
+        raid_log = await self._client.get_raid_log(encode_tag(tag))
+        return [entry._raw_data for entry in raid_log]
 
     @rate_limited
     async def verify_token(self, tag: str, token: str):
-        data = {"token": token}
-        return await self.request("POST", f"/players/{encode_tag(tag)}/verifytoken", json=data)
+        await self._ready()
+        return await self._client.verify_player_token(encode_tag(tag), token)
 
 
 _client: CoCClient | None = None
 
 
-def get_client() -> CoCClient:
+async def get_client() -> CoCClient:
     global _client
     if _client is None:
         if not COC_TOKEN:
             raise RuntimeError("COC_API_TOKEN environment variable not set")
-        _client = CoCClient(COC_BASE, COC_TOKEN)
+        _client = CoCClient(COC_TOKEN)
     return _client

--- a/coclib/services/player_service.py
+++ b/coclib/services/player_service.py
@@ -16,12 +16,13 @@ STALE_AFTER = timedelta(seconds=int(os.getenv("SNAPSHOT_MAX_AGE", "600")))
 
 
 async def _fetch_player(tag: str) -> dict:
-    return await get_client().player(tag)
+    client = await get_client()
+    return await client.player(tag)
 
 
 async def verify_token(tag: str, token: str) -> dict:
     """Verify a player's API token via the Clash of Clans API."""
-    client = get_client()
+    client = await get_client()
     return await client.verify_token(tag, token)
 
 

--- a/coclib/services/war_service.py
+++ b/coclib/services/war_service.py
@@ -16,7 +16,8 @@ STALE_AFTER = timedelta(seconds=int(os.getenv("SNAPSHOT_MAX_AGE", "600")))
 
 async def current_war(clan_tag: str) -> dict:
     clan_tag = normalize_tag(clan_tag)
-    data = await get_client().current_war(clan_tag)
+    client = await get_client()
+    data = await client.current_war(clan_tag)
 
     last = (
         WarSnapshot.query.filter_by(clan_tag=clan_tag)

--- a/sync/requirements.txt
+++ b/sync/requirements.txt
@@ -16,7 +16,7 @@ h11==0.16.0
 h2==4.2.0
 hpack==4.1.0
 httpcore==1.0.9
-httpx==0.28.1
+coc.py==3.9.1
 hyperframe==6.1.0
 idna==3.10
 importlib_metadata==8.7.0


### PR DESCRIPTION
## Summary
- swap `httpx` API client for coc.py
- remove raw httpx usage from service modules
- update dependencies and docs

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_687ef6bf0c74832c972f4350fb78de03