### PR TITLE
Switch to coc.py library

### DIFF
--- a/back-end/requirements.txt
+++ b/back-end/requirements.txt
@@ -20,7 +20,7 @@ h11==0.16.0
 h2==4.2.0
 hpack==4.1.0
 httpcore==1.0.9
-httpx==0.28.1
+coc.py==3.9.1
 hyperframe==6.1.0
 idna==3.10
 importlib_metadata==8.7.0

--- a/coclib/config.py
+++ b/coclib/config.py
@@ -16,6 +16,7 @@ class Config:
 
     # Clash of Clans API
     COC_TOKEN = os.getenv("COC_API_TOKEN")  # required
+    COC_TOKENS = [t.strip() for t in (COC_TOKEN or "").split(",") if t.strip()]
     COC_BASE = "https://api.clashofclans.com/v1"
 
     # Cache (SimpleCache by default; swap config for redis if wanted)

--- a/coclib/services/clan_service.py
+++ b/coclib/services/clan_service.py
@@ -78,7 +78,7 @@ async def get_clan(tag: str) -> dict:
         # Schedule a full get_player() to also write a snapshot
         member_tasks.append(get_player(member["tag"]))
     if member_tasks:
-        # Run them concurrently; httpx handles connection pooling.
+        # Run them concurrently while reusing the client session.
         await gather(*member_tasks)
 
     db.session.commit()

--- a/coclib/services/coc_client.py
+++ b/coclib/services/coc_client.py
@@ -3,7 +3,8 @@ import logging
 from functools import wraps
 from datetime import datetime, timedelta
 import os
-import httpx
+
+import coc
 
 from coclib.utils import encode_tag
 
@@ -13,8 +14,8 @@ _last_reset = datetime.utcnow()
 _req_count = 0
 _lock = asyncio.Lock()
 
-COC_BASE = os.getenv("COC_BASE", "https://api.clashofclans.com/v1")
 COC_TOKEN = os.getenv("COC_API_TOKEN")
+COC_TOKENS = [t.strip() for t in (COC_TOKEN or "").split(",") if t.strip()]
 COC_REQS_PER_DAY = int(os.getenv("COC_REQS_PER_DAY", "5000"))
 
 
@@ -35,60 +36,82 @@ def rate_limited(fn):
 
 
 class CoCClient:
-    def __init__(self, base: str, token: str):
-        self.base = base
-        self.headers = {"Authorization": f"Bearer {token}"}
+    def __init__(self, base: str, tokens: list[str]):
+        self._client = coc.Client(raw_attribute=True, base_url=base)
+        self._login = asyncio.create_task(self._client.login_with_tokens(*tokens))
 
-    async def request(self, method: str, path: str, **kwargs):
-        async with httpx.AsyncClient(
-            base_url=self.base,
-            headers=self.headers,
-            timeout=10,
-            http2=True,
-        ) as client:
-            resp = await client.request(method, path, **kwargs)
+    async def _ensure_login(self):
+        if self._login is not None:
+            await self._login
+            self._login = None
 
-            if resp.status_code in (403, 404) and method == "GET":
-                try:
-                    payload = resp.json()
-                    reason = payload.get("reason", "")
-                except ValueError:
-                    reason = ""
-                if resp.status_code == 403 and reason.startswith("accessDenied"):
-                    logger.warning("Access denied for %s: %s", path, reason)
-                    return {"state": "accessDenied"}
-                return {"state": "notInWar"}
+    async def _handle_forbidden(self, exc: coc.Forbidden, path: str) -> dict:
+        logger.warning("Access denied for %s: %s", path, exc)
+        return {"state": "accessDenied"}
 
-            resp.raise_for_status()
-            return resp.json()
+    async def _handle_not_found(self, exc: coc.NotFound | None = None) -> dict:
+        return {"state": "notInWar"}
 
-    async def get(self, path: str):
-        return await self.request("GET", path)
+    async def _safe(self, coro, path: str):
+        try:
+            return await coro
+        except coc.Forbidden as exc:
+            return await self._handle_forbidden(exc, path)
+        except coc.NotFound:
+            return await self._handle_not_found()
+
+    async def _wrap(self, obj):
+        if hasattr(obj, "_raw_data"):
+            return obj._raw_data
+        return obj
 
     @rate_limited
     async def clan(self, tag: str):
-        return await self.get(f"/clans/{encode_tag(tag)}")
+        await self._ensure_login()
+        coro = self._client.get_clan(encode_tag(tag))
+        result = await self._safe(coro, f"/clans/{encode_tag(tag)}")
+        return self._wrap(result)
 
     @rate_limited
     async def clan_members(self, tag: str):
-        return await self.get(f"/clans/{encode_tag(tag)}/members")
+        await self._ensure_login()
+        coro = self._client.get_members(encode_tag(tag))
+        result = await self._safe(coro, f"/clans/{encode_tag(tag)}/members")
+        if isinstance(result, list):
+            return [self._wrap(m) for m in result]
+        return result
 
     @rate_limited
     async def player(self, tag: str):
-        return await self.get(f"/players/{encode_tag(tag)}")
+        await self._ensure_login()
+        coro = self._client.get_player(encode_tag(tag))
+        result = await self._safe(coro, f"/players/{encode_tag(tag)}")
+        return self._wrap(result)
 
     @rate_limited
     async def current_war(self, tag: str):
-        return await self.get(f"/clans/{encode_tag(tag)}/currentwar")
+        await self._ensure_login()
+        coro = self._client.get_current_war(encode_tag(tag))
+        result = await self._safe(coro, f"/clans/{encode_tag(tag)}/currentwar")
+        if result is None:
+            return {"state": "notInWar"}
+        return self._wrap(result)
 
     @rate_limited
     async def capital_raid_seasons(self, tag: str):
-        return await self.get(f"/clans/{encode_tag(tag)}/capitalraidseasons")
+        await self._ensure_login()
+        coro = self._client.get_raid_log(encode_tag(tag))
+        result = await self._safe(coro, f"/clans/{encode_tag(tag)}/capitalraidseasons")
+        if hasattr(result, "_raw_data"):
+            return result._raw_data
+        return result
 
     @rate_limited
     async def verify_token(self, tag: str, token: str):
-        data = {"token": token}
-        return await self.request("POST", f"/players/{encode_tag(tag)}/verifytoken", json=data)
+        await self._ensure_login()
+        coro = self._client.verify_player_token(encode_tag(tag), token)
+        success = await self._safe(coro, f"/players/{encode_tag(tag)}/verifytoken")
+        return {"status": "ok", "tag": f"#{encode_tag(tag)}"} if success else {"status": "invalid"}
 
 
 _client: CoCClient | None = None
@@ -97,7 +120,9 @@ _client: CoCClient | None = None
 def get_client() -> CoCClient:
     global _client
     if _client is None:
-        if not COC_TOKEN:
+        tokens = COC_TOKENS
+        if not tokens:
             raise RuntimeError("COC_API_TOKEN environment variable not set")
-        _client = CoCClient(COC_BASE, COC_TOKEN)
+        base = os.getenv("COC_BASE", "https://api.clashofclans.com/v1")
+        _client = CoCClient(base, tokens)
     return _client

--- a/sync/coclib/config.py
+++ b/sync/coclib/config.py
@@ -16,6 +16,7 @@ class Config:
 
     # Clash of Clans API
     COC_TOKEN = os.getenv("COC_API_TOKEN")  # required
+    COC_TOKENS = [t.strip() for t in (COC_TOKEN or "").split(",") if t.strip()]
     COC_BASE = "https://api.clashofclans.com/v1"
 
     # Cache (SimpleCache by default; swap config for redis if wanted)

--- a/sync/requirements.txt
+++ b/sync/requirements.txt
@@ -16,7 +16,7 @@ h11==0.16.0
 h2==4.2.0
 hpack==4.1.0
 httpcore==1.0.9
-httpx==0.28.1
+coc.py==3.9.1
 hyperframe==6.1.0
 idna==3.10
 importlib_metadata==8.7.0


### PR DESCRIPTION
## Summary
- replace custom HTTP client with coc.py
- remove httpx dependency from backend & sync
- allow multiple API tokens and login via `login_with_tokens`

## Testing
- `ruff check back-end sync coclib db`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_687ef6bf0c74832c972f4350fb78de03