### PR TITLE
Fix table environment variable names

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -28,8 +28,8 @@ public class ChatService {
 
     public ChatService(
             DynamoDbClient dynamoDb,
-            @Value("${messages.table:webapp-chat}") String tableName,
-            @Value("${messages.legacy-table:webapp-chat-messages}") String legacyTableName) {
+            @Value("${chat.table:webapp-chat}") String tableName,
+            @Value("${messages.table:webapp-chat-messages}") String legacyTableName) {
         this.dynamoDb = dynamoDb;
         this.tableName = tableName;
         this.legacyTableName = legacyTableName;


### PR DESCRIPTION
## Summary
- inject the new chat table and legacy messages table using environment variable names

## Testing
- `./gradlew test` in `messages-java`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6880eb42339c832c8cc5b66a26ac14c9