### PR TITLE
Switch chat to single-table design

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -268,7 +268,7 @@ export default function App() {
           <Suspense fallback={<Loading className="py-20" />}>
             <Routes>
               <Route path="/" element={<DashboardPage defaultTag={clanTag} showSearchForm={false} onClanLoaded={setClanInfo} />} />
-              <Route path="/chat" element={<ChatPage verified={verified} groupId={homeClanTag || '1'} userId={playerTag || ''} />} />
+              <Route path="/chat" element={<ChatPage verified={verified} chatId={homeClanTag || '1'} userId={playerTag || ''} />} />
               <Route path="/scout" element={<ScoutPage />} />
               <Route path="/stats" element={<StatsPage />} />
               <Route path="/account" element={<AccountPage onVerified={() => setVerified(true)} />} />

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -4,8 +4,8 @@ import useChat from '../hooks/useChat.js';
 import ChatMessage from './ChatMessage.jsx';
 import Loading from './Loading.jsx';
 
-export default function ChatPanel({ groupId = '1', userId = '' }) {
-  const { messages, loadMore, hasMore } = useChat(groupId);
+export default function ChatPanel({ chatId = '1', userId = '' }) {
+  const { messages, loadMore, hasMore } = useChat(chatId);
   const [text, setText] = useState('');
   const [sending, setSending] = useState(false);
   const [tab, setTab] = useState('Clan');
@@ -61,12 +61,12 @@ useEffect(() => {
     const trimmed = text.trim();
     if (!trimmed) return;
     setSending(true);
-    console.log('Publishing message', trimmed, 'to', groupId);
+    console.log('Publishing message', trimmed, 'to', chatId);
     try {
       await fetchJSON('/chat/publish', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ groupId, userId, text: trimmed }),
+        body: JSON.stringify({ chatId, userId, text: trimmed }),
       });
       setText('');
     } catch (err) {

--- a/front-end/src/pages/ChatPage.jsx
+++ b/front-end/src/pages/ChatPage.jsx
@@ -3,12 +3,12 @@ import Loading from '../components/Loading.jsx';
 
 const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
 
-export default function ChatPage({ verified, groupId, userId }) {
+export default function ChatPage({ verified, chatId, userId }) {
   return (
     <div className="h-[calc(100dvh-8rem)] flex flex-col overflow-y-auto overscroll-y-contain">
       <Suspense fallback={<Loading className="py-20" />}>
         {verified ? (
-          <ChatPanel groupId={groupId} userId={userId} />
+          <ChatPanel chatId={chatId} userId={userId} />
         ) : (
           <div className="p-4">Verify your account to chat.</div>
         )}

--- a/messages-java/build.gradle
+++ b/messages-java/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation platform('software.amazon.awssdk:bom:2.25.32')
     implementation 'software.amazon.awssdk:dynamodb'
+    implementation 'software.amazon.awssdk:dynamodb-enhanced'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/messages-java/src/main/java/com/clanboards/messages/config/AwsConfig.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/AwsConfig.java
@@ -1,8 +1,10 @@
 package com.clanboards.messages.config;
 
+import com.clanboards.messages.repository.ChatRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
@@ -13,5 +15,19 @@ public class AwsConfig {
         return DynamoDbClient.builder()
                 .region(Region.of(region))
                 .build();
+    }
+
+    @Bean
+    public DynamoDbEnhancedClient dynamoDbEnhancedClient(DynamoDbClient client) {
+        return DynamoDbEnhancedClient.builder()
+                .dynamoDbClient(client)
+                .build();
+    }
+
+    @Bean
+    public ChatRepository chatRepository(
+            DynamoDbEnhancedClient enhancedClient,
+            @Value("${chat.table:webapp-chat}") String tableName) {
+        return new ChatRepository(enhancedClient, tableName);
     }
 }

--- a/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
@@ -23,8 +23,8 @@ public class ChatController {
 
     @PostMapping("/publish")
     public ResponseEntity<Map<String, String>> publish(@RequestBody PublishRequest req) {
-        ChatMessage msg = chatService.publish(req.groupId(), req.text(), req.userId());
-        messaging.convertAndSend("/topic/chat/" + req.groupId(), Map.of(
+        ChatMessage msg = chatService.publish(req.chatId(), req.text(), req.userId());
+        messaging.convertAndSend("/topic/chat/" + req.chatId(), Map.of(
                 "channel", msg.channel(),
                 "userId", msg.userId(),
                 "content", msg.content(),
@@ -33,13 +33,13 @@ public class ChatController {
         return ResponseEntity.ok(Map.of("status", "ok", "ts", msg.ts().toString()));
     }
 
-    @GetMapping("/history/{groupId}")
+    @GetMapping("/history/{chatId}")
     public ResponseEntity<List<Map<String, String>>> history(
-            @PathVariable String groupId,
+            @PathVariable String chatId,
             @RequestParam(defaultValue = "20") int limit,
             @RequestParam(required = false) String before) {
         List<ChatMessage> msgs = chatService.history(
-                groupId,
+                chatId,
                 Math.min(limit, 100),
                 before != null ? Instant.parse(before) : null
         );
@@ -52,5 +52,5 @@ public class ChatController {
         return ResponseEntity.ok(body);
     }
 
-    public static record PublishRequest(String groupId, String text, String userId) {}
+    public static record PublishRequest(String chatId, String text, String userId) {}
 }

--- a/messages-java/src/main/java/com/clanboards/messages/repository/ChatRepository.java
+++ b/messages-java/src/main/java/com/clanboards/messages/repository/ChatRepository.java
@@ -1,0 +1,75 @@
+package com.clanboards.messages.repository;
+
+import com.clanboards.messages.model.ChatMessage;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+public class ChatRepository {
+    private final DynamoDbTable<MessageItem> table;
+
+    public ChatRepository(DynamoDbEnhancedClient client, String tableName) {
+        this.table = client.table(tableName, software.amazon.awssdk.enhanced.dynamodb.TableSchema.fromBean(MessageItem.class));
+    }
+
+    static String pk(String chatId) {
+        return "CHAT#" + chatId;
+    }
+
+    static String sk(Instant ts, String uuid) {
+        return "MSG#" + ts.toString() + "#" + uuid;
+    }
+
+    public void saveMessage(ChatMessage msg) {
+        MessageItem item = new MessageItem();
+        item.setPK(pk(msg.channel()));
+        item.setSK(sk(msg.ts(), UUID.randomUUID().toString()));
+        item.setChatId(msg.channel());
+        item.setSenderId(msg.userId());
+        item.setContent(msg.content());
+        item.setTs(msg.ts().toString());
+        table.putItem(item);
+    }
+
+    public List<ChatMessage> listMessages(String chatId, int limit, Instant before) {
+        QueryConditional cond;
+        if (before != null) {
+            cond = QueryConditional.sortLessThan(Key.builder()
+                    .partitionValue(pk(chatId))
+                    .sortValue("MSG#" + before.toString())
+                    .build());
+        } else {
+            cond = QueryConditional.keyEqualTo(Key.builder().partitionValue(pk(chatId)).build());
+        }
+
+        QueryEnhancedRequest req = QueryEnhancedRequest.builder()
+                .queryConditional(cond)
+                .limit(limit)
+                .scanIndexForward(false)
+                .build();
+
+        List<ChatMessage> result = new ArrayList<>();
+        for (Page<MessageItem> page : table.query(req)) {
+            for (MessageItem it : page.items()) {
+                result.add(new ChatMessage(
+                        it.getChatId(),
+                        it.getSenderId(),
+                        it.getContent(),
+                        Instant.parse(it.getTs())
+                ));
+            }
+        }
+        result.sort(Comparator.comparing(ChatMessage::ts));
+        return result;
+    }
+}

--- a/messages-java/src/main/java/com/clanboards/messages/repository/MessageItem.java
+++ b/messages-java/src/main/java/com/clanboards/messages/repository/MessageItem.java
@@ -1,0 +1,35 @@
+package com.clanboards.messages.repository;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+@DynamoDbBean
+public class MessageItem {
+    private String PK;
+    private String SK;
+    private String chatId;
+    private String senderId;
+    private String content;
+    private String ts;
+
+    @DynamoDbPartitionKey
+    public String getPK() { return PK; }
+    public void setPK(String PK) { this.PK = PK; }
+
+    @DynamoDbSortKey
+    public String getSK() { return SK; }
+    public void setSK(String SK) { this.SK = SK; }
+
+    public String getChatId() { return chatId; }
+    public void setChatId(String chatId) { this.chatId = chatId; }
+
+    public String getSenderId() { return senderId; }
+    public void setSenderId(String senderId) { this.senderId = senderId; }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+
+    public String getTs() { return ts; }
+    public void setTs(String ts) { this.ts = ts; }
+}

--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -1,121 +1,32 @@
 package com.clanboards.messages.service;
 
 import com.clanboards.messages.model.ChatMessage;
-import org.springframework.beans.factory.annotation.Value;
+import com.clanboards.messages.repository.ChatRepository;
 import org.springframework.stereotype.Service;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
-import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
-import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
-import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeParseException;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
 
 @Service
 public class ChatService {
-    private static final Logger logger = LoggerFactory.getLogger(ChatService.class);
-    private final DynamoDbClient dynamoDb;
-    private final String tableName;
-    private final String legacyTableName;
+    private final ChatRepository repository;
 
-    public ChatService(
-            DynamoDbClient dynamoDb,
-            @Value("${chat.table:webapp-chat}") String tableName,
-            @Value("${messages.table:webapp-chat-messages}") String legacyTableName) {
-        this.dynamoDb = dynamoDb;
-        this.tableName = tableName;
-        this.legacyTableName = legacyTableName;
+    public ChatService(ChatRepository repository) {
+        this.repository = repository;
     }
 
-    public ChatMessage publish(String groupId, String text, String userId) {
+    public ChatMessage publish(String chatId, String text, String userId) {
         Instant ts = Instant.now();
-        Map<String, AttributeValue> item = new HashMap<>();
-        item.put("PK", AttributeValue.fromS(groupId));
-        item.put("SK", AttributeValue.fromS(ts.toString()));
-        item.put("GSI1PK", AttributeValue.fromS(userId));
-        item.put("channel", AttributeValue.fromS(groupId));
-        item.put("ts", AttributeValue.fromS(ts.toString()));
-        item.put("userId", AttributeValue.fromS(userId));
-        item.put("content", AttributeValue.fromS(text));
-        try {
-        System.out.println("Attempting to write to table: " + tableName);
-        logger.info("Attempting to write to table (logger): {}", tableName);
-            dynamoDb.putItem(PutItemRequest.builder()
-                    .tableName(tableName)
-                    .item(item)
-                    .build());
-        } catch (DynamoDbException ex) {
-//             to stdout as well for testing println
-            System.err.println("Failed to write to table " + tableName + ": " + ex.getMessage());
-            logger.error("Failed to write to table (logger) {}: {}", tableName, ex.getMessage());
-        }
-
-        if (legacyTableName != null && !legacyTableName.isBlank() && !legacyTableName.equals(tableName)) {
-            Map<String, AttributeValue> legacy = new HashMap<>();
-            legacy.put("channel", AttributeValue.fromS(groupId));
-            legacy.put("ts", AttributeValue.fromS(ts.toString()));
-            legacy.put("userId", AttributeValue.fromS(userId));
-            legacy.put("content", AttributeValue.fromS(text));
-            System.out.println("Attempting to write to legacy table: " + legacyTableName);
-            logger.info("Attempting to write to legacy table (logger): {}", legacyTableName);
-            try {
-                dynamoDb.putItem(PutItemRequest.builder()
-                        .tableName(legacyTableName)
-                        .item(legacy)
-                        .build());
-            } catch (DynamoDbException ex) {
-                logger.warn("Failed to write to legacy table (logger) {}: {}", legacyTableName, ex.getMessage());
-                System.err.println("Failed to write to legacy table " + legacyTableName + ": " + ex.getMessage());
-            }
-        }
-        return new ChatMessage(groupId, userId, text, ts);
+        ChatMessage msg = new ChatMessage(chatId, userId, text, ts);
+        repository.saveMessage(msg);
+        return msg;
     }
 
-    public List<ChatMessage> history(String groupId, int limit) {
-        return history(groupId, limit, null);
+    public List<ChatMessage> history(String chatId, int limit) {
+        return history(chatId, limit, null);
     }
 
-    public List<ChatMessage> history(String groupId, int limit, Instant before) {
-        Map<String, AttributeValue> values = new HashMap<>();
-        values.put(":c", AttributeValue.fromS(groupId));
-        String expr = "channel = :c";
-        if (before != null) {
-            expr += " and ts < :b";
-            values.put(":b", AttributeValue.fromS(before.toString()));
-        }
-
-        QueryRequest req = QueryRequest.builder()
-                .tableName(tableName)
-                .keyConditionExpression(expr)
-                .expressionAttributeValues(values)
-                .limit(limit)
-                .scanIndexForward(false)
-                .build();
-        QueryResponse resp = dynamoDb.query(req);
-        return resp.items().stream()
-                .sorted(Comparator.comparing(m -> parseInstant(m.get("ts").s())))
-                .map(item -> new ChatMessage(
-                        item.get("channel").s(),
-                        item.get("userId").s(),
-                        item.get("content").s(),
-                        parseInstant(item.get("ts").s())
-                ))
-                .collect(Collectors.toList());
-    }
-
-    private Instant parseInstant(String value) {
-        try {
-            return Instant.parse(value);
-        } catch (DateTimeParseException ex) {
-            return LocalDateTime.parse(value).toInstant(ZoneOffset.UTC);
-        }
+    public List<ChatMessage> history(String chatId, int limit, Instant before) {
+        return repository.listMessages(chatId, limit, before);
     }
 }

--- a/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
@@ -35,7 +35,7 @@ class ChatControllerTest {
 
         mvc.perform(post("/api/v1/chat/publish")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"groupId\":\"1\",\"text\":\"hi\",\"userId\":\"u\"}"))
+                .content("{\"chatId\":\"1\",\"text\":\"hi\",\"userId\":\"u\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("ok"))
                 .andExpect(jsonPath("$.ts").value(ts.toString()));

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -1,92 +1,35 @@
 package com.clanboards.messages.service;
 
 import com.clanboards.messages.model.ChatMessage;
+import com.clanboards.messages.repository.ChatRepository;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.ArgumentCaptor;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
-import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
-import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
-import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import org.mockito.Mockito;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class ChatServiceTest {
     @Test
-    void publishWritesToBothTables() {
-        DynamoDbClient dynamoDb = Mockito.mock(DynamoDbClient.class);
-        ChatService service = new ChatService(dynamoDb, "new", "old");
+    void publishSavesMessage() {
+        ChatRepository repo = Mockito.mock(ChatRepository.class);
+        ChatService service = new ChatService(repo);
 
-        service.publish("1", "hello", "u");
-        ArgumentCaptor<PutItemRequest> captor = ArgumentCaptor.forClass(PutItemRequest.class);
-        Mockito.verify(dynamoDb, Mockito.times(2)).putItem(captor.capture());
-        List<PutItemRequest> calls = captor.getAllValues();
-        assertTrue(calls.stream().anyMatch(r -> r.tableName().equals("new")));
-        assertTrue(calls.stream().anyMatch(r -> r.tableName().equals("old")));
+        ChatMessage msg = service.publish("1", "hello", "u");
+        assertEquals("1", msg.channel());
+        Mockito.verify(repo).saveMessage(Mockito.any(ChatMessage.class));
     }
 
     @Test
-    void publishContinuesWhenPrimaryWriteFails() {
-        DynamoDbClient dynamoDb = Mockito.mock(DynamoDbClient.class);
-        Mockito.doThrow(DynamoDbException.builder().message("fail").build())
-                .when(dynamoDb)
-                .putItem(Mockito.<PutItemRequest>argThat(r -> r.tableName().equals("new")));
+    void historyDelegatesToRepo() {
+        ChatRepository repo = Mockito.mock(ChatRepository.class);
+        List<ChatMessage> expected = List.of(new ChatMessage("1", "u", "hi", Instant.now()));
+        Mockito.when(repo.listMessages("1", 2, null)).thenReturn(expected);
 
-        ChatService service = new ChatService(dynamoDb, "new", "old");
-        ChatMessage msg = service.publish("1", "hi", "u");
-        assertNotNull(msg);
-        Mockito.verify(dynamoDb, Mockito.times(2)).putItem(Mockito.any(PutItemRequest.class));
-    }
-    @Test
-    void historyParsesTimestampsWithoutZone() {
-        DynamoDbClient dynamoDb = Mockito.mock(DynamoDbClient.class);
-        ChatService service = new ChatService(dynamoDb, "chat", "legacy");
-        String ts = "2025-07-19T06:55:24.755730";
-        Map<String, AttributeValue> item = Map.of(
-                "channel", AttributeValue.fromS("1"),
-                "userId", AttributeValue.fromS("u"),
-                "content", AttributeValue.fromS("hi"),
-                "ts", AttributeValue.fromS(ts)
-        );
-        QueryResponse resp = QueryResponse.builder().items(List.of(item)).build();
-        Mockito.when(dynamoDb.query(Mockito.any(QueryRequest.class))).thenReturn(resp);
-
-        List<ChatMessage> msgs = service.history("1", 1, null);
-        Instant expected = LocalDateTime.parse(ts).toInstant(ZoneOffset.UTC);
-        assertEquals(1, msgs.size());
-        assertEquals(expected, msgs.get(0).ts());
-    }
-
-    @Test
-    void historySortsByTimestamp() {
-        DynamoDbClient dynamoDb = Mockito.mock(DynamoDbClient.class);
-        ChatService service = new ChatService(dynamoDb, "chat", "legacy");
-        Map<String, AttributeValue> item1 = Map.of(
-                "channel", AttributeValue.fromS("1"),
-                "userId", AttributeValue.fromS("u"),
-                "content", AttributeValue.fromS("first"),
-                "ts", AttributeValue.fromS("2025-07-19T06:55:24Z")
-        );
-        Map<String, AttributeValue> item2 = Map.of(
-                "channel", AttributeValue.fromS("1"),
-                "userId", AttributeValue.fromS("u"),
-                "content", AttributeValue.fromS("second"),
-                "ts", AttributeValue.fromS("2025-07-19T06:55:25Z")
-        );
-        QueryResponse resp = QueryResponse.builder().items(List.of(item2, item1)).build();
-        Mockito.when(dynamoDb.query(Mockito.any(QueryRequest.class))).thenReturn(resp);
-
-        List<ChatMessage> msgs = service.history("1", 2, null);
-        assertEquals(2, msgs.size());
-        assertEquals("first", msgs.get(0).content());
-        assertEquals("second", msgs.get(1).content());
+        ChatService service = new ChatService(repo);
+        List<ChatMessage> result = service.history("1", 2, null);
+        assertSame(expected, result);
     }
 }


### PR DESCRIPTION
## Summary
- migrate chat service to a DynamoDB single-table design
- inject a new `ChatRepository` via Spring config
- refactor `ChatService` and controller to use `chatId`
- rename chat props on the front-end
- update unit tests and add missing repository classes

## Testing
- `./gradlew test`
- `npm install`
- `npm test`
- `npm run build`
- `ruff check back-end coclib db`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_68813655a91c832cb1eb56a19550be1e