### PR TITLE
Implement basic global chat sharding

### DIFF
--- a/CHAT_STATUS.md
+++ b/CHAT_STATUS.md
@@ -1,0 +1,12 @@
+# Phase 3 Progress
+
+## Completed
+- [x] ChatRepository using DynamoDbEnhancedClient
+- [x] PK/SK helpers in repository
+- [x] Friendship service with request handling
+
+## Remaining
+- [ ] BatchWriteItem fan-out for messages
+- [ ] DomainEvent WebSocket flow
+- [ ] Additional repository methods (createIfAbsent, TTL)
+

--- a/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
@@ -33,6 +33,18 @@ public class ChatController {
         return ResponseEntity.ok(Map.of("status", "ok", "ts", msg.ts().toString()));
     }
 
+    @PostMapping("/publish/global")
+    public ResponseEntity<Map<String, String>> publishGlobal(@RequestBody GlobalRequest req) {
+        ChatMessage msg = chatService.publishGlobal(req.text(), req.userId());
+        messaging.convertAndSend("/topic/chat/" + msg.channel(), Map.of(
+                "channel", msg.channel(),
+                "userId", msg.userId(),
+                "content", msg.content(),
+                "ts", msg.ts().toString()
+        ));
+        return ResponseEntity.ok(Map.of("status", "ok", "ts", msg.ts().toString()));
+    }
+
     @GetMapping("/history/{chatId}")
     public ResponseEntity<List<Map<String, String>>> history(
             @PathVariable String chatId,
@@ -53,4 +65,5 @@ public class ChatController {
     }
 
     public static record PublishRequest(String chatId, String text, String userId) {}
+    public static record GlobalRequest(String text, String userId) {}
 }

--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -22,6 +22,14 @@ public class ChatService {
         return msg;
     }
 
+    public ChatMessage publishGlobal(String text, String userId) {
+        Instant ts = Instant.now();
+        String shard = ChatRepository.globalShardKey(userId);
+        ChatMessage msg = new ChatMessage(shard, userId, text, ts);
+        repository.saveGlobalMessage(msg);
+        return msg;
+    }
+
     public List<ChatMessage> history(String chatId, int limit) {
         return history(chatId, limit, null);
     }

--- a/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
@@ -52,4 +52,17 @@ class ChatControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].content").value("hi"));
     }
+
+    @Test
+    void publishGlobalReturnsOk() throws Exception {
+        Instant ts = Instant.parse("2024-01-01T00:00:00Z");
+        Mockito.when(chatService.publishGlobal("hi", "u"))
+                .thenReturn(new ChatMessage("global#shard-1", "u", "hi", ts));
+
+        mvc.perform(post("/api/v1/chat/publish/global")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"text\":\"hi\",\"userId\":\"u\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ok"));
+    }
 }

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -32,4 +32,14 @@ class ChatServiceTest {
         List<ChatMessage> result = service.history("1", 2, null);
         assertSame(expected, result);
     }
+
+    @Test
+    void publishGlobalUsesShardKey() {
+        ChatRepository repo = Mockito.mock(ChatRepository.class);
+        ChatService service = new ChatService(repo);
+
+        ChatMessage msg = service.publishGlobal("hi", "user1");
+        assertEquals(ChatRepository.globalShardKey("user1"), msg.channel());
+        Mockito.verify(repo).saveGlobalMessage(Mockito.any(ChatMessage.class));
+    }
 }


### PR DESCRIPTION
## Summary
- add `globalShardKey` logic in `ChatRepository`
- expose global chat publishing in `ChatService` and controller
- cover new flows with unit tests
- document progress in `CHAT_STATUS.md`

## Testing
- `./gradlew test` in `messages-java`
- `./gradlew test` in `user_service`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_688153b6c630832ca0951a7b69b70df9