### PR TITLE
Implement service worker chat subscription

### DIFF
--- a/CHAT_STATUS.md
+++ b/CHAT_STATUS.md
@@ -11,7 +11,6 @@
 - [x] GraphQL client utilities and offline outbox added
 - [x] Chat UI now sends GraphQL mutations and retries from IndexedDB
 
-## Remaining
-- [ ] Subscribe service worker to all chat/shard IDs after login
+- [x] Subscribe service worker to all chat/shard IDs after login
 - [ ] Render global and friend chats using aggregated subscriptions
 - [ ] Expose friend request actions in UI

--- a/front-end/public/sw.js
+++ b/front-end/public/sw.js
@@ -10,6 +10,17 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(self.clients.claim());
 });
 
+const subscribedChats = new Set();
+
+self.addEventListener('message', (event) => {
+  const msg = event.data;
+  if (!msg || msg.type !== 'subscribe-chats' || !Array.isArray(msg.ids)) return;
+  for (const id of msg.ids) {
+    if (typeof id === 'string') subscribedChats.add(id);
+  }
+  console.log('Subscribed chats updated', [...subscribedChats]);
+});
+
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
   if (url.origin === self.location.origin && url.pathname.startsWith('/api/')) {

--- a/front-end/src/pages/ChatPage.jsx
+++ b/front-end/src/pages/ChatPage.jsx
@@ -11,8 +11,14 @@ export default function ChatPage({ verified, chatId, userId }) {
     (async () => {
       try {
         const data = await graphqlRequest('query { listChats { id } }');
-        console.log('Subscribed chats', data.listChats.map((c) => c.id));
-        // In a real implementation we'd notify the service worker here
+        const ids = data.listChats.map((c) => c.id);
+        console.log('Subscribed chats', ids);
+        if (navigator.serviceWorker?.controller) {
+          navigator.serviceWorker.controller.postMessage({
+            type: 'subscribe-chats',
+            ids,
+          });
+        }
       } catch (err) {
         console.error('Failed to fetch chat list', err);
       }


### PR DESCRIPTION
## Summary
- notify service worker of chat IDs after verifying user
- store subscribed chat IDs in `sw.js`
- update phase tracker

## Testing
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_688174bb687c832ca2a67951abfa066a