### PR TITLE
Fix CORS for Java services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,5 @@ fabric.properties
 messages-java/build/
 messages-java/.gradle/
 messages-java/gradle/wrapper/gradle-wrapper.jar
+user_service/build/
+user_service/.gradle/

--- a/user_service/src/main/java/com/clanboards/users/config/CorsConfig.java
+++ b/user_service/src/main/java/com/clanboards/users/config/CorsConfig.java
@@ -1,4 +1,4 @@
-package com.clanboards.messages.config;
+package com.clanboards.users.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
## Summary
- expand CORS mapping in `messages-java`
- add CORS config to `user_service`
- ignore `user_service` build output

## Testing
- `./gradlew test` in `messages-java`
- `./gradlew test` in `user_service`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_68817cdd2ab4832c9462d13a2cafc3a4