### PR TITLE
Fix CORS via secrets

### DIFF
--- a/messages-java/build.gradle
+++ b/messages-java/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.25.32')
     implementation 'software.amazon.awssdk:dynamodb'
     implementation 'software.amazon.awssdk:dynamodb-enhanced'
+    implementation 'software.amazon.awssdk:secretsmanager'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/messages-java/src/main/java/com/clanboards/messages/config/AwsConfig.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/AwsConfig.java
@@ -7,12 +7,20 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 @Configuration
 public class AwsConfig {
     @Bean
     public DynamoDbClient dynamoDbClient(@Value("${aws.region:us-east-1}") String region) {
         return DynamoDbClient.builder()
+                .region(Region.of(region))
+                .build();
+    }
+
+    @Bean
+    public SecretsManagerClient secretsManagerClient(@Value("${aws.region:us-east-1}") String region) {
+        return SecretsManagerClient.builder()
                 .region(Region.of(region))
                 .build();
     }

--- a/messages-java/src/main/java/com/clanboards/messages/config/CorsConfig.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/CorsConfig.java
@@ -1,19 +1,54 @@
 package com.clanboards.messages.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+
+import java.util.Arrays;
 
 @Configuration
 public class CorsConfig {
+    private final SecretsManagerClient secrets;
+    private final String allowedOrigins;
+    private final String secretName;
+
+    public CorsConfig(
+            SecretsManagerClient secrets,
+            @Value("${cors.allowed-origins:*}") String allowedOrigins,
+            @Value("${cors.secret-name:}") String secretName
+    ) {
+        this.secrets = secrets;
+        this.allowedOrigins = allowedOrigins;
+        this.secretName = secretName;
+    }
+
     @Bean
     public WebMvcConfigurer corsConfigurer() {
+        String origins = this.allowedOrigins;
+        if ((origins == null || origins.isBlank()) && !this.secretName.isBlank()) {
+            try {
+                origins = secrets.getSecretValue(
+                        GetSecretValueRequest.builder().secretId(this.secretName).build()
+                ).secretString();
+            } catch (Exception ignored) {
+            }
+        }
+        if (origins == null || origins.isBlank()) {
+            origins = "*";
+        }
+        String[] patterns = Arrays.stream(origins.split(","))
+                .map(String::trim)
+                .toArray(String[]::new);
+
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/api/**")
-                        .allowedOriginPatterns("*")
+                        .allowedOriginPatterns(patterns)
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*");
             }

--- a/user_service/build.gradle
+++ b/user_service/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.25.32')
     implementation 'software.amazon.awssdk:dynamodb'
     implementation 'software.amazon.awssdk:dynamodb-enhanced'
+    implementation 'software.amazon.awssdk:secretsmanager'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/user_service/src/main/java/com/clanboards/users/config/AwsConfig.java
+++ b/user_service/src/main/java/com/clanboards/users/config/AwsConfig.java
@@ -6,12 +6,20 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 @Configuration
 public class AwsConfig {
     @Bean
     public DynamoDbClient dynamoDbClient(@Value("${aws.region:us-east-1}") String region) {
         return DynamoDbClient.builder()
+                .region(Region.of(region))
+                .build();
+    }
+
+    @Bean
+    public SecretsManagerClient secretsManagerClient(@Value("${aws.region:us-east-1}") String region) {
+        return SecretsManagerClient.builder()
                 .region(Region.of(region))
                 .build();
     }

--- a/user_service/src/main/java/com/clanboards/users/config/CorsConfig.java
+++ b/user_service/src/main/java/com/clanboards/users/config/CorsConfig.java
@@ -1,19 +1,54 @@
 package com.clanboards.users.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+
+import java.util.Arrays;
 
 @Configuration
 public class CorsConfig {
+    private final SecretsManagerClient secrets;
+    private final String allowedOrigins;
+    private final String secretName;
+
+    public CorsConfig(
+            SecretsManagerClient secrets,
+            @Value("${cors.allowed-origins:*}") String allowedOrigins,
+            @Value("${cors.secret-name:}") String secretName
+    ) {
+        this.secrets = secrets;
+        this.allowedOrigins = allowedOrigins;
+        this.secretName = secretName;
+    }
+
     @Bean
     public WebMvcConfigurer corsConfigurer() {
+        String origins = this.allowedOrigins;
+        if ((origins == null || origins.isBlank()) && !this.secretName.isBlank()) {
+            try {
+                origins = secrets.getSecretValue(
+                        GetSecretValueRequest.builder().secretId(this.secretName).build()
+                ).secretString();
+            } catch (Exception ignored) {
+            }
+        }
+        if (origins == null || origins.isBlank()) {
+            origins = "*";
+        }
+        String[] patterns = Arrays.stream(origins.split(","))
+                .map(String::trim)
+                .toArray(String[]::new);
+
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/api/**")
-                        .allowedOriginPatterns("*")
+                        .allowedOriginPatterns(patterns)
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*");
             }


### PR DESCRIPTION
## Summary
- load CORS origins from AWS Secrets Manager if provided
- expose SecretsManagerClient beans
- include AWS SDK secretsmanager dependency

## Testing
- `nox -s lint tests`
- `./gradlew test` in `messages-java`
- `./gradlew test` in `user_service`


------
https://chatgpt.com/codex/tasks/task_e_68818417ea08832c855f553a55e6a355