### PR TITLE
Implement GraphQL endpoint for chat service

### DIFF
--- a/front-end/src/lib/gql.js
+++ b/front-end/src/lib/gql.js
@@ -4,7 +4,7 @@ export async function graphqlRequest(query, variables = {}) {
   const token = localStorage.getItem('token');
   const headers = { 'Content-Type': 'application/json' };
   if (token) headers.Authorization = `Bearer ${token}`;
-  const url = `${API_URL}/api/v1/graphql`;
+  const url = `${API_URL}/api/v1/chat/graphql`;
   const res = await fetch(url, {
     method: 'POST',
     headers,

--- a/front-end/src/lib/gql.test.js
+++ b/front-end/src/lib/gql.test.js
@@ -16,7 +16,7 @@ describe('graphqlRequest', () => {
     global.fetch = fetchMock;
     await graphqlRequest('query { test }');
     expect(fetchMock).toHaveBeenCalledWith(
-      `${API_URL}/api/v1/graphql`,
+      `${API_URL}/api/v1/chat/graphql`,
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: 'Bearer abc123' }),
       })

--- a/messages-java/build.gradle
+++ b/messages-java/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-graphql'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation platform('software.amazon.awssdk:bom:2.25.32')
@@ -26,6 +27,7 @@ dependencies {
     implementation 'software.amazon.awssdk:dynamodb-enhanced'
     implementation 'software.amazon.awssdk:secretsmanager'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.graphql:spring-graphql-test'
 }
 
 test {

--- a/messages-java/src/main/java/com/clanboards/messages/config/AuthInterceptor.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/AuthInterceptor.java
@@ -1,0 +1,36 @@
+package com.clanboards.messages.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.graphql.server.WebGraphQlInterceptor;
+import org.springframework.graphql.server.WebGraphQlRequest;
+import org.springframework.graphql.server.WebGraphQlResponse;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.Base64;
+
+@Component
+public class AuthInterceptor implements WebGraphQlInterceptor {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public Mono<WebGraphQlResponse> intercept(WebGraphQlRequest request, Chain chain) {
+        String auth = request.getHeaders().getFirst("Authorization");
+        if (auth != null && auth.startsWith("Bearer ")) {
+            String token = auth.substring(7);
+            String[] parts = token.split("\\.");
+            if (parts.length > 1) {
+                try {
+                    String payload = new String(Base64.getUrlDecoder().decode(parts[1]));
+                    JsonNode node = mapper.readTree(payload);
+                    String sub = node.has("sub") ? node.get("sub").asText() : null;
+                    if (sub != null) {
+                        request.configureExecutionInput((ei, builder) -> builder.graphQLContext(ctx -> ctx.put("userId", sub)).build());
+                    }
+                } catch (Exception ignored) {}
+            }
+        }
+        return chain.next(request);
+    }
+}

--- a/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLController.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLController.java
@@ -1,0 +1,58 @@
+package com.clanboards.messages.controller;
+
+import com.clanboards.messages.graphql.Chat;
+import com.clanboards.messages.graphql.ChatKind;
+import com.clanboards.messages.graphql.Message;
+import com.clanboards.messages.model.ChatMessage;
+import com.clanboards.messages.repository.ChatRepository;
+import com.clanboards.messages.service.ChatService;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.ContextValue;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+@Controller
+public class GraphQLController {
+    private final ChatService chatService;
+
+    public GraphQLController(ChatService chatService) {
+        this.chatService = chatService;
+    }
+
+    @QueryMapping
+    public List<Chat> listChats() {
+        return IntStream.range(0, ChatRepository.SHARD_COUNT)
+                .mapToObj(i -> new Chat("global#shard-" + i, ChatKind.GLOBAL, null, Collections.emptyList(), Instant.EPOCH, null))
+                .toList();
+    }
+
+    @QueryMapping
+    public List<Message> getMessages(@Argument String chatId, @Argument Instant after, @Argument Integer limit) {
+        int lim = limit != null ? limit : 50;
+        List<ChatMessage> msgs = chatService.history(chatId, lim, after);
+        return msgs.stream()
+                .map(m -> new Message(UUID.randomUUID().toString(), m.channel(), m.ts(), m.userId(), m.content()))
+                .toList();
+    }
+
+    @MutationMapping
+    public Message sendMessage(@Argument String chatId, @Argument String content, @ContextValue("userId") String userId) {
+        if (userId == null || userId.isBlank()) {
+            throw new RuntimeException("Unauthenticated");
+        }
+        ChatMessage saved;
+        if (chatId.startsWith("global#")) {
+            saved = chatService.publishGlobal(content, userId);
+        } else {
+            saved = chatService.publish(chatId, content, userId);
+        }
+        return new Message(UUID.randomUUID().toString(), saved.channel(), saved.ts(), saved.userId(), saved.content());
+    }
+}

--- a/messages-java/src/main/java/com/clanboards/messages/graphql/Chat.java
+++ b/messages-java/src/main/java/com/clanboards/messages/graphql/Chat.java
@@ -1,0 +1,13 @@
+package com.clanboards.messages.graphql;
+
+import java.time.Instant;
+import java.util.List;
+
+public record Chat(
+        String id,
+        ChatKind kind,
+        String name,
+        List<String> members,
+        Instant createdAt,
+        Message lastMessage
+) {}

--- a/messages-java/src/main/java/com/clanboards/messages/graphql/ChatKind.java
+++ b/messages-java/src/main/java/com/clanboards/messages/graphql/ChatKind.java
@@ -1,0 +1,5 @@
+package com.clanboards.messages.graphql;
+
+public enum ChatKind {
+    CLAN, GLOBAL, DIRECT
+}

--- a/messages-java/src/main/java/com/clanboards/messages/graphql/Friend.java
+++ b/messages-java/src/main/java/com/clanboards/messages/graphql/Friend.java
@@ -1,0 +1,8 @@
+package com.clanboards.messages.graphql;
+
+import java.time.Instant;
+
+public record Friend(
+        String userId,
+        Instant since
+) {}

--- a/messages-java/src/main/java/com/clanboards/messages/graphql/Message.java
+++ b/messages-java/src/main/java/com/clanboards/messages/graphql/Message.java
@@ -1,0 +1,11 @@
+package com.clanboards.messages.graphql;
+
+import java.time.Instant;
+
+public record Message(
+        String id,
+        String chatId,
+        Instant ts,
+        String senderId,
+        String content
+) {}

--- a/messages-java/src/main/resources/application.properties
+++ b/messages-java/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.graphql.path=/api/v1/chat/graphql

--- a/messages-java/src/main/resources/graphql/schema.graphqls
+++ b/messages-java/src/main/resources/graphql/schema.graphqls
@@ -1,0 +1,42 @@
+enum ChatKind { CLAN GLOBAL DIRECT }
+
+type Chat {
+  id: ID!
+  kind: ChatKind!
+  name: String          # null for DMs
+  members: [User!]!
+  createdAt: String!
+  lastMessage: Message
+}
+
+type Message {
+  id: ID!
+  chatId: ID!
+  ts: String!
+  senderId: ID!
+  content: String!
+}
+
+type Friend {
+  userId: ID!
+  since: String!
+}
+
+type Query {
+  listChats: [Chat!]!
+  getMessages(chatId: ID!, after: String, limit: Int = 50): [Message!]!
+  listFriends: [Friend!]!
+}
+
+type Mutation {
+  createDirectChat(recipientId: ID!): Chat!
+  sendMessage(chatId: ID!, content: String!): Message!
+  sendFriendRequest(to: ID!): ID!                # returns requestId
+  respondFriendRequest(requestId: ID!, accept: Boolean!): Boolean!
+}
+
+type Subscription {
+  onMessage(chatId: ID!): Message
+}
+type User { id: ID! }
+

--- a/messages-java/src/test/java/com/clanboards/messages/GraphQLControllerTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/GraphQLControllerTest.java
@@ -1,0 +1,49 @@
+package com.clanboards.messages;
+
+import com.clanboards.messages.model.ChatMessage;
+import com.clanboards.messages.service.ChatService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Base64;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class GraphQLControllerTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private ChatService chatService;
+
+    private static String token(String sub) {
+        String payload = Base64.getUrlEncoder().withoutPadding().encodeToString(("{\"sub\":\""+sub+"\"}").getBytes());
+        return "x." + payload + ".y";
+    }
+
+    @Test
+    void getMessagesWorks() throws Exception {
+        Instant ts = Instant.parse("2024-01-01T00:00:00Z");
+        List<ChatMessage> msgs = List.of(new ChatMessage("1", "u", "hi", ts));
+        Mockito.when(chatService.history("1", 2, null)).thenReturn(msgs);
+
+        String query = "query($id:ID!,$limit:Int){ getMessages(chatId:$id,limit:$limit){ content } }";
+        mvc.perform(post("/api/v1/chat/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token("u"))
+                .content("{\"query\":\""+query+"\",\"variables\":{\"id\":\"1\",\"limit\":2}}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.getMessages[0].content").value("hi"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring GraphQL dependency and schema
- create GraphQL controller with query and mutation mappings
- capture user ID from JWT in a new auth interceptor
- include tests for GraphQL controller
- update GraphQL path to `/api/v1/chat/graphql`

## Testing
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_6881a4fa74d0832c8bb6c14e80b3230b