### PR TITLE
Fix chat history and friend requests

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -5,6 +5,7 @@ import CachedImage from './components/CachedImage.jsx';
 import Loading from './components/Loading.jsx';
 import PlayerTagForm from './components/PlayerTagForm.jsx';
 import { fetchJSON } from './lib/api.js';
+import { getSub } from './lib/auth.js';
 import useFeatures from './hooks/useFeatures.js';
 import BottomNav from './components/BottomNav.jsx';
 import DesktopNav from './components/DesktopNav.jsx';
@@ -44,6 +45,7 @@ function getInitials(tok) {
   }
 }
 
+
 export default function App() {
   const [token, setToken] = useState(() => {
     const stored = localStorage.getItem('token');
@@ -54,6 +56,7 @@ export default function App() {
     return stored;
   });
   const [initials, setInitials] = useState(() => (token ? getInitials(token) : ''));
+  const [userId, setUserId] = useState(() => (token ? getSub(token) : ''));
   const [playerTag, setPlayerTag] = useState(null);
   const [verified, setVerified] = useState(false);
   const [homeClanTag, setHomeClanTag] = useState(null);
@@ -102,6 +105,7 @@ export default function App() {
 
   useEffect(() => {
     setInitials(token ? getInitials(token) : '');
+    setUserId(token ? getSub(token) : '');
   }, [token]);
 
   useEffect(() => {
@@ -268,7 +272,7 @@ export default function App() {
           <Suspense fallback={<Loading className="py-20" />}>
             <Routes>
               <Route path="/" element={<DashboardPage defaultTag={clanTag} showSearchForm={false} onClanLoaded={setClanInfo} />} />
-              <Route path="/chat" element={<ChatPage verified={verified} chatId={homeClanTag || '1'} userId={playerTag || ''} />} />
+              <Route path="/chat" element={<ChatPage verified={verified} chatId={homeClanTag || '1'} userId={userId} />} />
               <Route path="/scout" element={<ScoutPage />} />
               <Route path="/stats" element={<StatsPage />} />
               <Route path="/account" element={<AccountPage onVerified={() => setVerified(true)} />} />

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -32,7 +32,7 @@ useEffect(() => {
     let ignore = false;
 
     async function loadInfo() {
-      const ids = [...new Set(messages.map((m) => m.userId).filter(Boolean))];
+      const ids = [...new Set(messages.map((m) => m.senderId).filter(Boolean))];
       const missing = ids.filter((id) => !infoMap[id]);
       if (missing.length === 0) {
         setLoading(false);
@@ -117,16 +117,14 @@ useEffect(() => {
               </div>
             </div>
           ) : (
-            messages.map((m, idx) =>
-              infoMap[m.userId] ? (
-                <ChatMessage
-                  key={m.ts || idx}
-                  message={m}
-                  info={infoMap[m.userId]}
-                  isSelf={m.userId === userId}
-                />
-              ) : null
-            )
+            messages.map((m, idx) => (
+              <ChatMessage
+                key={m.ts || idx}
+                message={m}
+                info={infoMap[m.senderId]}
+                isSelf={m.senderId === userId}
+              />
+            ))
           )}
           <div ref={endRef} />
         </div>

--- a/front-end/src/lib/auth.js
+++ b/front-end/src/lib/auth.js
@@ -1,0 +1,14 @@
+export function getJwtPayload(token) {
+  try {
+    const payload = atob(token.split('.')[1]);
+    return JSON.parse(payload);
+  } catch {
+    return null;
+  }
+}
+
+export function getSub(token) {
+  const data = getJwtPayload(token);
+  return data && data.sub ? data.sub : '';
+}
+

--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -6,6 +6,7 @@ import VerifiedBadge from '../components/VerifiedBadge.jsx';
 import ChatBadge from '../components/ChatBadge.jsx';
 import RiskPrioritySelect, { PRESETS } from '../components/RiskPrioritySelect.jsx';
 import { graphqlRequest } from '../lib/gql.js';
+import { getSub } from '../lib/auth.js';
 
 export default function Account({ onVerified }) {
   const [profile, setProfile] = useState(null);
@@ -142,13 +143,19 @@ export default function Account({ onVerified }) {
               onClick={async () => {
                 if (!newFriendId.trim()) return;
                 try {
-                  await graphqlRequest(
-                    `mutation($id: ID!) { sendFriendRequest(to:$id) }`,
-                    { id: newFriendId.trim() },
-                  );
+                  const token = localStorage.getItem('token');
+                  await fetchJSON('/friends/request', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                      fromUserId: getSub(token || ''),
+                      toUserId: newFriendId.trim(),
+                    }),
+                  });
                   setNewFriendId('');
                   alert('Request sent');
-                } catch {
+                } catch (err) {
+                  console.error('Failed to send friend request', err);
                   alert('Failed to send request');
                 }
               }}

--- a/user_service/build.gradle
+++ b/user_service/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'software.amazon.awssdk:dynamodb'
     implementation 'software.amazon.awssdk:dynamodb-enhanced'
     implementation 'software.amazon.awssdk:secretsmanager'
-    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/user_service/src/main/java/com/clanboards/users/config/DatabaseConfig.java
+++ b/user_service/src/main/java/com/clanboards/users/config/DatabaseConfig.java
@@ -1,0 +1,43 @@
+package com.clanboards.users.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+import java.net.URI;
+
+@Configuration
+public class DatabaseConfig {
+    @Bean
+    public DataSource dataSource(
+            @Value("${DATABASE_URL:}") String databaseUrl,
+            @Value("${DATABASE_USERNAME:}") String username,
+            @Value("${DATABASE_PASSWORD:}") String password) throws Exception {
+        if (databaseUrl == null || databaseUrl.isBlank()) {
+            return DataSourceBuilder.create()
+                    .driverClassName("org.h2.Driver")
+                    .url("jdbc:h2:mem:testdb")
+                    .username("sa")
+                    .password("")
+                    .build();
+        }
+        URI uri = new URI(databaseUrl);
+        String userInfo = uri.getUserInfo();
+        if (userInfo != null && (username == null || username.isBlank())) {
+            String[] parts = userInfo.split(":", 2);
+            username = parts[0];
+            if (parts.length > 1) password = parts[1];
+        }
+        String jdbcUrl = "jdbc:postgresql://" + uri.getHost()
+                + (uri.getPort() > 0 ? ":" + uri.getPort() : "")
+                + uri.getPath();
+        return DataSourceBuilder.create()
+                .driverClassName("org.postgresql.Driver")
+                .url(jdbcUrl)
+                .username(username)
+                .password(password)
+                .build();
+    }
+}

--- a/user_service/src/main/resources/application.properties
+++ b/user_service/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
## Summary
- decode ID token to determine user ID
- align chat messages for current user
- always render chat messages even if user info is missing
- send friend requests via REST endpoint with logging
- persist friend requests in PostgreSQL

## Testing
- `nox -s lint tests`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6881caf81ee0832c9762393ba8430621