### PR TITLE
Fix friend request ID handling

### DIFF
--- a/back-end/app/api/user_routes.py
+++ b/back-end/app/api/user_routes.py
@@ -17,6 +17,7 @@ async def _verify_player_token(tag: str, token: str) -> dict:
 def me():
     return jsonify(
         {
+            "id": g.user.id,
             "email": g.user.email,
             "name": g.user.name,
             "player_tag": g.user.player_tag,

--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -16,12 +16,15 @@ export default function Account({ onVerified }) {
   const [showInfo, setShowInfo] = useState(false);
   const [friends, setFriends] = useState([]);
   const [newFriendId, setNewFriendId] = useState('');
+  const [selfId, setSelfId] = useState(null);
 
 
 
   useEffect(() => {
     const load = async () => {
       try {
+        const me = await fetchJSON('/user/me');
+        setSelfId(me.id);
         const data = await fetchJSON('/user/profile');
         setProfile(data);
         const features = await fetchJSON('/user/features');
@@ -141,15 +144,14 @@ export default function Account({ onVerified }) {
             <button
               type="button"
               onClick={async () => {
-                if (!newFriendId.trim()) return;
+                if (!newFriendId.trim() || selfId === null) return;
                 try {
-                  const token = localStorage.getItem('token');
                   await fetchJSON('/friends/request', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                      fromUserId: getSub(token || ''),
-                      toUserId: newFriendId.trim(),
+                      fromUserId: selfId,
+                      toUserId: Number(newFriendId.trim()),
                     }),
                   });
                   setNewFriendId('');

--- a/user_service/src/main/java/com/clanboards/users/controller/FriendController.java
+++ b/user_service/src/main/java/com/clanboards/users/controller/FriendController.java
@@ -27,6 +27,6 @@ public class FriendController {
         return ResponseEntity.ok(Map.of("ok", result));
     }
 
-    public record RequestPayload(String fromUserId, String toUserId) {}
+    public record RequestPayload(Long fromUserId, Long toUserId) {}
     public record RespondPayload(Long requestId, boolean accept) {}
 }

--- a/user_service/src/main/java/com/clanboards/users/model/FriendRequest.java
+++ b/user_service/src/main/java/com/clanboards/users/model/FriendRequest.java
@@ -10,19 +10,19 @@ public class FriendRequest {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String fromUserId;
-    private String toUserId;
+    private Long fromUserId;
+    private Long toUserId;
     private String status;
     private Instant createdAt = Instant.now();
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
 
-    public String getFromUserId() { return fromUserId; }
-    public void setFromUserId(String fromUserId) { this.fromUserId = fromUserId; }
+    public Long getFromUserId() { return fromUserId; }
+    public void setFromUserId(Long fromUserId) { this.fromUserId = fromUserId; }
 
-    public String getToUserId() { return toUserId; }
-    public void setToUserId(String toUserId) { this.toUserId = toUserId; }
+    public Long getToUserId() { return toUserId; }
+    public void setToUserId(Long toUserId) { this.toUserId = toUserId; }
 
     public String getStatus() { return status; }
     public void setStatus(String status) { this.status = status; }

--- a/user_service/src/main/java/com/clanboards/users/service/FriendService.java
+++ b/user_service/src/main/java/com/clanboards/users/service/FriendService.java
@@ -18,7 +18,7 @@ public class FriendService {
         this.table = client.table("chat-friends", TableSchema.fromBean(FriendshipItem.class));
     }
 
-    public Long sendRequest(String fromUserId, String toUserId) {
+    public Long sendRequest(Long fromUserId, Long toUserId) {
         FriendRequest req = new FriendRequest();
         req.setFromUserId(fromUserId);
         req.setToUserId(toUserId);

--- a/user_service/src/test/java/com/clanboards/users/service/FriendServiceTest.java
+++ b/user_service/src/test/java/com/clanboards/users/service/FriendServiceTest.java
@@ -26,7 +26,7 @@ class FriendServiceTest {
         Mockito.when(repo.save(Mockito.any())).thenReturn(saved);
 
         FriendService svc = new FriendService(repo, client);
-        Long id = svc.sendRequest("a", "b");
+        Long id = svc.sendRequest(1L, 2L);
         assertEquals(1L, id);
         ArgumentCaptor<FriendRequest> captor = ArgumentCaptor.forClass(FriendRequest.class);
         Mockito.verify(repo).save(captor.capture());
@@ -37,8 +37,8 @@ class FriendServiceTest {
     void acceptRequestWritesFriends() {
         FriendRequest req = new FriendRequest();
         req.setId(2L);
-        req.setFromUserId("a");
-        req.setToUserId("b");
+        req.setFromUserId(1L);
+        req.setToUserId(2L);
         req.setStatus("PENDING");
 
         FriendRequestRepository repo = Mockito.mock(FriendRequestRepository.class);


### PR DESCRIPTION
## Summary
- expose user id in `/user/me`
- store `fromUserId` and `toUserId` as `Long` in the user service
- adjust friend request controller and service for numeric IDs
- update Account page to send numeric IDs
- update unit tests

## Testing
- `./gradlew test`
- `npm install`
- `npm test`
- `npm run build`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6882454d9fa8832caa8780e6c9e2777d