### PR TITLE
Use sub identifiers across services

### DIFF
--- a/back-end/app/api/user_routes.py
+++ b/back-end/app/api/user_routes.py
@@ -18,6 +18,7 @@ def me():
     return jsonify(
         {
             "id": g.user.id,
+            "sub": g.user.sub,
             "email": g.user.email,
             "name": g.user.name,
             "player_tag": g.user.player_tag,

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -57,6 +57,7 @@ export default function App() {
   });
   const [initials, setInitials] = useState(() => (token ? getInitials(token) : ''));
   const [userId, setUserId] = useState(() => (token ? getSub(token) : ''));
+  const [numericId, setNumericId] = useState(null);
   const [playerTag, setPlayerTag] = useState(null);
   const [verified, setVerified] = useState(false);
   const [homeClanTag, setHomeClanTag] = useState(null);
@@ -116,6 +117,8 @@ export default function App() {
         const me = await fetchJSON('/user/me');
         setPlayerTag(me.player_tag);
         setVerified(me.verified);
+        setUserId(me.sub);
+        setNumericId(me.id);
         if (me.player_tag) {
           const player = await fetchJSON(`/player/${encodeURIComponent(me.player_tag)}`);
           if (player.clanTag) {

--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -15,8 +15,9 @@ export default function Account({ onVerified }) {
   const [chatEnabled, setChatEnabled] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
   const [friends, setFriends] = useState([]);
-  const [newFriendId, setNewFriendId] = useState('');
+  const [newFriendSub, setNewFriendSub] = useState('');
   const [selfId, setSelfId] = useState(null);
+  const [selfSub, setSelfSub] = useState('');
 
 
 
@@ -25,6 +26,7 @@ export default function Account({ onVerified }) {
       try {
         const me = await fetchJSON('/user/me');
         setSelfId(me.id);
+        setSelfSub(me.sub);
         const data = await fetchJSON('/user/profile');
         setProfile(data);
         const features = await fetchJSON('/user/features');
@@ -137,24 +139,24 @@ export default function Account({ onVerified }) {
           <div className="flex gap-2">
             <input
               className="flex-1 border rounded px-2 py-1"
-              placeholder="User ID"
-              value={newFriendId}
-              onChange={(e) => setNewFriendId(e.target.value)}
+              placeholder="User Sub"
+              value={newFriendSub}
+              onChange={(e) => setNewFriendSub(e.target.value)}
             />
             <button
               type="button"
               onClick={async () => {
-                if (!newFriendId.trim() || selfId === null) return;
+                if (!newFriendSub.trim() || !selfSub) return;
                 try {
                   await fetchJSON('/friends/request', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                      fromUserId: selfId,
-                      toUserId: Number(newFriendId.trim()),
+                      fromSub: selfSub,
+                      toSub: newFriendSub.trim(),
                     }),
                   });
-                  setNewFriendId('');
+                  setNewFriendSub('');
                   alert('Request sent');
                 } catch (err) {
                   console.error('Failed to send friend request', err);

--- a/user_service/src/main/java/com/clanboards/users/controller/FriendController.java
+++ b/user_service/src/main/java/com/clanboards/users/controller/FriendController.java
@@ -17,7 +17,7 @@ public class FriendController {
 
     @PostMapping("/request")
     public ResponseEntity<Map<String, Long>> request(@RequestBody RequestPayload payload) {
-        Long id = service.sendRequest(payload.fromUserId(), payload.toUserId());
+        Long id = service.sendRequest(payload.fromSub(), payload.toSub());
         return ResponseEntity.ok(Map.of("id", id));
     }
 
@@ -27,6 +27,6 @@ public class FriendController {
         return ResponseEntity.ok(Map.of("ok", result));
     }
 
-    public record RequestPayload(Long fromUserId, Long toUserId) {}
+    public record RequestPayload(String fromSub, String toSub) {}
     public record RespondPayload(Long requestId, boolean accept) {}
 }

--- a/user_service/src/main/java/com/clanboards/users/model/User.java
+++ b/user_service/src/main/java/com/clanboards/users/model/User.java
@@ -1,0 +1,19 @@
+package com.clanboards.users.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    private Long id;
+    private String sub;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getSub() { return sub; }
+    public void setSub(String sub) { this.sub = sub; }
+}

--- a/user_service/src/main/java/com/clanboards/users/repository/UserRepository.java
+++ b/user_service/src/main/java/com/clanboards/users/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.clanboards.users.repository;
+
+import com.clanboards.users.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findBySub(String sub);
+}

--- a/user_service/src/main/java/com/clanboards/users/service/FriendService.java
+++ b/user_service/src/main/java/com/clanboards/users/service/FriendService.java
@@ -3,6 +3,7 @@ package com.clanboards.users.service;
 import com.clanboards.users.model.FriendRequest;
 import com.clanboards.users.model.FriendshipItem;
 import com.clanboards.users.repository.FriendRequestRepository;
+import com.clanboards.users.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
@@ -11,14 +12,18 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 @Service
 public class FriendService {
     private final FriendRequestRepository repo;
+    private final UserRepository userRepo;
     private final DynamoDbTable<FriendshipItem> table;
 
-    public FriendService(FriendRequestRepository repo, DynamoDbEnhancedClient client) {
+    public FriendService(FriendRequestRepository repo, UserRepository userRepo, DynamoDbEnhancedClient client) {
         this.repo = repo;
+        this.userRepo = userRepo;
         this.table = client.table("chat-friends", TableSchema.fromBean(FriendshipItem.class));
     }
 
-    public Long sendRequest(Long fromUserId, Long toUserId) {
+    public Long sendRequest(String fromSub, String toSub) {
+        Long fromUserId = userRepo.findBySub(fromSub).orElseThrow().getId();
+        Long toUserId = userRepo.findBySub(toSub).orElseThrow().getId();
         FriendRequest req = new FriendRequest();
         req.setFromUserId(fromUserId);
         req.setToUserId(toUserId);

--- a/user_service/src/test/java/com/clanboards/users/service/FriendServiceTest.java
+++ b/user_service/src/test/java/com/clanboards/users/service/FriendServiceTest.java
@@ -3,6 +3,8 @@ package com.clanboards.users.service;
 import com.clanboards.users.model.FriendRequest;
 import com.clanboards.users.model.FriendshipItem;
 import com.clanboards.users.repository.FriendRequestRepository;
+import com.clanboards.users.repository.UserRepository;
+import com.clanboards.users.model.User;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -18,6 +20,7 @@ class FriendServiceTest {
     @Test
     void sendRequestSavesPending() {
         FriendRequestRepository repo = Mockito.mock(FriendRequestRepository.class);
+        UserRepository userRepo = Mockito.mock(UserRepository.class);
         DynamoDbEnhancedClient client = Mockito.mock(DynamoDbEnhancedClient.class);
         DynamoDbTable<FriendshipItem> table = Mockito.mock(DynamoDbTable.class);
         Mockito.when(client.table(Mockito.anyString(), Mockito.any(TableSchema.class))).thenReturn(table);
@@ -25,8 +28,16 @@ class FriendServiceTest {
         saved.setId(1L);
         Mockito.when(repo.save(Mockito.any())).thenReturn(saved);
 
-        FriendService svc = new FriendService(repo, client);
-        Long id = svc.sendRequest(1L, 2L);
+        User from = new User();
+        from.setId(1L);
+        from.setSub("a");
+        User to = new User();
+        to.setId(2L);
+        to.setSub("b");
+        Mockito.when(userRepo.findBySub("a")).thenReturn(Optional.of(from));
+        Mockito.when(userRepo.findBySub("b")).thenReturn(Optional.of(to));
+        FriendService svc = new FriendService(repo, userRepo, client);
+        Long id = svc.sendRequest("a", "b");
         assertEquals(1L, id);
         ArgumentCaptor<FriendRequest> captor = ArgumentCaptor.forClass(FriendRequest.class);
         Mockito.verify(repo).save(captor.capture());
@@ -42,12 +53,13 @@ class FriendServiceTest {
         req.setStatus("PENDING");
 
         FriendRequestRepository repo = Mockito.mock(FriendRequestRepository.class);
+        UserRepository userRepo = Mockito.mock(UserRepository.class);
         Mockito.when(repo.findById(2L)).thenReturn(Optional.of(req));
         DynamoDbEnhancedClient client = Mockito.mock(DynamoDbEnhancedClient.class);
         DynamoDbTable<FriendshipItem> table = Mockito.mock(DynamoDbTable.class);
         Mockito.when(client.table(Mockito.anyString(), Mockito.any(TableSchema.class))).thenReturn(table);
 
-        FriendService svc = new FriendService(repo, client);
+        FriendService svc = new FriendService(repo, userRepo, client);
         boolean result = svc.respond(2L, true);
         assertTrue(result);
         Mockito.verify(table, Mockito.times(2)).putItem(Mockito.any(FriendshipItem.class));


### PR DESCRIPTION
## Summary
- expose `sub` in `/user/me`
- support sub identifiers in friend service
- lookup numeric IDs internally when sending friend requests
- adjust React frontend to use `sub` when sending friend requests
- test friend service with subs

## Testing
- `ruff check back-end coclib db`
- `./gradlew test` in user_service
- `./gradlew test` in messages-java
- `npm install`
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_68825178b58c832ca4ad419f2227ad6d