### PR TITLE
Fix global chat message duplication

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -31,7 +31,7 @@ public class ChatService {
         Instant ts = Instant.now();
         String shard = ChatRepository.globalShardKey(userId);
         ChatMessage msg = new ChatMessage(shard, userId, text, ts);
-        repository.saveGlobalMessage(msg);
+        repository.saveMessage(msg);
         events.publishEvent(new MessageSavedEvent(msg));
         return msg;
     }

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -46,6 +46,6 @@ class ChatServiceTest {
 
         ChatMessage msg = service.publishGlobal("hi", "user1");
         assertEquals(ChatRepository.globalShardKey("user1"), msg.channel());
-        Mockito.verify(repo).saveGlobalMessage(Mockito.any(ChatMessage.class));
+        Mockito.verify(repo).saveMessage(Mockito.any(ChatMessage.class));
     }
 }


### PR DESCRIPTION
## Summary
- stop replicating global chat messages to all shards and save a single copy
- update the ChatService tests

## Testing
- `./gradlew test`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_68827f2e5fcc832c9ac3975f284c3f8f