### PR TITLE
Add infinite scroll to chat

### DIFF
--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -18,7 +18,21 @@ export default function ChatPanel({ chatId = null, userId = '', globalIds = [], 
   const [sending, setSending] = useState(false);
   const [infoMap, setInfoMap] = useState({});
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const endRef = useRef(null);
+  const containerRef = useRef(null);
+
+  async function handleScroll(e) {
+    const el = e.target;
+    if (el.scrollTop < 100 && hasMore && !loadingMore) {
+      setLoadingMore(true);
+      try {
+        await loadMore();
+      } finally {
+        setLoadingMore(false);
+      }
+    }
+  }
 
 useEffect(() => {
   if (endRef.current && typeof endRef.current.scrollIntoView === 'function') {
@@ -123,20 +137,22 @@ useEffect(() => {
         ))}
       </div>
       <>
-        <div className="flex-1 overflow-y-auto min-h-0 space-y-2 p-4 pt-4">
+        <div
+          ref={containerRef}
+          onScroll={handleScroll}
+          data-testid="message-scroll"
+          className="flex-1 overflow-y-auto min-h-0 space-y-2 p-4 pt-4"
+        >
           {tab === 'Clan' && !chatId ? (
             <div className="py-20 text-center text-slate-500 text-sm">
               Please join a clan to chat…
             </div>
           ) : (
             <>
-              {hasMore && !loading && (
-                <button
-                  onClick={loadMore}
-                  className="block mx-auto mb-2 text-sm text-blue-600 underline"
-                >
-                  Load earlier messages
-                </button>
+              {loadingMore && (
+                <div className="text-center text-sm text-slate-500">
+                  Loading more…
+                </div>
               )}
               {loading ? (
                 <div className="py-20">

--- a/front-end/src/components/ChatPanel.test.jsx
+++ b/front-end/src/components/ChatPanel.test.jsx
@@ -2,16 +2,22 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
+const loadMoreMock = vi.fn();
+
 vi.mock('../hooks/useChat.js', () => ({
-  default: () => ({ messages: [], loadMore: vi.fn(), hasMore: false, appendMessage: vi.fn() }),
+  default: () => ({ messages: [], loadMore: loadMoreMock, hasMore: true, appendMessage: vi.fn() }),
 }));
 vi.mock('../hooks/useMultiChat.js', () => ({
-  default: () => ({ messages: [], loadMore: vi.fn(), hasMore: false, appendMessage: vi.fn() }),
+  default: () => ({ messages: [], loadMore: loadMoreMock, hasMore: true, appendMessage: vi.fn() }),
   globalShardFor: () => 'global#shard-0',
 }));
 vi.mock('../lib/api.js', () => ({ fetchJSON: vi.fn(), fetchJSONCached: vi.fn() }));
 
 import ChatPanel from './ChatPanel.jsx';
+
+beforeEach(() => {
+  loadMoreMock.mockClear();
+});
 
 describe('ChatPanel component', () => {
   it('renders input field', () => {
@@ -32,5 +38,12 @@ describe('ChatPanel component', () => {
     fireEvent.click(clanTab);
     expect(screen.getByText('Please join a clan to chat…')).toBeInTheDocument();
     expect(screen.queryByPlaceholderText('Type a message…')).not.toBeInTheDocument();
+  });
+
+  it('loads more when scrolled near top', () => {
+    render(<ChatPanel />);
+    const container = screen.getByTestId('message-scroll');
+    fireEvent.scroll(container, { target: { scrollTop: 50 } });
+    expect(loadMoreMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- enable infinite scrolling in ChatPanel
- test scrolling triggers message fetch

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_6882f6847198832ca0e161696a99049b