### PR TITLE
Show player info on friend requests

### DIFF
--- a/front-end/src/components/PlayerMini.jsx
+++ b/front-end/src/components/PlayerMini.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import { fetchJSONCached } from '../lib/api.js';
+import CachedImage from './CachedImage.jsx';
+
+export default function PlayerMini({ tag }) {
+  const [player, setPlayer] = useState(null);
+
+  useEffect(() => {
+    let ignore = false;
+    async function load() {
+      if (!tag) return;
+      try {
+        const data = await fetchJSONCached(`/player/${encodeURIComponent(tag)}`);
+        if (!ignore) setPlayer(data);
+      } catch {
+        if (!ignore) setPlayer(null);
+      }
+    }
+    load();
+    return () => {
+      ignore = true;
+    };
+  }, [tag]);
+
+  if (!tag) return null;
+  if (!player) return <span>#{tag}</span>;
+
+  return (
+    <span className="flex items-center gap-1">
+      {player.leagueIcon && (
+        <CachedImage src={player.leagueIcon} alt="league" className="w-4 h-4" />
+      )}
+      <span>{player.name}</span>
+      <span className="text-xs text-slate-500">#{player.tag}</span>
+    </span>
+  );
+}

--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -4,6 +4,7 @@ import { fetchJSON } from '../lib/api.js';
 import Loading from '../components/Loading.jsx';
 import VerifiedBadge from '../components/VerifiedBadge.jsx';
 import ChatBadge from '../components/ChatBadge.jsx';
+import PlayerMini from '../components/PlayerMini.jsx';
 import RiskPrioritySelect, { PRESETS } from '../components/RiskPrioritySelect.jsx';
 import { graphqlRequest } from '../lib/gql.js';
 import { getSub } from '../lib/auth.js';
@@ -162,7 +163,9 @@ export default function Account({ onVerified }) {
               <h5 className="text-sm font-medium mt-2">Requests</h5>
               {requests.map((r) => (
                 <div key={r.id} className="flex items-center gap-2 text-sm">
-                  <span className="flex-1">{r.fromUserId}</span>
+                  <span className="flex-1">
+                    <PlayerMini tag={r.playerTag} />
+                  </span>
                   <button
                     className="px-2 py-0.5 rounded bg-green-600 text-white"
                     onClick={async () => {

--- a/user_service/src/main/java/com/clanboards/users/controller/FriendController.java
+++ b/user_service/src/main/java/com/clanboards/users/controller/FriendController.java
@@ -37,12 +37,15 @@ public class FriendController {
     public ResponseEntity<List<PendingPayload>> list(@RequestParam String sub) {
         logger.info("GET /requests sub={}", sub);
         var list = service.listRequests(sub).stream()
-                .map(r -> new PendingPayload(r.getId(), r.getFromUserId()))
+                .map(r -> new PendingPayload(
+                        r.getId(),
+                        r.getFromUserId(),
+                        service.getPlayerTag(r.getFromUserId())))
                 .toList();
         return ResponseEntity.ok(list);
     }
 
     public record RequestPayload(String fromSub, String toTag) {}
     public record RespondPayload(Long requestId, boolean accept) {}
-    public record PendingPayload(Long id, Long fromUserId) {}
+    public record PendingPayload(Long id, Long fromUserId, String playerTag) {}
 }

--- a/user_service/src/main/java/com/clanboards/users/service/FriendService.java
+++ b/user_service/src/main/java/com/clanboards/users/service/FriendService.java
@@ -3,6 +3,7 @@ package com.clanboards.users.service;
 import com.clanboards.users.exception.ResourceNotFoundException;
 import com.clanboards.users.model.FriendRequest;
 import com.clanboards.users.model.FriendshipItem;
+import com.clanboards.users.model.User;
 import com.clanboards.users.repository.FriendRequestRepository;
 import com.clanboards.users.repository.UserRepository;
 import java.util.List;
@@ -24,6 +25,12 @@ public class FriendService {
         this.repo = repo;
         this.userRepo = userRepo;
         this.table = client.table("chat-friends", TableSchema.fromBean(FriendshipItem.class));
+    }
+
+    public String getPlayerTag(Long userId) {
+        return userRepo.findById(userId)
+                .map(User::getPlayerTag)
+                .orElse(null);
     }
 
     public Long sendRequest(String fromSub, String toTag) {


### PR DESCRIPTION
## Summary
- include `playerTag` for friend request listing in user service
- fetch and display player details in friend request list
- add a reusable `PlayerMini` component for small player badges

## Testing
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_6882f639d650832cad19813047ad16f6