### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
     types: [closed]
 
+permissions:
+  contents: read
+
 env:
   AWS_REGION: ${{ secrets.AWS_REGION }}
   ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}


### PR DESCRIPTION
Potential fix for [https://github.com/ChangeinX/coc/security/code-scanning/1](https://github.com/ChangeinX/coc/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to apply to all jobs. This block will explicitly define the least privileges required for the workflow. Based on the provided workflow, the `contents: read` permission is sufficient for most steps, and additional permissions (if any) can be added as needed for specific jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
