### PR TITLE
Refactor PlayerMini usage

### DIFF
--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import CachedImage from './CachedImage.jsx';
+import PlayerMini from './PlayerMini.jsx';
 
 export default function ChatMessage({ message, info, isSelf }) {
   const { content } = message;
+  const senderTag = message.senderId?.startsWith('#')
+    ? message.senderId
+    : message.userId?.startsWith('#')
+    ? message.userId
+    : null;
 
   return (
     <div className={`flex ${isSelf ? 'justify-end' : 'justify-start'}`}>
@@ -11,11 +16,10 @@ export default function ChatMessage({ message, info, isSelf }) {
       >
         {content}
         {info && (
-          <div className="flex items-center gap-1 text-xs text-slate-500 mt-1">
-            {info.icon && (
-              <CachedImage src={info.icon} alt="league" className="w-4 h-4" />
-            )}
-            <span>{info.name}</span>
+          <div className="mt-1 text-xs text-slate-500">
+            <PlayerMini
+              player={{ name: info.name, tag: senderTag, leagueIcon: info.icon }}
+            />
           </div>
         )}
       </div>

--- a/front-end/src/components/ChatMessage.test.jsx
+++ b/front-end/src/components/ChatMessage.test.jsx
@@ -11,7 +11,12 @@ const sample = { name: 'Alice', icon: 'http://ex/icon.png' };
 
 describe('ChatMessage', () => {
   it('displays player name and icon', () => {
-    render(<ChatMessage message={{ content: 'hi' }} info={sample} />);
+    render(
+      <ChatMessage
+        message={{ content: 'hi', senderId: '#AAA' }}
+        info={sample}
+      />
+    );
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.getByAltText('league')).toHaveAttribute('src', sample.icon);
   });

--- a/front-end/src/components/MemberList.jsx
+++ b/front-end/src/components/MemberList.jsx
@@ -4,7 +4,7 @@ import RiskRing from './RiskRing.jsx';
 import DonationRing from './DonationRing.jsx';
 import { timeAgo } from '../lib/time.js';
 import { getTownHallIcon } from '../lib/townhall.js';
-import CachedImage from './CachedImage.jsx';
+import PlayerMini from './PlayerMini.jsx';
 
 function Row({ index, style, data }) {
   const { members, onSelect, refreshing } = data;
@@ -17,15 +17,14 @@ function Row({ index, style, data }) {
     >
       <div className="flex flex-col">
         <div className="flex items-center gap-2">
-          {m.leagueIcon && (
-            <CachedImage src={m.leagueIcon} alt="league" className="w-5 h-5" />
-          )}
           <img
             src={getTownHallIcon(m.townHallLevel)}
             alt={`TH${m.townHallLevel}`}
             className="w-5 h-5"
           />
-          <span className="font-medium">{m.name}</span>
+          <span className="font-medium">
+            <PlayerMini player={m} />
+          </span>
         </div>
         <span className="text-xs text-slate-500">
           {m.last_seen ? timeAgo(m.last_seen) : '\u2014'}

--- a/front-end/src/components/MemberList.test.jsx
+++ b/front-end/src/components/MemberList.test.jsx
@@ -13,5 +13,6 @@ describe('MemberList', () => {
     render(<MemberList members={members} height={400} onSelect={spy} />);
     screen.getByText('Bob').click();
     expect(spy).toHaveBeenCalledWith('#B');
+    expect(screen.getByText('#B')).toBeInTheDocument();
   });
 });

--- a/front-end/src/components/PlayerMini.jsx
+++ b/front-end/src/components/PlayerMini.jsx
@@ -2,15 +2,20 @@ import React, { useEffect, useState } from 'react';
 import { fetchJSONCached } from '../lib/api.js';
 import CachedImage from './CachedImage.jsx';
 
-export default function PlayerMini({ tag }) {
-  const [player, setPlayer] = useState(null);
+export default function PlayerMini({ tag, player: preload }) {
+  const [player, setPlayer] = useState(preload || null);
 
   useEffect(() => {
+    if (preload) {
+      setPlayer(preload);
+      return;
+    }
     let ignore = false;
     async function load() {
-      if (!tag) return;
+      const t = tag || preload?.tag;
+      if (!t) return;
       try {
-        const data = await fetchJSONCached(`/player/${encodeURIComponent(tag)}`);
+        const data = await fetchJSONCached(`/player/${encodeURIComponent(t)}`);
         if (!ignore) setPlayer(data);
       } catch {
         if (!ignore) setPlayer(null);
@@ -20,10 +25,11 @@ export default function PlayerMini({ tag }) {
     return () => {
       ignore = true;
     };
-  }, [tag]);
+  }, [tag, preload]);
 
-  if (!tag) return null;
-  if (!player) return <span>#{tag}</span>;
+  const displayTag = preload?.tag || tag;
+  if (!displayTag) return null;
+  if (!player) return <span>{displayTag}</span>;
 
   return (
     <span className="flex items-center gap-1">
@@ -31,7 +37,7 @@ export default function PlayerMini({ tag }) {
         <CachedImage src={player.leagueIcon} alt="league" className="w-4 h-4" />
       )}
       <span>{player.name}</span>
-      <span className="text-xs text-slate-500">#{player.tag}</span>
+      <span className="text-xs text-slate-500">{player.tag}</span>
     </span>
   );
 }

--- a/front-end/src/components/ProfileCard.jsx
+++ b/front-end/src/components/ProfileCard.jsx
@@ -3,7 +3,7 @@ import RiskRing from './RiskRing.jsx';
 import Loading from './Loading.jsx';
 import { timeAgo } from '../lib/time.js';
 import { getTownHallIcon } from '../lib/townhall.js';
-import CachedImage from './CachedImage.jsx';
+import PlayerMini from './PlayerMini.jsx';
 
 export default function ProfileCard({ member, onClick, refreshing = false }) {
   if (!member) return null;
@@ -17,17 +17,14 @@ export default function ProfileCard({ member, onClick, refreshing = false }) {
           <Loading size={16} />
         </div>
       )}
-      <div className="flex gap-1 mb-1">
-        {member.leagueIcon && (
-          <CachedImage src={member.leagueIcon} alt="league" className="w-6 h-6" />
-        )}
+      <div className="flex gap-1 items-center mb-1">
+        <PlayerMini player={member} />
         <img
           src={getTownHallIcon(member.townHallLevel)}
           alt={`TH${member.townHallLevel}`}
           className="w-6 h-6"
         />
       </div>
-      <p className="font-medium text-center mb-1">{member.name}</p>
       <RiskRing score={member.risk_score} size={48} />
       <div className="mt-2 text-center space-y-1 w-full">
         <p>TH{member.townHallLevel}</p>

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -11,6 +11,7 @@ import ErrorBoundary from '../components/ErrorBoundary.jsx';
 import ProfileCard from '../components/ProfileCard.jsx';
 import { getTownHallIcon } from '../lib/townhall.js';
 import CachedImage from '../components/CachedImage.jsx';
+import PlayerMini from '../components/PlayerMini.jsx';
 import { Users, SearchX } from 'lucide-react';
 
 const winStreakIcon = new URL('../assets/win-streak.svg', import.meta.url).href;
@@ -283,15 +284,12 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                 >
                                                     <td data-label="Player" className="px-4 py-2 font-medium">
                                                         <span className="flex items-center gap-2">
-                                                            {m.leagueIcon && (
-                                                                <CachedImage src={m.leagueIcon} alt="league" className="w-5 h-5" />
-                                                            )}
                                                             <img
                                                                 src={getTownHallIcon(m.townHallLevel)}
                                                                 alt={`TH${m.townHallLevel}`}
                                                                 className="w-5 h-5"
                                                             />
-                                                            {m.name}
+                                                            <PlayerMini player={m} />
                                                         </span>
                                                     </td>
                                                     <td data-label="Tag" className="px-4 py-2 text-slate-500">{m.tag}</td>
@@ -354,15 +352,12 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                         <td data-label="Player" className="px-3 py-2 font-medium">
                                                             <div className="flex flex-col">
                                                                 <span className="flex items-center gap-2">
-                                                                    {m.leagueIcon && (
-                                                                        <CachedImage src={m.leagueIcon} alt="league" className="w-5 h-5" />
-                                                                    )}
                                                                     <img
                                                                         src={getTownHallIcon(m.townHallLevel)}
                                                                         alt={`TH${m.townHallLevel}`}
                                                                         className="w-5 h-5"
                                                                     />
-                                                                    {m.name}
+                                                                    <PlayerMini player={m} />
                                                                 </span>
                                                                 <span className="text-xs text-slate-500">
                                                                     {m.last_seen ? timeAgo(m.last_seen) : '\u2014'}


### PR DESCRIPTION
## Summary
- preload PlayerMini with existing data to avoid extra API requests
- use PlayerMini for league badge/name in ChatMessage, MemberList, ProfileCard and Dashboard
- update related tests
- run front-end build and repo test suite

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6882ffdb30ac832cacbbf70b731e45d3