### PR TITLE
Fix PlayerMini league icon mapping

### DIFF
--- a/front-end/src/components/PlayerMini.jsx
+++ b/front-end/src/components/PlayerMini.jsx
@@ -34,7 +34,12 @@ export default function PlayerMini({ tag, player: preload, showTag = true }) {
   return (
     <span className="flex items-center gap-1">
       {player.leagueIcon && (
-        <CachedImage src={player.leagueIcon} alt="league" className="w-4 h-4" />
+        <CachedImage
+          key={player.tag}
+          src={player.leagueIcon}
+          alt="league"
+          className="w-4 h-4"
+        />
       )}
       <span>{player.name}</span>
       {showTag && player.tag && (


### PR DESCRIPTION
## Summary
- fix PlayerMini so CachedImage remounts when player changes
- keep cached icons aligned with each player

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_688385a03c34832c937e39743e5c608c