### PR TITLE
Fix friend list endpoint

### DIFF
--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -41,12 +41,12 @@ export default function Account({ onVerified }) {
   }, []);
 
   useEffect(() => {
-    if (!chatEnabled) return;
+    if (!chatEnabled || !selfSub) return;
     let ignore = false;
     const load = async () => {
       try {
-        const data = await graphqlRequest('query { listFriends { userId since } }');
-        if (!ignore) setFriends(data.listFriends);
+        const data = await fetchJSON(`/friends/list?sub=${selfSub}`);
+        if (!ignore) setFriends(data);
       } catch {
         if (!ignore) setFriends([]);
       }
@@ -55,7 +55,7 @@ export default function Account({ onVerified }) {
     return () => {
       ignore = true;
     };
-  }, [chatEnabled]);
+  }, [chatEnabled, selfSub]);
 
   useEffect(() => {
     if (!chatEnabled || !selfSub) return;

--- a/user_service/src/main/java/com/clanboards/users/controller/FriendController.java
+++ b/user_service/src/main/java/com/clanboards/users/controller/FriendController.java
@@ -45,6 +45,13 @@ public class FriendController {
         return ResponseEntity.ok(list);
     }
 
+    @GetMapping("/list")
+    public ResponseEntity<List<FriendService.FriendDto>> friends(@RequestParam String sub) {
+        logger.info("GET /list sub={}", sub);
+        var list = service.listFriends(sub);
+        return ResponseEntity.ok(list);
+    }
+
     public record RequestPayload(String fromSub, String toTag) {}
     public record RespondPayload(Long requestId, boolean accept) {}
     public record PendingPayload(Long id, Long fromUserId, String playerTag) {}

--- a/user_service/src/main/java/com/clanboards/users/repository/FriendRequestRepository.java
+++ b/user_service/src/main/java/com/clanboards/users/repository/FriendRequestRepository.java
@@ -2,8 +2,15 @@ package com.clanboards.users.repository;
 
 import com.clanboards.users.model.FriendRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
     List<FriendRequest> findByToUserIdAndStatus(Long toUserId, String status);
+
+    List<FriendRequest> findByFromUserIdAndStatus(Long fromUserId, String status);
+
+    @Query("SELECT f FROM FriendRequest f WHERE (f.fromUserId = :userId OR f.toUserId = :userId) AND f.status = :status")
+    List<FriendRequest> findFriends(@Param("userId") Long userId, @Param("status") String status);
 }

--- a/user_service/src/main/java/com/clanboards/users/service/FriendService.java
+++ b/user_service/src/main/java/com/clanboards/users/service/FriendService.java
@@ -62,4 +62,20 @@ public class FriendService {
                 .getId();
         return repo.findByToUserIdAndStatus(userId, "PENDING");
     }
+
+    public List<FriendDto> listFriends(String sub) {
+        logger.info("Listing friends for {}", sub);
+        Long userId = userRepo.findBySub(sub)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found: " + sub))
+                .getId();
+        List<FriendRequest> records = repo.findFriends(userId, "ACCEPTED");
+        return records.stream()
+                .map(r -> {
+                    Long other = r.getFromUserId().equals(userId) ? r.getToUserId() : r.getFromUserId();
+                    return new FriendDto(other, r.getCreatedAt());
+                })
+                .toList();
+    }
+
+    public record FriendDto(Long userId, java.time.Instant since) {}
 }


### PR DESCRIPTION
## Summary
- add repository query for listing friends
- add service method to resolve accepted friends
- expose `/api/v1/friends/list` endpoint
- show accepted friends via REST instead of GraphQL in front-end

## Testing
- `ruff check back-end coclib db`
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6883bc3844c4832c815eaa5ffe128075