### PR TITLE
Fix friends list display

### DIFF
--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -152,7 +152,9 @@ export default function Account({ onVerified }) {
           <h4 className="text-lg font-medium">Friends</h4>
           <div className="space-y-1">
             {friends.map((f) => (
-              <div key={f.userId} className="text-sm text-slate-700">{f.userId}</div>
+              <div key={f.userId} className="text-sm text-slate-700">
+                <PlayerMini tag={f.playerTag} />
+              </div>
             ))}
             {friends.length === 0 && (
               <div className="text-sm text-slate-500">No friends yet</div>

--- a/user_service/src/main/java/com/clanboards/users/service/FriendService.java
+++ b/user_service/src/main/java/com/clanboards/users/service/FriendService.java
@@ -72,10 +72,10 @@ public class FriendService {
         return records.stream()
                 .map(r -> {
                     Long other = r.getFromUserId().equals(userId) ? r.getToUserId() : r.getFromUserId();
-                    return new FriendDto(other, r.getCreatedAt());
+                    return new FriendDto(other, getPlayerTag(other), r.getCreatedAt());
                 })
                 .toList();
     }
 
-    public record FriendDto(Long userId, java.time.Instant since) {}
+    public record FriendDto(Long userId, String playerTag, java.time.Instant since) {}
 }

--- a/user_service/src/test/java/com/clanboards/users/service/FriendServiceTest.java
+++ b/user_service/src/test/java/com/clanboards/users/service/FriendServiceTest.java
@@ -77,4 +77,33 @@ class FriendServiceTest {
         assertEquals(1, list.size());
         assertEquals(5L, list.get(0).getId());
     }
+
+    @Test
+    void listFriendsIncludesPlayerTag() {
+        FriendRequestRepository repo = Mockito.mock(FriendRequestRepository.class);
+        UserRepository userRepo = Mockito.mock(UserRepository.class);
+
+        User user = new User();
+        user.setId(1L);
+        user.setSub("abc");
+        Mockito.when(userRepo.findBySub("abc")).thenReturn(Optional.of(user));
+
+        User friend = new User();
+        friend.setId(2L);
+        friend.setPlayerTag("#AAA");
+        Mockito.when(userRepo.findById(2L)).thenReturn(Optional.of(friend));
+
+        FriendRequest req = new FriendRequest();
+        req.setId(5L);
+        req.setFromUserId(1L);
+        req.setToUserId(2L);
+        req.setStatus("ACCEPTED");
+        Mockito.when(repo.findFriends(1L, "ACCEPTED")).thenReturn(List.of(req));
+
+        FriendService svc = new FriendService(repo, userRepo);
+        List<FriendService.FriendDto> list = svc.listFriends("abc");
+        assertEquals(1, list.size());
+        assertEquals(2L, list.get(0).userId());
+        assertEquals("#AAA", list.get(0).playerTag());
+    }
 }


### PR DESCRIPTION
## Summary
- show league icon, name and tag for friends in Account page
- expose playerTag from friend service and test it

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6883ca9b57f8832cb80235629561fd11