### PR TITLE
Move friends management into chat

### DIFF
--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PlayerMini from './PlayerMini.jsx';
 
 export default function ChatMessage({ message, info, isSelf }) {
@@ -8,9 +8,26 @@ export default function ChatMessage({ message, info, isSelf }) {
     : message.userId?.startsWith('#')
     ? message.userId
     : null;
+  const timer = useRef(null);
+
+  function triggerAddFriend() {
+    if (senderTag) {
+      window.dispatchEvent(new CustomEvent('open-friend-add', { detail: senderTag }));
+    }
+  }
 
   return (
-    <div className={`flex ${isSelf ? 'justify-end' : 'justify-start'}`}>
+    <div
+      className={`flex ${isSelf ? 'justify-end' : 'justify-start'}`}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        triggerAddFriend();
+      }}
+      onTouchStart={() => {
+        timer.current = setTimeout(triggerAddFriend, 600);
+      }}
+      onTouchEnd={() => clearTimeout(timer.current)}
+    >
       <div
         className={`max-w-[80%] rounded px-2 py-1 ${isSelf ? 'bg-blue-100' : 'bg-slate-100'}`}
       >

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -6,13 +6,14 @@ import useChat from '../hooks/useChat.js';
 import useMultiChat, { globalShardFor } from '../hooks/useMultiChat.js';
 import ChatMessage from './ChatMessage.jsx';
 import Loading from './Loading.jsx';
+import FriendsPanel from './FriendsPanel.jsx';
 
 export default function ChatPanel({ chatId = null, userId = '', globalIds = [], friendIds = [] }) {
-  const [tab, setTab] = useState(chatId ? 'Clan' : 'All');
+  const [tab, setTab] = useState(chatId ? 'Clan' : 'Global');
   const clanChat = chatId ? useChat(chatId) : { messages: [], loadMore: () => {}, hasMore: false, appendMessage: () => {} };
   const globalChat = useMultiChat(globalIds);
   const friendChat = useMultiChat(friendIds);
-  const current = tab === 'Clan' ? clanChat : tab === 'All' ? globalChat : friendChat;
+  const current = tab === 'Clan' ? clanChat : tab === 'Global' ? globalChat : friendChat;
   const { messages, loadMore, hasMore, appendMessage } = current;
   const [text, setText] = useState('');
   const [sending, setSending] = useState(false);
@@ -99,7 +100,7 @@ useEffect(() => {
     if (tab === 'Clan' && !chatId) return;
     setSending(true);
     let targetId = chatId;
-    if (tab === 'All') {
+    if (tab === 'Global') {
       targetId = globalShardFor(userId);
     }
     const localMsg = {
@@ -126,7 +127,7 @@ useEffect(() => {
   return (
     <div className="flex flex-col h-full">
       <div className="flex border-b sticky top-0 bg-white z-10">
-        {['Clan', 'Friends', 'All'].map((t) => (
+        {['Clan', 'Friends', 'Global'].map((t) => (
           <button
             key={t}
             onClick={() => setTab(t)}
@@ -136,7 +137,10 @@ useEffect(() => {
           </button>
         ))}
       </div>
-      <>
+      {tab === 'Friends' ? (
+        <FriendsPanel />
+      ) : (
+        <>
         <div
           ref={containerRef}
           onScroll={handleScroll}
@@ -195,7 +199,8 @@ useEffect(() => {
             </button>
           </form>
         )}
-      </>
+        </>
+      )}
     </div>
   );
 }

--- a/front-end/src/components/ChatPanel.test.jsx
+++ b/front-end/src/components/ChatPanel.test.jsx
@@ -11,7 +11,10 @@ vi.mock('../hooks/useMultiChat.js', () => ({
   default: () => ({ messages: [], loadMore: loadMoreMock, hasMore: true, appendMessage: vi.fn() }),
   globalShardFor: () => 'global#shard-0',
 }));
-vi.mock('../lib/api.js', () => ({ fetchJSON: vi.fn(), fetchJSONCached: vi.fn() }));
+vi.mock('../lib/api.js', () => ({
+  fetchJSON: vi.fn(() => Promise.resolve({})),
+  fetchJSONCached: vi.fn(),
+}));
 
 import ChatPanel from './ChatPanel.jsx';
 

--- a/front-end/src/components/FriendsPanel.jsx
+++ b/front-end/src/components/FriendsPanel.jsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useRef, useState } from 'react';
+import BottomSheet from './BottomSheet.jsx';
+import PlayerMini from './PlayerMini.jsx';
+import { fetchJSON } from '../lib/api.js';
+
+export default function FriendsPanel() {
+  const [friends, setFriends] = useState([]);
+  const [requests, setRequests] = useState([]);
+  const [sub, setSub] = useState('');
+  const [showAdd, setShowAdd] = useState(false);
+  const [showReqs, setShowReqs] = useState(false);
+  const [newTag, setNewTag] = useState('');
+  const inputRef = useRef(null);
+  const prevRequests = useRef([]);
+
+  useEffect(() => {
+    fetchJSON('/user/me')
+      .then((m) => setSub(m.sub))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!sub) return;
+    const load = async () => {
+      try {
+        const list = await fetchJSON(`/friends/list?sub=${sub}`);
+        setFriends(list);
+      } catch {
+        setFriends([]);
+      }
+      try {
+        const reqs = await fetchJSON(`/friends/requests?sub=${sub}`);
+        setRequests(reqs);
+        prevRequests.current = reqs;
+      } catch {
+        setRequests([]);
+        prevRequests.current = [];
+      }
+    };
+    load();
+  }, [sub]);
+
+  useEffect(() => {
+    if (showAdd && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [showAdd]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      setNewTag(e.detail || '');
+      setShowAdd(true);
+    };
+    window.addEventListener('open-friend-add', handler);
+    return () => window.removeEventListener('open-friend-add', handler);
+  }, []);
+
+  const sendRequest = async () => {
+    const trimmed = newTag.trim();
+    if (!trimmed || !sub) return;
+    const temp = { id: Date.now(), playerTag: trimmed };
+    setRequests((r) => [...r, temp]);
+    setShowAdd(false);
+    setNewTag('');
+    try {
+      await fetchJSON('/friends/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fromSub: sub, toTag: trimmed }),
+      });
+    } catch {
+      setRequests((r) => r.filter((x) => x.id !== temp.id));
+      alert('Failed to send request');
+    }
+  };
+
+  const respond = async (req, accept) => {
+    try {
+      await fetchJSON('/friends/respond', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId: req.id, accept }),
+      });
+      setRequests((r) => r.filter((x) => x.id !== req.id));
+      if (accept) {
+        setFriends((f) => [...f, { userId: req.fromUserId, playerTag: req.playerTag }]);
+      }
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between p-2 border-b">
+        <h4 className="font-medium flex items-center gap-2">
+          Friends
+          {requests.length > 0 && (
+            <button
+              onClick={() => setShowReqs(true)}
+              className="bg-blue-600 text-white rounded-full px-2 py-0.5 text-xs"
+            >
+              Pending {requests.length}
+            </button>
+          )}
+        </h4>
+        <button
+          className="w-8 h-8 rounded-full bg-blue-600 text-white flex items-center justify-center"
+          onClick={() => setShowAdd(true)}
+        >
+          +
+        </button>
+      </div>
+      <div className="p-4 space-y-2 overflow-y-auto flex-1">
+        {friends.map((f) => (
+          <div key={f.userId || f.playerTag} className="flex items-center gap-2">
+            <PlayerMini tag={f.playerTag} />
+            {requests.some((r) => r.playerTag === f.playerTag) && (
+              <span className="text-xs text-slate-500">\u23F3 Pending</span>
+            )}
+          </div>
+        ))}
+        {friends.length === 0 && (
+          <div className="text-sm text-slate-500">No friends yet</div>
+        )}
+      </div>
+
+      <BottomSheet open={showAdd} onClose={() => setShowAdd(false)}>
+        <div className="p-4 space-y-2">
+          <input
+            ref={inputRef}
+            className="w-full border rounded px-3 py-2"
+            placeholder="Player Tag"
+            value={newTag}
+            onChange={(e) => setNewTag(e.target.value)}
+          />
+          <button
+            className="w-full px-4 py-2 rounded bg-blue-600 text-white"
+            onClick={sendRequest}
+          >
+            Send
+          </button>
+        </div>
+      </BottomSheet>
+
+      <BottomSheet open={showReqs} onClose={() => setShowReqs(false)}>
+        <div className="p-4 space-y-2">
+          {requests.map((r) => (
+            <div key={r.id} className="flex items-center gap-2 text-sm">
+              <span className="flex-1">
+                <PlayerMini tag={r.playerTag} />
+              </span>
+              <button
+                className="px-2 py-0.5 rounded bg-green-600 text-white"
+                onClick={() => respond(r, true)}
+              >
+                Accept
+              </button>
+              <button
+                className="px-2 py-0.5 rounded bg-red-600 text-white"
+                onClick={() => respond(r, false)}
+              >
+                Reject
+              </button>
+            </div>
+          ))}
+          {requests.length === 0 && (
+            <div className="text-sm text-slate-500">No requests</div>
+          )}
+        </div>
+      </BottomSheet>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- relocate friend management out of the account page
- implement new `FriendsPanel` on chat page
- add FAB and pending pill in friends tab
- long-press messages to add friend
- rename chat tab All -> Global

## Testing
- `npm install`
- `npm test`
- `npm run build`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6883d1f98384832c93fe18654a4381cc