### PR TITLE
Fix friend request direction bug and enable chat long press

### DIFF
--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -7,7 +7,7 @@ export default function ChatMessage({ message, info, isSelf }) {
     ? message.senderId
     : message.userId?.startsWith('#')
     ? message.userId
-    : null;
+    : info?.tag || null;
   const timer = useRef(null);
 
   function triggerAddFriend() {
@@ -18,12 +18,13 @@ export default function ChatMessage({ message, info, isSelf }) {
 
   return (
     <div
-      className={`flex ${isSelf ? 'justify-end' : 'justify-start'}`}
+      className={`flex ${isSelf ? 'justify-end' : 'justify-start'} select-none`}
       onContextMenu={(e) => {
         e.preventDefault();
         triggerAddFriend();
       }}
-      onTouchStart={() => {
+      onTouchStart={(e) => {
+        e.preventDefault();
         timer.current = setTimeout(triggerAddFriend, 600);
       }}
       onTouchEnd={() => clearTimeout(timer.current)}

--- a/front-end/src/components/ChatMessage.test.jsx
+++ b/front-end/src/components/ChatMessage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 vi.mock('../hooks/useCachedIcon.js', () => ({
@@ -20,5 +20,19 @@ describe('ChatMessage', () => {
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.getByAltText('league')).toHaveAttribute('src', sample.icon);
     expect(screen.queryByText('#A1B2C')).not.toBeInTheDocument();
+  });
+
+  it('dispatches add friend event on context menu', () => {
+    const handler = vi.fn();
+    window.addEventListener('open-friend-add', handler);
+    render(
+      <ChatMessage
+        message={{ content: 'yo', senderId: '123' }}
+        info={{ ...sample, tag: '#TAG' }}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByText('yo'));
+    expect(handler).toHaveBeenCalledTimes(1);
+    window.removeEventListener('open-friend-add', handler);
   });
 });

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -79,7 +79,11 @@ useEffect(() => {
       missing.forEach((id, idx) => {
         const data = fetched[idx];
         if (data) {
-          updated[id] = { name: data.name, icon: data.leagueIcon };
+          updated[id] = {
+            name: data.name,
+            icon: data.leagueIcon,
+            tag: data.tag,
+          };
         }
       });
       setInfoMap(updated);

--- a/user_service/src/main/java/com/clanboards/users/exception/GlobalExceptionHandler.java
+++ b/user_service/src/main/java/com/clanboards/users/exception/GlobalExceptionHandler.java
@@ -19,6 +19,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", ex.getMessage()));
     }
 
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<Map<String, String>> handleBadRequest(InvalidRequestException ex) {
+        logger.warn("Bad request: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", ex.getMessage()));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, String>> handleException(Exception ex) {
         logger.error("Unhandled error", ex);

--- a/user_service/src/main/java/com/clanboards/users/exception/InvalidRequestException.java
+++ b/user_service/src/main/java/com/clanboards/users/exception/InvalidRequestException.java
@@ -1,0 +1,7 @@
+package com.clanboards.users.exception;
+
+public class InvalidRequestException extends RuntimeException {
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/user_service/src/main/java/com/clanboards/users/service/FriendService.java
+++ b/user_service/src/main/java/com/clanboards/users/service/FriendService.java
@@ -1,6 +1,7 @@
 package com.clanboards.users.service;
 
 import com.clanboards.users.exception.ResourceNotFoundException;
+import com.clanboards.users.exception.InvalidRequestException;
 import com.clanboards.users.model.FriendRequest;
 import com.clanboards.users.model.User;
 import com.clanboards.users.repository.FriendRequestRepository;
@@ -35,6 +36,9 @@ public class FriendService {
         Long toUserId = userRepo.findByPlayerTag(toTag)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found: " + toTag))
                 .getId();
+        if (fromUserId.equals(toUserId)) {
+            throw new InvalidRequestException("Cannot send friend request to yourself");
+        }
         FriendRequest req = new FriendRequest();
         req.setFromUserId(fromUserId);
         req.setToUserId(toUserId);

--- a/user_service/src/test/java/com/clanboards/users/service/FriendServiceTest.java
+++ b/user_service/src/test/java/com/clanboards/users/service/FriendServiceTest.java
@@ -4,6 +4,7 @@ import com.clanboards.users.model.FriendRequest;
 import com.clanboards.users.repository.FriendRequestRepository;
 import com.clanboards.users.repository.UserRepository;
 import com.clanboards.users.model.User;
+import com.clanboards.users.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -36,6 +37,22 @@ class FriendServiceTest {
         ArgumentCaptor<FriendRequest> captor = ArgumentCaptor.forClass(FriendRequest.class);
         Mockito.verify(repo).save(captor.capture());
         assertEquals("PENDING", captor.getValue().getStatus());
+    }
+
+    @Test
+    void sendRequestToSelfThrows() {
+        FriendRequestRepository repo = Mockito.mock(FriendRequestRepository.class);
+        UserRepository userRepo = Mockito.mock(UserRepository.class);
+
+        User user = new User();
+        user.setId(1L);
+        user.setSub("a");
+        user.setPlayerTag("AA");
+        Mockito.when(userRepo.findBySub("a")).thenReturn(Optional.of(user));
+        Mockito.when(userRepo.findByPlayerTag("AA")).thenReturn(Optional.of(user));
+
+        FriendService svc = new FriendService(repo, userRepo);
+        assertThrows(InvalidRequestException.class, () -> svc.sendRequest("a", "AA"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- prevent sending friend requests to yourself
- expose player tag info in chat panel
- use info tag in chat messages and improve long press handling
- test friend service guard and chat message interaction

## Testing
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6883e0fa2908832c9ce27a26b22efb79