### PR TITLE
Fix chat message click to add friend

### DIFF
--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -19,6 +19,7 @@ export default function ChatMessage({ message, info, isSelf }) {
   return (
     <div
       className={`flex ${isSelf ? 'justify-end' : 'justify-start'} select-none`}
+      onClick={() => triggerAddFriend()}
       onContextMenu={(e) => {
         e.preventDefault();
         triggerAddFriend();

--- a/front-end/src/components/ChatMessage.test.jsx
+++ b/front-end/src/components/ChatMessage.test.jsx
@@ -35,4 +35,18 @@ describe('ChatMessage', () => {
     expect(handler).toHaveBeenCalledTimes(1);
     window.removeEventListener('open-friend-add', handler);
   });
+
+  it('dispatches add friend event on click', () => {
+    const handler = vi.fn();
+    window.addEventListener('open-friend-add', handler);
+    render(
+      <ChatMessage
+        message={{ content: 'yo', senderId: '123' }}
+        info={{ ...sample, tag: '#TAG' }}
+      />,
+    );
+    fireEvent.click(screen.getByText('yo'));
+    expect(handler).toHaveBeenCalledTimes(1);
+    window.removeEventListener('open-friend-add', handler);
+  });
 });


### PR DESCRIPTION
## Summary
- dispatch `open-friend-add` on click in `ChatMessage`
- test click event for add friend

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6883e6f98ddc832cb16fb915e734e180