### PR TITLE
Implement direct chat creation

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLController.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLController.java
@@ -37,6 +37,16 @@ public class GraphQLController {
                 .toList();
     }
 
+    @MutationMapping
+    public Chat createDirectChat(@Argument String recipientId, @ContextValue("userId") String userId) {
+        if (userId == null || userId.isBlank()) {
+            throw new RuntimeException("Unauthenticated");
+        }
+        log.info("GraphQL createDirectChat {} -> {}", userId, recipientId);
+        String id = chatService.createDirectChat(userId, recipientId);
+        return new Chat(id, ChatKind.DIRECT, null, List.of(userId, recipientId), Instant.now(), null);
+    }
+
     @QueryMapping
     public List<Message> getMessages(@Argument String chatId, @Argument Instant after, @Argument Integer limit) {
         int lim = limit != null ? limit : 50;

--- a/messages-java/src/main/java/com/clanboards/messages/repository/ChatRepository.java
+++ b/messages-java/src/main/java/com/clanboards/messages/repository/ChatRepository.java
@@ -37,6 +37,13 @@ public class ChatRepository {
         return "global#shard-" + Math.floorMod(userId.hashCode(), SHARD_COUNT);
     }
 
+    public static String directChatId(String a, String b) {
+        if (a.compareTo(b) < 0) {
+            return "direct#" + a + "#" + b;
+        }
+        return "direct#" + b + "#" + a;
+    }
+
     static String pk(String chatId) {
         return "CHAT#" + chatId;
     }

--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -22,6 +22,12 @@ public class ChatService {
         this.events = events;
     }
 
+    public String createDirectChat(String fromUserId, String toUserId) {
+        String id = ChatRepository.directChatId(fromUserId, toUserId);
+        repository.createChatIfAbsent(id);
+        return id;
+    }
+
     public ChatMessage publish(String chatId, String text, String userId) {
         log.info("Publishing message to chat {} by {}", chatId, userId);
         try {

--- a/messages-java/src/test/java/com/clanboards/messages/GraphQLControllerTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/GraphQLControllerTest.java
@@ -46,4 +46,18 @@ class GraphQLControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.getMessages[0].content").value("hi"));
     }
+
+    @Test
+    void createDirectChatWorks() throws Exception {
+        Mockito.when(chatService.createDirectChat("u", "v")).thenReturn("direct#u#v");
+
+        String query = "mutation($id:ID!){ createDirectChat(recipientId:$id){ id } }";
+        mvc.perform(post("/api/v1/chat/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token("u"))
+                .content("{\"query\":\""+query+"\",\"variables\":{\"id\":\"v\"}}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.createDirectChat.id").value("direct#u#v"));
+        Mockito.verify(chatService).createDirectChat("u", "v");
+    }
 }

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -48,4 +48,15 @@ class ChatServiceTest {
         assertEquals(ChatRepository.globalShardKey("user1"), msg.channel());
         Mockito.verify(repo).saveMessage(Mockito.any(ChatMessage.class));
     }
+
+    @Test
+    void createDirectChatCreatesChat() {
+        ChatRepository repo = Mockito.mock(ChatRepository.class);
+        ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
+        ChatService service = new ChatService(repo, events);
+
+        String id = service.createDirectChat("a", "b");
+        assertEquals(ChatRepository.directChatId("a", "b"), id);
+        Mockito.verify(repo).createChatIfAbsent(id);
+    }
 }


### PR DESCRIPTION
## Summary
- support direct chat in chat service
- expose `createDirectChat` mutation in GraphQL controller
- expose deterministic direct chat IDs
- add unit tests

## Testing
- `nox -s lint tests`
- `ruff check back-end coclib`
- `./gradlew test` in messages-java


------
https://chatgpt.com/codex/tasks/task_e_68840b7d3cb8832c9f721d8e2b0a485c