### PR TITLE
Improve broker availability logging

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/events/BrokerStatusListener.java
+++ b/messages-java/src/main/java/com/clanboards/messages/events/BrokerStatusListener.java
@@ -1,0 +1,26 @@
+package com.clanboards.messages.events;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.broker.BrokerAvailabilityEvent;
+import org.springframework.stereotype.Component;
+
+/**
+ * Logs broker availability changes so operations staff can track when the
+ * in-memory STOMP broker goes down or comes back online.
+ */
+@Component
+public class BrokerStatusListener {
+    private static final Logger log = LoggerFactory.getLogger(BrokerStatusListener.class);
+
+    @EventListener
+    public void handleBrokerEvent(BrokerAvailabilityEvent event) {
+        if (event.isBrokerAvailable()) {
+            log.info("STOMP broker became available");
+        } else {
+            // include the event's string form which identifies the handler
+            log.warn("STOMP broker became unavailable: {}", event.toString());
+        }
+    }
+}

--- a/messages-java/src/main/resources/logback-spring.xml
+++ b/messages-java/src/main/resources/logback-spring.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.springframework.messaging.simp.broker" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- log STOMP broker availability changes
- configure Logback for production

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_688418ad7220832c9dffd0ed1027a960