### PR TITLE
Fix player token verification

### DIFF
--- a/back-end/app/api/user_routes.py
+++ b/back-end/app/api/user_routes.py
@@ -9,7 +9,7 @@ from . import API_PREFIX
 bp = Blueprint("user", __name__, url_prefix=f"{API_PREFIX}/user")
 
 
-async def _verify_player_token(tag: str, token: str) -> dict:
+async def _verify_player_token(tag: str, token: str) -> bool:
     return await verify_player_token(tag, token)
 
 
@@ -83,9 +83,9 @@ async def verify_player():
     if g.user.is_verified:
         abort(400)
     result = await _verify_player_token(g.user.player_tag, token)
-    if result.get("status") != "ok":
+    if not result:
         abort(400)
-    g.user.player_tag = normalize_tag(result.get("tag", g.user.player_tag))
+    g.user.player_tag = normalize_tag(g.user.player_tag)
     g.user.is_verified = True
     db.session.add(g.user)
     db.session.commit()

--- a/coclib/services/player_service.py
+++ b/coclib/services/player_service.py
@@ -20,7 +20,7 @@ async def _fetch_player(tag: str) -> dict:
     return (await client.get_player(tag))._raw_data
 
 
-async def verify_token(tag: str, token: str) -> dict:
+async def verify_token(tag: str, token: str) -> bool:
     """Verify a player's API token via the Clash of Clans API."""
     client = await get_client()
     return await client.verify_player_token(player_tag=tag, token=token)

--- a/tests/test_user_verification.py
+++ b/tests/test_user_verification.py
@@ -23,7 +23,7 @@ def _mock_verify(monkeypatch):
 
 
 async def dummy_verify(tag: str, token: str):
-    return {"tag": f"#{tag}", "token": token, "status": "ok"}
+    return True
 
 
 def test_verify_sets_flag(monkeypatch):


### PR DESCRIPTION
## Summary
- correct `verify_token` return type in player service
- adjust user verification route to expect a boolean
- update the verification test for new behaviour

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_688435766a64832c98e7af5fa17439bc