### PR TITLE
Fix direct chat id mismatch

### DIFF
--- a/user_service/src/main/java/com/clanboards/users/controller/FriendController.java
+++ b/user_service/src/main/java/com/clanboards/users/controller/FriendController.java
@@ -39,7 +39,7 @@ public class FriendController {
         var list = service.listRequests(sub).stream()
                 .map(r -> new PendingPayload(
                         r.getId(),
-                        r.getFromUserId(),
+                        service.getSub(r.getFromUserId()),
                         service.getPlayerTag(r.getFromUserId())))
                 .toList();
         return ResponseEntity.ok(list);
@@ -61,6 +61,6 @@ public class FriendController {
 
     public record RequestPayload(String fromSub, String toTag) {}
     public record RespondPayload(Long requestId, boolean accept) {}
-    public record PendingPayload(Long id, Long fromUserId, String playerTag) {}
+    public record PendingPayload(Long id, String fromUserId, String playerTag) {}
     public record RemovePayload(String fromSub, String toTag) {}
 }

--- a/user_service/src/main/java/com/clanboards/users/service/FriendService.java
+++ b/user_service/src/main/java/com/clanboards/users/service/FriendService.java
@@ -28,6 +28,12 @@ public class FriendService {
                 .orElse(null);
     }
 
+    public String getSub(Long userId) {
+        return userRepo.findById(userId)
+                .map(User::getSub)
+                .orElse(null);
+    }
+
     public Long sendRequest(String fromSub, String toTag) {
         logger.info("Requesting friend from {} to {}", fromSub, toTag);
         Long fromUserId = userRepo.findBySub(fromSub)
@@ -76,7 +82,7 @@ public class FriendService {
         return records.stream()
                 .map(r -> {
                     Long other = r.getFromUserId().equals(userId) ? r.getToUserId() : r.getFromUserId();
-                    return new FriendDto(other, getPlayerTag(other), r.getCreatedAt());
+                    return new FriendDto(getSub(other), getPlayerTag(other), r.getCreatedAt());
                 })
                 .toList();
     }
@@ -99,5 +105,5 @@ public class FriendService {
         return false;
     }
 
-    public record FriendDto(Long userId, String playerTag, java.time.Instant since) {}
+    public record FriendDto(String userId, String playerTag, java.time.Instant since) {}
 }

--- a/user_service/src/test/java/com/clanboards/users/service/FriendServiceTest.java
+++ b/user_service/src/test/java/com/clanboards/users/service/FriendServiceTest.java
@@ -107,6 +107,7 @@ class FriendServiceTest {
 
         User friend = new User();
         friend.setId(2L);
+        friend.setSub("other");
         friend.setPlayerTag("#AAA");
         Mockito.when(userRepo.findById(2L)).thenReturn(Optional.of(friend));
 
@@ -120,7 +121,7 @@ class FriendServiceTest {
         FriendService svc = new FriendService(repo, userRepo);
         List<FriendService.FriendDto> list = svc.listFriends("abc");
         assertEquals(1, list.size());
-        assertEquals(2L, list.get(0).userId());
+        assertEquals("other", list.get(0).userId());
         assertEquals("#AAA", list.get(0).playerTag());
     }
 }


### PR DESCRIPTION
## Summary
- expose a `getSub` helper
- return subs from friend API endpoints
- update friend service tests

## Testing
- `./gradlew test`
- `ruff check back-end coclib db`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_68843b0368e8832cbc580dd7c46aea04