### PR TITLE
Improve friend chat interactions

### DIFF
--- a/front-end/src/components/AddFriendDialog.jsx
+++ b/front-end/src/components/AddFriendDialog.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import BottomSheet from './BottomSheet.jsx';
+import PlayerMini from './PlayerMini.jsx';
 import { fetchJSON, fetchJSONWithError } from '../lib/api.js';
 
 export default function AddFriendDialog({ sub: propSub = null, friends: propFriends = null }) {
   const [open, setOpen] = useState(false);
   const [mode, setMode] = useState('add');
   const [tag, setTag] = useState('');
+  const [prepopulated, setPrepopulated] = useState(false);
   const [sub, setSub] = useState(propSub);
   const [friends, setFriends] = useState(propFriends || []);
   const inputRef = useRef(null);
@@ -22,6 +24,7 @@ export default function AddFriendDialog({ sub: propSub = null, friends: propFrie
     const handler = async (e) => {
       const t = e.detail || '';
       setTag(t);
+      setPrepopulated(!!t);
       let curSub = propSub || sub;
       let curFriends = propFriends || friends;
       if (!propSub || !propFriends) {
@@ -61,6 +64,7 @@ export default function AddFriendDialog({ sub: propSub = null, friends: propFrie
     if (!trimmed || !sub) return;
     setOpen(false);
     setTag('');
+    setPrepopulated(false);
     try {
       await fetchJSONWithError('/friends/request', {
         method: 'POST',
@@ -84,27 +88,42 @@ export default function AddFriendDialog({ sub: propSub = null, friends: propFrie
       alert('Failed to remove friend');
     }
     setOpen(false);
+    setPrepopulated(false);
   };
 
   return (
-    <BottomSheet open={open} onClose={() => setOpen(false)}>
+    <BottomSheet open={open} onClose={() => { setOpen(false); setPrepopulated(false); }}>
       <div className="p-4 space-y-2">
         {mode === 'add' ? (
-          <>
-            <input
-              ref={inputRef}
-              className="w-full border rounded px-3 py-2"
-              placeholder="Player Tag"
-              value={tag}
-              onChange={(e) => setTag(e.target.value)}
-            />
-            <button
-              className="w-full px-4 py-2 rounded bg-blue-600 text-white"
-              onClick={sendRequest}
-            >
-              Send
-            </button>
-          </>
+          prepopulated && tag ? (
+            <>
+              <div className="text-center">
+                <PlayerMini tag={tag} showTag={false} />
+              </div>
+              <button
+                className="w-full px-4 py-2 rounded bg-blue-600 text-white"
+                onClick={sendRequest}
+              >
+                Add Friend
+              </button>
+            </>
+          ) : (
+            <>
+              <input
+                ref={inputRef}
+                className="w-full border rounded px-3 py-2"
+                placeholder="Player Tag"
+                value={tag}
+                onChange={(e) => setTag(e.target.value)}
+              />
+              <button
+                className="w-full px-4 py-2 rounded bg-blue-600 text-white"
+                onClick={sendRequest}
+              >
+                Send
+              </button>
+            </>
+          )
         ) : (
           <>
             <div className="text-center text-sm">Unfriend {tag}?</div>

--- a/front-end/src/components/AddFriendDialog.test.jsx
+++ b/front-end/src/components/AddFriendDialog.test.jsx
@@ -1,5 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('../lib/api.js', () => ({
+  fetchJSONCached: vi.fn().mockResolvedValue({ name: 'Foo', tag: '#XYZ', leagueIcon: 'http://ex/icon.png' }),
+  fetchJSON: vi.fn(),
+  fetchJSONWithError: vi.fn(),
+  API_URL: '',
+}));
+
 import AddFriendDialog from './AddFriendDialog.jsx';
 
 describe('AddFriendDialog', () => {
@@ -13,5 +22,12 @@ describe('AddFriendDialog', () => {
     render(<AddFriendDialog sub="s" friends={[{ playerTag: '#ABC' }]} />);
     window.dispatchEvent(new CustomEvent('open-friend-add', { detail: '#ABC' }));
     expect(await screen.findByText('Unfriend #ABC?')).toBeInTheDocument();
+  });
+
+  it('shows player info when tag provided', async () => {
+    render(<AddFriendDialog sub="1" friends={[]} />);
+    window.dispatchEvent(new CustomEvent('open-friend-add', { detail: '#XYZ' }));
+    expect(await screen.findByText('Foo')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Player Tag')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- show friend info in AddFriendDialog when prepopulated with tag
- allow tapping friend to jump straight to chat
- long press friends to confirm removal
- make requests and friend list show player name and icon

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_688451888ae8832c919b41044e08b289