### PR TITLE
Add row style option for Friends view

### DIFF
--- a/front-end/src/components/FriendsPanel.test.jsx
+++ b/front-end/src/components/FriendsPanel.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+const friends = [{ userId: '1', playerTag: '#AAA' }];
+
+vi.mock('../lib/api.js', () => ({
+  fetchJSON: vi.fn(() => Promise.resolve({ sub: '1' })),
+  fetchJSONCached: vi.fn((url) => {
+    if (url.startsWith('/friends/list')) return Promise.resolve(friends);
+    if (url.startsWith('/friends/requests')) return Promise.resolve([]);
+    if (url.startsWith('/player/'))
+      return Promise.resolve({ name: 'Alice', tag: '#AAA', leagueIcon: '' });
+    return Promise.resolve({});
+  }),
+}));
+vi.mock('../lib/gql.js', () => ({ graphqlRequest: vi.fn() }));
+
+import FriendsPanel from './FriendsPanel.jsx';
+
+describe('FriendsPanel', () => {
+  it('toggles row view', async () => {
+    render(<FriendsPanel onSelectChat={() => {}} />);
+    await screen.findByText('Friends');
+    const toggle = screen.getByRole('button', { name: /row view/i });
+    fireEvent.click(toggle);
+    const container = screen.getByTestId('friends-container');
+    expect(container).toHaveClass('overflow-x-auto');
+  });
+});

--- a/front-end/src/components/PlayerAvatar.jsx
+++ b/front-end/src/components/PlayerAvatar.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { fetchJSONCached } from '../lib/api.js';
+import CachedImage from './CachedImage.jsx';
+
+export default function PlayerAvatar({ tag, player: preload = null, showName = true, className = '', ...props }) {
+  const [player, setPlayer] = useState(preload);
+
+  useEffect(() => {
+    if (preload) return;
+    if (!tag) return;
+    let ignore = false;
+    async function load() {
+      try {
+        const data = await fetchJSONCached(`/player/${encodeURIComponent(tag)}`);
+        if (!ignore) setPlayer(data);
+      } catch {
+        if (!ignore) setPlayer(null);
+      }
+    }
+    load();
+    return () => {
+      ignore = true;
+    };
+  }, [tag, preload]);
+
+  const name = player?.name || tag;
+
+  return (
+    <div className={`flex flex-col items-center w-16 ${className}`} {...props}>
+      {player?.leagueIcon ? (
+        <CachedImage src={player.leagueIcon} alt="league" className="w-12 h-12 rounded-full" />
+      ) : (
+        <div className="w-12 h-12 rounded-full bg-slate-300 flex items-center justify-center text-lg font-semibold">
+          {name ? name.charAt(0) : '?'}
+        </div>
+      )}
+      {showName && <span className="text-xs mt-1 truncate w-12 text-center">{name}</span>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `PlayerAvatar` for small player icons
- update `FriendsPanel` with row/stack toggle and persistence
- test row view toggle

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_6884579f68a0832c91ab40403fac2e34