### PR TITLE
Enhance friends list layout

### DIFF
--- a/front-end/src/components/FriendThread.jsx
+++ b/front-end/src/components/FriendThread.jsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PlayerMini from './PlayerMini.jsx';
+import PlayerAvatar from './PlayerAvatar.jsx';
+
+export default function FriendThread({ friend, pending, onOpen, onRemove }) {
+  const longPress = useRef(false);
+  const timer = useRef(null);
+  const startX = useRef(0);
+  const [offset, setOffset] = useState(0);
+  const ref = useRef(null);
+
+  function handlePointerDown(e) {
+    ref.current?.classList.add('active');
+    if (e.pointerType !== 'mouse') {
+      longPress.current = false;
+      timer.current = setTimeout(() => {
+        longPress.current = true;
+        onRemove && onRemove(friend);
+      }, 600);
+    } else if (e.button === 2) {
+      e.preventDefault();
+      longPress.current = true;
+      onRemove && onRemove(friend);
+    }
+    startX.current = e.clientX;
+  }
+
+  function handlePointerUp() {
+    clearTimeout(timer.current);
+    ref.current?.classList.remove('active');
+    if (Math.abs(offset) > 40) {
+      setOffset(offset < -40 ? -88 : 0);
+      return;
+    }
+    if (!longPress.current) {
+      onOpen && onOpen(friend);
+    }
+    setOffset(0);
+  }
+
+  function handleCancel() {
+    clearTimeout(timer.current);
+    ref.current?.classList.remove('active');
+  }
+
+  function handlePointerMove(e) {
+    if (!startX.current) return;
+    const dx = e.clientX - startX.current;
+    if (dx < 0) setOffset(Math.max(-88, dx));
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === 'Delete') {
+      onRemove && onRemove(friend);
+    }
+  }
+
+  return (
+    <li
+      ref={ref}
+      className={`thread-wrapper select-none ${offset ? 'swiping' : ''}`}
+      role="button"
+      tabIndex="0"
+      aria-label={`Chat with ${friend.playerTag}`}
+      onKeyDown={handleKeyDown}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handleCancel}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onRemove && onRemove(friend);
+      }}
+    >
+      <div className="thread" style={{ transform: `translateX(${offset}px)` }}>
+        <div className="avatar">
+          <PlayerAvatar tag={friend.playerTag} showName={false} />
+        </div>
+        <div className="meta">
+          <PlayerMini tag={friend.playerTag} showTag={false} />
+          {pending && <span className="preview">\u23F3 Pending</span>}
+        </div>
+        <div className="time" aria-hidden="true">
+          {''}
+        </div>
+      </div>
+      <div className="thread-actions">
+        <button onClick={() => onRemove && onRemove(friend)}>Remove</button>
+      </div>
+    </li>
+  );
+}

--- a/front-end/src/components/FriendsPanel.test.jsx
+++ b/front-end/src/components/FriendsPanel.test.jsx
@@ -19,6 +19,9 @@ vi.mock('../lib/gql.js', () => ({ graphqlRequest: vi.fn() }));
 import FriendsPanel from './FriendsPanel.jsx';
 
 describe('FriendsPanel', () => {
+  beforeEach(() => {
+    localStorage.removeItem('friends-view');
+  });
   it('toggles row view', async () => {
     render(<FriendsPanel onSelectChat={() => {}} />);
     await screen.findByText('Friends');
@@ -26,5 +29,12 @@ describe('FriendsPanel', () => {
     fireEvent.click(toggle);
     const container = screen.getByTestId('friends-container');
     expect(container).toHaveClass('overflow-x-auto');
+  });
+
+  it('renders friend threads', async () => {
+    render(<FriendsPanel onSelectChat={() => {}} />);
+    await screen.findByText('Friends');
+    const item = await screen.findByRole('button', { name: /chat with/i });
+    expect(item.tagName).toBe('LI');
   });
 });

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -3,6 +3,13 @@
     background: linear-gradient(to bottom right, #f1f5f9, #e2e8f0);
     min-height: 100dvh;
     --bottom-bar-h: 4rem;
+    --spacing-unit: 0.75rem;
+    --label-primary: 0.875rem;
+    --label-secondary: 0.75rem;
+    --bg-thread: #ffffff;
+    --bg-thread-active: #e2e8f0;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
 }
 
 body {
@@ -10,6 +17,16 @@ body {
     -webkit-font-smoothing: antialiased;
     background-color: #1e3a8a;
     margin: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+    #root {
+        background: linear-gradient(to bottom right, #1e293b, #0f172a);
+        --bg-thread: #1e293b;
+        --bg-thread-active: #334155;
+        --text-primary: #f1f5f9;
+        --text-secondary: #94a3b8;
+    }
 }
 
 @media (min-width: 640px) {
@@ -107,8 +124,104 @@ body {
         padding: 0.5rem 1rem;
         font-size: 0.75rem;
     }
-    .mobile-table tbody td::before {
+.mobile-table tbody td::before {
+    display: none;
+    content: none;
+}
+
+.friends-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    container-type: inline-size;
+}
+
+.thread {
+    display: flex;
+    gap: var(--spacing-unit);
+    align-items: center;
+    padding: var(--spacing-unit);
+    background: var(--bg-thread);
+    border-radius: 0.5rem;
+    font-size: var(--label-primary);
+    position: relative;
+    transition: transform 0.2s ease;
+}
+
+.thread:active {
+    background: var(--bg-thread-active);
+}
+
+.thread .avatar {
+    flex: 0 0 auto;
+}
+
+.thread .meta {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    color: var(--text-primary);
+}
+
+.thread .preview {
+    color: var(--text-secondary);
+    font-size: var(--label-secondary);
+}
+
+.thread .time {
+    flex: 0 0 auto;
+    font-size: var(--label-secondary);
+    color: var(--text-secondary);
+}
+
+.thread-wrapper {
+    position: relative;
+}
+
+.thread-actions {
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 88px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #ef4444;
+    color: white;
+    transform: translateX(88px);
+    transition: transform 0.2s ease;
+}
+
+.thread-wrapper.active .thread {
+    background: var(--bg-thread-active);
+}
+
+.thread-wrapper.swiping .thread-actions {
+    transform: translateX(0);
+}
+
+.skeleton {
+    background: linear-gradient(90deg, #e5e7eb 25%, #f1f5f9 50%, #e5e7eb 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+
+@container (max-width: 379px) {
+    .thread .preview {
         display: none;
-        content: none;
+    }
+}
+
+@container (min-width: 600px) {
+    .friends-list.split {
+        display: flex;
+        flex-direction: column;
+        max-width: 20rem;
     }
 }


### PR DESCRIPTION
## Summary
- add FriendThread component for swipeable friend rows
- convert FriendsPanel list to use FriendThread
- apply responsive styling tokens and container queries
- show skeleton loaders and swipe actions
- test for new thread markup

## Testing
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_68846c42db14832c9fddc25d016bf1f2