### PR TITLE
Improve friends list layout

### DIFF
--- a/front-end/src/components/FriendThread.jsx
+++ b/front-end/src/components/FriendThread.jsx
@@ -1,0 +1,87 @@
+import React, { useRef, useState } from 'react';
+import PlayerAvatar from './PlayerAvatar.jsx';
+import PlayerMini from './PlayerMini.jsx';
+
+function formatTs(ts) {
+  if (!ts) return '';
+  try {
+    return new Date(ts).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return '';
+  }
+}
+
+export default function FriendThread({
+  friend,
+  pending,
+  onSelect,
+  onRemove,
+  preview,
+  ts,
+}) {
+  const longPress = useRef(false);
+  const timer = useRef(null);
+  const startX = useRef(0);
+  const [swiped, setSwiped] = useState(false);
+
+  function handlePointerDown(e) {
+    startX.current = e.clientX;
+    longPress.current = false;
+    timer.current = setTimeout(() => {
+      longPress.current = true;
+      if (onRemove) onRemove(friend);
+    }, 600);
+  }
+
+  function handlePointerMove(e) {
+    if (Math.abs(e.clientX - startX.current) > 30) {
+      clearTimeout(timer.current);
+      if (e.clientX < startX.current - 30) {
+        setSwiped(true);
+      }
+    }
+  }
+
+  function handlePointerUp() {
+    clearTimeout(timer.current);
+    if (!longPress.current && !swiped) {
+      onSelect(friend);
+    }
+    if (swiped) {
+      setTimeout(() => setSwiped(false), 2000);
+    }
+  }
+
+  return (
+    <li
+      className={`thread ${swiped ? 'swiped' : ''}`}
+      aria-label={pending ? 'Unread' : undefined}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={() => clearTimeout(timer.current)}
+    >
+      <div className="avatar">
+        <PlayerAvatar tag={friend.playerTag} showName={false} className="w-12" />
+      </div>
+      <div className="meta">
+        <div className="name">
+          <PlayerMini tag={friend.playerTag} showTag={false} showLeague={false} />
+        </div>
+        <div className="preview">{preview || 'Tap to chat…'}</div>
+      </div>
+      <time className="time" dateTime={ts || ''}>{formatTs(ts)}</time>
+      <div className="thread-actions">
+        <button
+          className="text-sm focus:outline-none"
+          onClick={() => onRemove(friend.playerTag)}
+        >
+          Remove
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/front-end/src/components/FriendsPanel.test.jsx
+++ b/front-end/src/components/FriendsPanel.test.jsx
@@ -14,17 +14,21 @@ vi.mock('../lib/api.js', () => ({
     return Promise.resolve({});
   }),
 }));
-vi.mock('../lib/gql.js', () => ({ graphqlRequest: vi.fn() }));
+vi.mock('../lib/gql.js', () => ({
+  graphqlRequest: vi.fn(() =>
+    Promise.resolve({ getMessages: [{ content: 'hi', ts: '2025-07-26T00:00:00Z' }] }),
+  ),
+}));
 
 import FriendsPanel from './FriendsPanel.jsx';
 
 describe('FriendsPanel', () => {
-  it('toggles row view', async () => {
+  it('renders friend threads', async () => {
     render(<FriendsPanel onSelectChat={() => {}} />);
     await screen.findByText('Friends');
-    const toggle = screen.getByRole('button', { name: /row view/i });
-    fireEvent.click(toggle);
-    const container = screen.getByTestId('friends-container');
-    expect(container).toHaveClass('overflow-x-auto');
+    const item = await screen.findByRole('listitem');
+    expect(item).toHaveClass('thread');
+    await screen.findByText('hi');
+    expect(item).toHaveTextContent('hi');
   });
 });

--- a/front-end/src/components/PlayerMini.jsx
+++ b/front-end/src/components/PlayerMini.jsx
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { fetchJSONCached } from '../lib/api.js';
 import CachedImage from './CachedImage.jsx';
 
-export default function PlayerMini({ tag, player: preload, showTag = true }) {
+export default function PlayerMini({
+  tag,
+  player: preload,
+  showTag = true,
+  showLeague = true,
+}) {
   const [player, setPlayer] = useState(preload || null);
 
   useEffect(() => {
@@ -33,7 +38,7 @@ export default function PlayerMini({ tag, player: preload, showTag = true }) {
 
   return (
     <span className="flex items-center gap-1">
-      {player.leagueIcon && (
+      {showLeague && player.leagueIcon && (
         <CachedImage
           key={player.tag}
           src={player.leagueIcon}

--- a/front-end/src/components/SkeletonThread.jsx
+++ b/front-end/src/components/SkeletonThread.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function SkeletonThread() {
+  return (
+    <li className="thread animate-pulse">
+      <div className="avatar bg-slate-300 rounded-full" />
+      <div className="meta flex-1">
+        <div className="h-4 bg-slate-300 rounded w-1/2 mb-1" />
+        <div className="h-3 bg-slate-200 rounded w-3/4" />
+      </div>
+      <div className="time h-3 bg-slate-200 rounded w-8" />
+    </li>
+  );
+}

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -107,8 +107,117 @@ body {
         padding: 0.5rem 1rem;
         font-size: 0.75rem;
     }
-    .mobile-table tbody td::before {
+.mobile-table tbody td::before {
+    display: none;
+    content: none;
+}
+}
+
+/* Generic spacing and color tokens */
+:root {
+    --spacing-unit: 0.75rem;
+    --label-primary: #1e293b;
+    --surface: #ffffff;
+    --surface-dark: #0f172a;
+    --highlight-bg: rgba(59,130,246,0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --label-primary: #e2e8f0;
+        --surface: #1f2937;
+        --surface-dark: #111827;
+        --highlight-bg: rgba(59,130,246,0.2);
+    }
+}
+
+/* Friend thread layout */
+.thread {
+    display: flex;
+    gap: var(--spacing-unit);
+    padding: var(--spacing-unit);
+    align-items: center;
+    position: relative;
+    background-color: var(--surface);
+    width: 100%;
+    border-bottom: 1px solid #e5e7eb;
+}
+.thread:last-child {
+    border-bottom: none;
+}
+
+.thread .avatar {
+    flex-shrink: 0;
+    width: 3rem;
+    height: 3rem;
+}
+
+.thread .meta {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.thread .meta .name {
+    color: var(--label-primary);
+    font-weight: 500;
+}
+
+.thread .meta .preview {
+    font-size: 0.875rem;
+    color: #475569;
+}
+
+.thread .time {
+    color: #94a3b8;
+    font-size: 0.75rem;
+    margin-left: auto;
+    align-self: flex-start;
+}
+
+.thread:active {
+    background-color: var(--highlight-bg);
+}
+
+.thread-actions {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: 88px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #ef4444;
+    color: #fff;
+    transform: translateX(100%);
+    transition: transform 0.2s;
+}
+
+.thread.swiped .thread-actions {
+    transform: translateX(0);
+}
+
+.friends-wrapper {
+    container-type: inline-size;
+}
+
+@container (max-width: 380px) {
+    .thread .preview {
         display: none;
-        content: none;
+    }
+}
+
+@container (min-width: 600px) {
+    .friends-wrapper {
+        display: flex;
+    }
+    .friends-list {
+        flex: 0 0 40%;
+        max-width: 20rem;
+        border-right: 1px solid #e5e7eb;
+        overflow-y: auto;
+    }
+    .friends-detail {
+        flex: 1 1 auto;
     }
 }


### PR DESCRIPTION
## Summary
- restyle threads with full-width rows and consistent token colors
- include message previews and local timestamps
- hide redundant league icons via new prop on PlayerMini
- fetch recent messages for each friend
- update tests

## Testing
- `npm --prefix front-end test`
- `npm --prefix front-end run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_68846c42db14832c9fddc25d016bf1f2