### PR TITLE
Fix datasource bean for notifications service

### DIFF
--- a/notifications/src/main/java/com/clanboards/notifications/config/DatabaseConfig.java
+++ b/notifications/src/main/java/com/clanboards/notifications/config/DatabaseConfig.java
@@ -1,0 +1,43 @@
+package com.clanboards.notifications.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+import java.net.URI;
+
+@Configuration
+public class DatabaseConfig {
+    @Bean
+    public DataSource dataSource(
+            @Value("${DATABASE_URL:}") String databaseUrl,
+            @Value("${DATABASE_USERNAME:}") String username,
+            @Value("${DATABASE_PASSWORD:}") String password) throws Exception {
+        if (databaseUrl == null || databaseUrl.isBlank()) {
+            return DataSourceBuilder.create()
+                    .driverClassName("org.h2.Driver")
+                    .url("jdbc:h2:mem:testdb")
+                    .username("sa")
+                    .password("")
+                    .build();
+        }
+        URI uri = new URI(databaseUrl);
+        String userInfo = uri.getUserInfo();
+        if (userInfo != null && (username == null || username.isBlank())) {
+            String[] parts = userInfo.split(":", 2);
+            username = parts[0];
+            if (parts.length > 1) password = parts[1];
+        }
+        String jdbcUrl = "jdbc:postgresql://" + uri.getHost()
+                + (uri.getPort() > 0 ? ":" + uri.getPort() : "")
+                + uri.getPath();
+        return DataSourceBuilder.create()
+                .driverClassName("org.postgresql.Driver")
+                .url(jdbcUrl)
+                .username(username)
+                .password(password)
+                .build();
+    }
+}

--- a/notifications/src/main/resources/application.properties
+++ b/notifications/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
## Summary
- configure datasource for the notifications service using environment variables
- disable JPA auto DDL in `application.properties`

## Testing
- `./gradlew test` in `notifications`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_68852c2a4698832c98f1df2953569911