### PR TITLE
Fix mobile Notification API reference

### DIFF
--- a/front-end/src/components/NotificationBanner.jsx
+++ b/front-end/src/components/NotificationBanner.jsx
@@ -4,7 +4,7 @@ import { subscribeForPush } from '../lib/push.js';
 export default function NotificationBanner() {
   const [dismissed, setDismissed] = useState(() => localStorage.getItem('dismiss-push') === '1');
 
-  if (dismissed || Notification.permission === 'granted') {
+  if (dismissed || typeof Notification === 'undefined' || Notification.permission === 'granted') {
     return null;
   }
 

--- a/front-end/src/components/NotificationBanner.test.jsx
+++ b/front-end/src/components/NotificationBanner.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NotificationBanner from './NotificationBanner.jsx';
+
+describe('NotificationBanner', () => {
+  it('does not render when Notification is undefined', () => {
+    const original = global.Notification;
+    delete global.Notification;
+    render(<NotificationBanner />);
+    expect(screen.queryByText(/enable notifications/i)).not.toBeInTheDocument();
+    global.Notification = original;
+  });
+});

--- a/front-end/src/lib/push.js
+++ b/front-end/src/lib/push.js
@@ -30,6 +30,7 @@ export async function sendSubscription(sub) {
 
 export async function subscribeForPush() {
   if (!('serviceWorker' in navigator)) throw new Error('no sw');
+  if (typeof Notification === 'undefined') throw new Error('no notifications');
   const permission = await Notification.requestPermission();
   if (permission !== 'granted') throw new Error('denied');
   const reg = await navigator.serviceWorker.ready;


### PR DESCRIPTION
## Summary
- handle missing Notification API
- hide banner if notifications unsupported
- add tests for NotificationBanner

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68855ebe8d44832c997c0ac21f0642f7