### PR TITLE
Improve VAPID secret handling

### DIFF
--- a/notifications/src/main/java/com/clanboards/notifications/config/VapidConfig.java
+++ b/notifications/src/main/java/com/clanboards/notifications/config/VapidConfig.java
@@ -9,6 +9,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
+
+import java.io.StringReader;
+import java.util.Properties;
 
 import java.io.IOException;
 
@@ -18,31 +22,73 @@ public class VapidConfig {
 
     @Bean
     public PushService pushService() {
-        String secretArn = System.getenv("VAPID_KEYS");
+        String secretValue = System.getenv("VAPID_KEYS");
+        ObjectMapper mapper = new ObjectMapper();
         try {
-            ObjectMapper mapper = new ObjectMapper();
-            JsonNode node;
-            if (secretArn != null && !secretArn.isEmpty()) {
-                var client = SecretsManagerClient.builder().build();
-                var request = GetSecretValueRequest.builder()
-                        .secretId(secretArn)
-                        .build();
-                var secret = client.getSecretValue(request).secretString();
-                node = mapper.readTree(secret);
+            String secretContent;
+            if (secretValue != null && !secretValue.isBlank()) {
+                if (looksLikeKeys(secretValue)) {
+                    logger.info("Loading VAPID keys from environment variable");
+                    secretContent = secretValue;
+                } else {
+                    logger.info("Loading VAPID keys from Secrets Manager using id {}", secretValue);
+                    var client = SecretsManagerClient.builder().build();
+                    var request = GetSecretValueRequest.builder()
+                            .secretId(secretValue)
+                            .build();
+                    secretContent = client.getSecretValue(request).secretString();
+                }
             } else {
                 var file = new java.io.File("/secrets/vapid.json");
                 if (!file.exists()) {
                     throw new IllegalStateException("VAPID_KEYS env var or /secrets/vapid.json required");
                 }
-                node = mapper.readTree(file);
+                logger.info("Loading VAPID keys from {}", file.getAbsolutePath());
+                secretContent = java.nio.file.Files.readString(file.toPath());
             }
-            return new PushService(
-                node.get("publicKey").asText(),
-                node.get("privateKey").asText(),
-                node.get("subject").asText());
+
+            VapidKeys keys = parseSecret(secretContent, mapper);
+            return new PushService(keys.publicKey, keys.privateKey, keys.subject);
+        } catch (SecretsManagerException e) {
+            logger.error("Failed to retrieve secret {} from Secrets Manager: {}", secretValue, e.awsErrorDetails().errorMessage(), e);
+            throw e;
         } catch (IOException | java.security.GeneralSecurityException e) {
             logger.error("Failed to load VAPID keys", e);
             throw new RuntimeException(e);
+        }
+    }
+
+    private boolean looksLikeKeys(String value) {
+        String trimmed = value.trim();
+        return trimmed.startsWith("{") || trimmed.contains("publicKey") || trimmed.contains("privateKey");
+    }
+
+    private VapidKeys parseSecret(String secret, ObjectMapper mapper) throws IOException {
+        if (secret.trim().startsWith("{")) {
+            JsonNode node = mapper.readTree(secret);
+            return new VapidKeys(
+                    node.path("publicKey").asText(),
+                    node.path("privateKey").asText(),
+                    node.path("subject").asText());
+        } else {
+            Properties props = new Properties();
+            props.load(new StringReader(secret));
+            return new VapidKeys(
+                    props.getProperty("publicKey", ""),
+                    props.getProperty("privateKey", ""),
+                    props.getProperty("subject", ""));
+        }
+    }
+
+    private static class VapidKeys {
+        final String publicKey;
+        final String privateKey;
+        final String subject;
+
+        VapidKeys(String publicKey, String privateKey, String subject) {
+            this.publicKey = publicKey;
+            this.privateKey = privateKey;
+            this.subject = subject;
         }
     }
 }


### PR DESCRIPTION
## Summary
- support VAPID keys stored as simple key/value pairs
- keep previous logging for secret retrieval errors
- avoid leaking secrets in logs

## Testing
- `./gradlew test` in `notifications`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_68855c2cafb0832ca0b42d4e17cb2c4c