### PR TITLE
Fix BouncyCastle provider setup

### DIFF
--- a/notifications/src/main/java/com/clanboards/notifications/config/BouncyCastleConfig.java
+++ b/notifications/src/main/java/com/clanboards/notifications/config/BouncyCastleConfig.java
@@ -1,0 +1,16 @@
+package com.clanboards.notifications.config;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+import java.security.Security;
+
+@Configuration
+public class BouncyCastleConfig {
+    @PostConstruct
+    public void registerProvider() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- register BouncyCastle security provider at startup so PushService can initialize correctly

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_688576dedce0832cac847b127d9c70c6