### PR TITLE
Improve Java service deploy caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,24 +153,28 @@ jobs:
           case "$SERVICE" in
             worker)
               DOCKERFILE=back-end/Dockerfile
+              CONTEXT=back-end
               REPOSITORY=$WORKER_REPOSITORY
               SERVICE_NAME=$WORKER_SERVICE
               CHANGED=${{ needs.detect.outputs.worker_any_changed }}
               ;;
             messages)
               DOCKERFILE=messages-java/Dockerfile
+              CONTEXT=messages-java
               REPOSITORY=$MESSAGES_REPOSITORY
               SERVICE_NAME=$MESSAGES_SERVICE
               CHANGED=${{ needs.detect.outputs.messages_any_changed }}
               ;;
             user)
               DOCKERFILE=user_service/Dockerfile
+              CONTEXT=user_service
               REPOSITORY=$USER_REPOSITORY
               SERVICE_NAME=$USER_SERVICE
               CHANGED=${{ needs.detect.outputs.user_any_changed }}
               ;;
             notifications)
               DOCKERFILE=notifications/Dockerfile
+              CONTEXT=notifications
               REPOSITORY=$NOTIFICATIONS_REPOSITORY
               SERVICE_NAME=$NOTIFICATIONS_SERVICE
               CHANGED=${{ needs.detect.outputs.notifications_any_changed }}
@@ -185,11 +189,11 @@ jobs:
           docker buildx build \
             --platform linux/arm64 \
             -f "$DOCKERFILE" \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
+            --cache-from type=gha,scope=$SERVICE \
+            --cache-to type=gha,mode=max,scope=$SERVICE \
             -t "$ECR_REGISTRY/$REPOSITORY:latest" \
             -t "$ECR_REGISTRY/$REPOSITORY:${{ github.sha }}" \
-            --push .
+            --push "$CONTEXT"
 
           task_def=$(aws ecs describe-services --cluster $CLUSTER --services $SERVICE_NAME --query 'services[0].taskDefinition' --output text)
           aws ecs describe-task-definition --task-definition "$task_def" --query 'taskDefinition' > taskdef.json

--- a/messages-java/Dockerfile
+++ b/messages-java/Dockerfile
@@ -2,8 +2,11 @@
 FROM gradle:8.7-jdk21 AS build
 WORKDIR /workspace/messages-java
 
-COPY messages-java/ .
+COPY messages-java/build.gradle messages-java/settings.gradle ./
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+    gradle --no-daemon build -x test || true
 
+COPY messages-java/src ./src
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle --no-daemon bootJar
 

--- a/notifications/Dockerfile
+++ b/notifications/Dockerfile
@@ -1,7 +1,11 @@
 # syntax=docker/dockerfile:1.5
 FROM gradle:8.7-jdk21 AS build
 WORKDIR /workspace/notifications
-COPY notifications/ .
+COPY notifications/build.gradle notifications/settings.gradle ./
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+    gradle --no-daemon build -x test || true
+
+COPY notifications/src ./src
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle --no-daemon bootJar
 

--- a/user_service/Dockerfile
+++ b/user_service/Dockerfile
@@ -2,8 +2,11 @@
 FROM gradle:8.7-jdk21 AS build
 WORKDIR /workspace/user-service
 
-COPY user_service/ .
+COPY user_service/build.gradle user_service/settings.gradle ./
+RUN --mount=type=cache,target=/home/gradle/.gradle \
+    gradle --no-daemon build -x test || true
 
+COPY user_service/src ./src
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle --no-daemon bootJar
 


### PR DESCRIPTION
## Summary
- scope Docker Buildx cache by service and set build context
- prime Gradle caches in Dockerfiles

## Testing
- `./gradlew test` for each Java service
- `nox -s lint tests`
- `ruff check back-end coclib db`


------
https://chatgpt.com/codex/tasks/task_e_6885860da8ac832c838d6de86426a792