### PR TITLE
Fix docker build context for Java services

### DIFF
--- a/messages-java/Dockerfile
+++ b/messages-java/Dockerfile
@@ -2,11 +2,11 @@
 FROM gradle:8.7-jdk21 AS build
 WORKDIR /workspace/messages-java
 
-COPY messages-java/build.gradle messages-java/settings.gradle ./
+COPY build.gradle settings.gradle ./
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle --no-daemon build -x test || true
 
-COPY messages-java/src ./src
+COPY src ./src
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle --no-daemon bootJar
 

--- a/notifications/Dockerfile
+++ b/notifications/Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1.5
 FROM gradle:8.7-jdk21 AS build
 WORKDIR /workspace/notifications
-COPY notifications/build.gradle notifications/settings.gradle ./
+COPY build.gradle settings.gradle ./
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle --no-daemon build -x test || true
 
-COPY notifications/src ./src
+COPY src ./src
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle --no-daemon bootJar
 

--- a/user_service/Dockerfile
+++ b/user_service/Dockerfile
@@ -2,11 +2,11 @@
 FROM gradle:8.7-jdk21 AS build
 WORKDIR /workspace/user-service
 
-COPY user_service/build.gradle user_service/settings.gradle ./
+COPY build.gradle settings.gradle ./
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle --no-daemon build -x test || true
 
-COPY user_service/src ./src
+COPY src ./src
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle --no-daemon bootJar
 


### PR DESCRIPTION
## Summary
- copy service sources relative to docker build context

## Testing
- `nox -s lint tests`
- `./gradlew test` in `messages-java`
- `./gradlew test` in `user_service`
- `./gradlew test` in `notifications`


------
https://chatgpt.com/codex/tasks/task_e_688590e4b3e4832c84ffc4e08d2000c5