### PR TITLE
Update deploy cache to use registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,8 +189,8 @@ jobs:
           docker buildx build \
             --platform linux/arm64 \
             -f "$DOCKERFILE" \
-            --cache-from type=gha,scope=$SERVICE \
-            --cache-to type=gha,mode=max,scope=$SERVICE \
+            --cache-from type=registry,ref=$ECR_REGISTRY/$REPOSITORY:buildcache \
+            --cache-to type=registry,ref=$ECR_REGISTRY/$REPOSITORY:buildcache,mode=max \
             -t "$ECR_REGISTRY/$REPOSITORY:latest" \
             -t "$ECR_REGISTRY/$REPOSITORY:${{ github.sha }}" \
             --push "$CONTEXT"


### PR DESCRIPTION
## Summary
- use registry-based caching for docker builds

## Testing
- `nox -s lint tests`
- `ruff check back-end coclib db`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68859e16fa1c832cb3ed3930c70c9b3d