### PR TITLE
Implement auth filter for notifications

### DIFF
--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'io.opentelemetry:opentelemetry-api:1.38.0'
     runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
 }
 
 test {

--- a/notifications/src/main/java/com/clanboards/notifications/config/AuthFilter.java
+++ b/notifications/src/main/java/com/clanboards/notifications/config/AuthFilter.java
@@ -1,0 +1,49 @@
+package com.clanboards.notifications.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Base64;
+
+@Component
+public class AuthFilter extends OncePerRequestFilter {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String auth = request.getHeader("Authorization");
+        HttpServletRequest req = request;
+        if (auth != null && auth.startsWith("Bearer ")) {
+            String token = auth.substring(7);
+            String[] parts = token.split("\\.");
+            if (parts.length > 1) {
+                try {
+                    String payload = new String(Base64.getUrlDecoder().decode(parts[1]));
+                    JsonNode node = mapper.readTree(payload);
+                    if (node.has("sub")) {
+                        String sub = node.get("sub").asText();
+                        request.setAttribute("sub", sub);
+                        req = new HttpServletRequestWrapper(request) {
+                            private final Principal principal = () -> sub;
+                            @Override
+                            public Principal getUserPrincipal() {
+                                return principal;
+                            }
+                        };
+                    }
+                } catch (Exception ignored) {}
+            }
+        }
+        filterChain.doFilter(req, response);
+    }
+}

--- a/notifications/src/main/java/com/clanboards/notifications/controller/NotificationController.java
+++ b/notifications/src/main/java/com/clanboards/notifications/controller/NotificationController.java
@@ -25,28 +25,44 @@ public class NotificationController {
     }
 
     @PostMapping("/subscribe")
-    public ResponseEntity<?> subscribe(@RequestBody PushSubscription sub, Principal principal) {
-        Long userId = parseUserId(principal);
+    public ResponseEntity<?> subscribe(@RequestBody PushSubscription sub,
+                                       jakarta.servlet.http.HttpServletRequest request,
+                                       Principal principal) {
+        Long userId = parseUserId(request, principal);
         service.subscribe(userId, sub);
         logger.info("User {} subscribed", userId);
         return ResponseEntity.ok(Map.of("status", "subscribed"));
     }
 
     @PostMapping("/test")
-    public ResponseEntity<?> test(@RequestBody Map<String, String> payload, Principal principal) {
-        Long userId = parseUserId(principal);
+    public ResponseEntity<?> test(@RequestBody Map<String, String> payload,
+                                  jakarta.servlet.http.HttpServletRequest request,
+                                  Principal principal) {
+        Long userId = parseUserId(request, principal);
         service.sendTest(userId, payload.getOrDefault("message", "test"));
         return ResponseEntity.ok(Map.of("status", "sent"));
     }
 
-    private Long parseUserId(Principal principal) {
-        String name = principal.getName();
+    private Long parseUserId(jakarta.servlet.http.HttpServletRequest request, Principal principal) {
+        String name = null;
+        if (principal != null) {
+            name = principal.getName();
+        }
+        if (name == null) {
+            Object sub = request.getAttribute("sub");
+            if (sub instanceof String s) {
+                name = s;
+            }
+        }
+        if (name == null) {
+            throw new org.springframework.web.server.ResponseStatusException(org.springframework.http.HttpStatus.UNAUTHORIZED);
+        }
         try {
             return Long.parseLong(name);
         } catch (NumberFormatException e) {
             return userRepository.findBySub(name)
                     .map(User::getId)
-                    .orElseThrow();
+                    .orElseThrow(() -> new org.springframework.web.server.ResponseStatusException(org.springframework.http.HttpStatus.UNAUTHORIZED));
         }
     }
 }

--- a/notifications/src/test/java/com/clanboards/notifications/NotificationControllerAuthTest.java
+++ b/notifications/src/test/java/com/clanboards/notifications/NotificationControllerAuthTest.java
@@ -1,0 +1,78 @@
+package com.clanboards.notifications;
+
+import com.clanboards.notifications.service.NotificationService;
+import com.clanboards.notifications.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import javax.sql.DataSource;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import java.util.Base64;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
+@AutoConfigureMockMvc
+class NotificationControllerAuthTest {
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        @Primary
+        DataSource dataSource() {
+            DriverManagerDataSource ds = new DriverManagerDataSource();
+            ds.setDriverClassName("org.h2.Driver");
+            ds.setUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1");
+            ds.setUsername("sa");
+            ds.setPassword("");
+            return ds;
+        }
+    }
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private NotificationService service;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private com.clanboards.notifications.service.SqsListener sqsListener;
+
+    @MockBean
+    private nl.martijndwars.webpush.PushService pushService;
+
+    private static String token(String sub) {
+        String payload = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(("{\"sub\":\"" + sub + "\"}").getBytes());
+        return "x." + payload + ".y";
+    }
+
+    @Test
+    void unauthenticatedRequestsReturn401() throws Exception {
+        mvc.perform(post("/api/v1/notifications/subscribe")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"endpoint\":\"e\",\"p256dhKey\":\"k\",\"authKey\":\"a\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void validTokenSucceeds() throws Exception {
+        mvc.perform(post("/api/v1/notifications/subscribe")
+                .header("Authorization", "Bearer " + token("1"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"endpoint\":\"e\",\"p256dhKey\":\"k\",\"authKey\":\"a\"}"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- add servlet `AuthFilter` to inject a Principal from JWT bearer tokens
- use request/Principal for authentication in `NotificationController`
- allow parsing of user IDs from JWT or repository
- add unit tests for auth behaviour
- include H2 for testing

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68864ac27cb4832c943737cadc9548ad