### PR TITLE
Fix friend notification duplication and badge

### DIFF
--- a/front-end/public/sw.js
+++ b/front-end/public/sw.js
@@ -30,11 +30,19 @@ function urlBase64ToUint8Array(base64String) {
 
 self.addEventListener('message', (event) => {
   const msg = event.data;
-  if (!msg || msg.type !== 'subscribe-chats' || !Array.isArray(msg.ids)) return;
-  for (const id of msg.ids) {
-    if (typeof id === 'string') subscribedChats.add(id);
+  if (!msg) return;
+  if (msg.type === 'subscribe-chats' && Array.isArray(msg.ids)) {
+    for (const id of msg.ids) {
+      if (typeof id === 'string') subscribedChats.add(id);
+    }
+    console.log('Subscribed chats updated', [...subscribedChats]);
+  } else if (msg.type === 'clear-badge') {
+    notificationCount = 0;
+    friendDetailCount = 0;
+    if (navigator.clearAppBadge) {
+      navigator.clearAppBadge().catch(() => {});
+    }
   }
-  console.log('Subscribed chats updated', [...subscribedChats]);
 });
 
 async function getPlayerInfo(userId) {
@@ -87,7 +95,7 @@ self.addEventListener('push', (event) => {
         const info = await getPlayerInfo(senderId);
         if (info) {
           options.icon = info.leagueIcon || options.icon;
-          body = `${info.name} sent you a message\n${preview}`;
+          body = `From ${info.name}\n${preview}`;
         }
       } catch (err) {
         console.error('Failed to fetch sender info', err);

--- a/front-end/src/pages/ChatPage.jsx
+++ b/front-end/src/pages/ChatPage.jsx
@@ -13,6 +13,12 @@ export default function ChatPage({ verified, chatId, userId }) {
   const initialTab = search.get('tab');
 
   useEffect(() => {
+    if (navigator.serviceWorker?.controller) {
+      navigator.serviceWorker.controller.postMessage({ type: 'clear-badge' });
+    }
+  }, [chatId]);
+
+  useEffect(() => {
     if (!verified) return;
     (async () => {
       try {

--- a/notifications/src/main/java/com/clanboards/notifications/service/SqsListener.java
+++ b/notifications/src/main/java/com/clanboards/notifications/service/SqsListener.java
@@ -69,10 +69,14 @@ public class SqsListener {
           if (node.has("senderId")) {
             String senderId = node.get("senderId").asText();
             var map = new HashMap<String, String>();
-            map.put("title", "New message");
+            // Include senderId so the service worker can fetch profile info.
+            map.put("senderId", senderId);
+            // Put the message text in the body field used by the service worker.
             map.put("body", payload);
             map.put("url", "/chat?user=" + senderId);
             map.put("tag", "friend-" + senderId);
+            // Do not include a title field to avoid browsers displaying a
+            // default notification before the service worker handles the push.
             payload = mapper.writeValueAsString(map);
           }
           if (userId != null) {


### PR DESCRIPTION
## Summary
- avoid FCM default notifications by removing `title` from SQS payload and include `senderId`
- improve service worker push handling: allow clearing badge and show better message format
- clear app badge when opening a chat

## Testing
- `ruff check back-end coclib db`
- `npm install`
- `npm test`
- `npm run build`
- `./notifications/gradlew -p notifications test`


------
https://chatgpt.com/codex/tasks/task_e_6886651d1160832c89c45cd3e1ef6eb2