### PR TITLE
Improve notifications badge handling

### DIFF
--- a/front-end/src/components/BottomNav.jsx
+++ b/front-end/src/components/BottomNav.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { Home, MessageCircle, Users, BarChart2, User } from 'lucide-react';
 
-export default function BottomNav({ clanIcon }) {
+export default function BottomNav({ clanIcon, badgeCount = 0 }) {
   const items = [
     { to: '/', label: 'Home', icon: Home },
     { to: '/chat', label: 'Chat', icon: MessageCircle },
@@ -22,7 +22,14 @@ export default function BottomNav({ clanIcon }) {
             `flex-1 py-2 text-center flex flex-col items-center ${isActive ? 'text-blue-600' : 'text-slate-600'}`
           }
         >
-          {React.createElement(item.icon, { className: 'w-5 h-5' })}
+          <span className="relative">
+            {React.createElement(item.icon, { className: 'w-5 h-5' })}
+            {item.to === '/chat' && badgeCount > 0 && (
+              <span className="absolute -top-1 -right-1 bg-red-600 text-white rounded-full text-[10px] px-1">
+                {badgeCount}
+              </span>
+            )}
+          </span>
           <span className="text-xs mt-1">{item.label}</span>
         </NavLink>
       ))}

--- a/front-end/src/components/BottomNav.test.jsx
+++ b/front-end/src/components/BottomNav.test.jsx
@@ -16,4 +16,14 @@ describe('BottomNav', () => {
     expect(screen.getByText('Stats')).toBeInTheDocument();
     expect(screen.getByText('Account')).toBeInTheDocument();
   });
+
+  it('shows badge when count provided', () => {
+    render(
+      <MemoryRouter>
+        <BottomNav badgeCount={3} />
+      </MemoryRouter>
+    );
+    const badge = screen.getByText('3');
+    expect(badge).toBeInTheDocument();
+  });
 });

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -15,12 +15,21 @@ export default function ChatPanel({
   globalIds = [],
   friendIds = [],
   initialTab = null,
+  initialDirectId = null,
 }) {
-  const [tab, setTab] = useState(initialTab || (chatId ? 'Clan' : 'Global'));
+  const [tab, setTab] = useState(
+    initialDirectId ? 'Friends' : initialTab || (chatId ? 'Clan' : 'Global')
+  );
   const clanChat = chatId ? useChat(chatId) : { messages: [], loadMore: () => {}, hasMore: false, appendMessage: () => {} };
   const globalChat = useMultiChat(globalIds);
   const friendChat = useMultiChat(friendIds);
-  const [directChatId, setDirectChatId] = useState(null);
+  const [directChatId, setDirectChatId] = useState(initialDirectId);
+  useEffect(() => {
+    if (initialDirectId) {
+      setDirectChatId(initialDirectId);
+      setTab('Friends');
+    }
+  }, [initialDirectId]);
   const directChat = useChat(directChatId);
   const current =
     tab === 'Clan'

--- a/front-end/src/components/DesktopNav.jsx
+++ b/front-end/src/components/DesktopNav.jsx
@@ -3,7 +3,7 @@ import { NavLink } from 'react-router-dom';
 import { Shield, MessageCircle, Users, BarChart2, User } from 'lucide-react';
 import CachedImage from './CachedImage.jsx';
 
-export default function DesktopNav({ clanIcon }) {
+export default function DesktopNav({ clanIcon, badgeCount = 0 }) {
   const items = [
     { to: '/', label: 'Home', icon: Shield },
     { to: '/chat', label: 'Chat', icon: MessageCircle },
@@ -23,11 +23,18 @@ export default function DesktopNav({ clanIcon }) {
             `flex items-center gap-1 ${isActive ? 'text-blue-600' : 'text-slate-700'}`
           }
         >
-          {item.to === '/' && clanIcon ? (
-            <CachedImage src={clanIcon} alt="clan" className="w-4 h-4" />
-          ) : (
-            React.createElement(item.icon, { className: 'w-4 h-4' })
-          )}
+          <span className="relative">
+            {item.to === '/' && clanIcon ? (
+              <CachedImage src={clanIcon} alt="clan" className="w-4 h-4" />
+            ) : (
+              React.createElement(item.icon, { className: 'w-4 h-4' })
+            )}
+            {item.to === '/chat' && badgeCount > 0 && (
+              <span className="absolute -top-1 -right-2 bg-red-600 text-white rounded-full text-[10px] px-1">
+                {badgeCount}
+              </span>
+            )}
+          </span>
           <span className="text-sm">{item.label}</span>
         </NavLink>
       ))}

--- a/front-end/src/components/DesktopNav.test.jsx
+++ b/front-end/src/components/DesktopNav.test.jsx
@@ -16,4 +16,14 @@ describe('DesktopNav', () => {
     expect(screen.getByText('Stats')).toBeInTheDocument();
     expect(screen.getByText('Account')).toBeInTheDocument();
   });
+
+  it('shows badge when count provided', () => {
+    render(
+      <MemoryRouter>
+        <DesktopNav badgeCount={2} />
+      </MemoryRouter>
+    );
+    const badge = screen.getByText('2');
+    expect(badge).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- broadcast badge count from service worker and expose `get-badge`
- show chat badge count in desktop and mobile navigation
- clear badge when viewing chat using serviceWorker.ready
- allow notification link to open direct chat
- sort friend list by most recent chat and refresh on push
- add tests for nav badge rendering

## Testing
- `nox -s lint tests`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688674e95074832c987328ff13db73b0