### PR TITLE
Fix push notification sender info

### DIFF
--- a/front-end/public/sw.js
+++ b/front-end/public/sw.js
@@ -10,6 +10,7 @@ const PLAYER_TTL = 6 * 60 * 60 * 1000; // 6 hours
 let notificationCount = 0;
 // track how many detailed friend message notifications were shown
 let friendDetailCount = 0;
+let authToken = null;
 
 self.addEventListener('install', (event) => {
   self.skipWaiting();
@@ -61,6 +62,8 @@ self.addEventListener('message', (event) => {
     } else {
       broadcastBadgeCount();
     }
+  } else if (msg.type === 'set-token') {
+    authToken = msg.token || null;
   }
 });
 
@@ -81,7 +84,9 @@ async function getPlayerInfo(userId) {
       await cache.delete(req);
     }
   }
-  const net = await fetch(req).catch(() => null);
+  const net = await fetch(url, {
+    headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+  }).catch(() => null);
   if (net && net.ok) {
     const cloned = net.clone();
     const headers = new Headers(cloned.headers);

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -189,8 +189,22 @@ export default function App() {
   useEffect(() => {
     if (token) {
       localStorage.setItem('token', token);
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.ready
+          .then((reg) => {
+            reg.active?.postMessage({ type: 'set-token', token });
+          })
+          .catch(() => {});
+      }
     } else {
       localStorage.removeItem('token');
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.ready
+          .then((reg) => {
+            reg.active?.postMessage({ type: 'set-token', token: null });
+          })
+          .catch(() => {});
+      }
     }
   }, [token]);
 


### PR DESCRIPTION
## Summary
- inject auth token to service worker so it can fetch player profiles
- update push service worker to send Authorization header when fetching player info

## Testing
- `nox -s lint tests`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688685a07b9c832ca91d88463991b10f