### PR TITLE
Fix PWA icon references

### DIFF
--- a/front-end/index.html
+++ b/front-end/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#2563eb" />
     <meta name="build-commit" content="%VITE_COMMIT_HASH%" />
     <link rel="icon" href="/src/assets/favicon_io/favicon.ico" />
-    <link rel="apple-touch-icon" href="/src/assets/favicon_io/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" href="/src/assets/AppIcons/Assets.xcassets/AppIcon.appiconset/180.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <title>Clan Dashboard</title>
     <script src="https://cdn.tailwindcss.com?plugins=typography"></script>

--- a/front-end/public/manifest.webmanifest
+++ b/front-end/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Clan Dashboard",
-  "short_name": "Clan",
+  "name": "Clan Boards",
+  "short_name": "Clan Boards",
   "icons": [
     {
       "src": "/src/assets/AppIcons/Assets.xcassets/AppIcon.appiconset/196.png",

--- a/front-end/public/manifest.webmanifest
+++ b/front-end/public/manifest.webmanifest
@@ -3,12 +3,12 @@
   "short_name": "Clan",
   "icons": [
     {
-      "src": "/src/assets/favicon_io/android-chrome-192x192.png",
-      "sizes": "192x192",
+      "src": "/src/assets/AppIcons/Assets.xcassets/AppIcon.appiconset/196.png",
+      "sizes": "196x196",
       "type": "image/png"
     },
     {
-      "src": "/src/assets/favicon_io/android-chrome-512x512.png",
+      "src": "/src/assets/AppIcons/Assets.xcassets/AppIcon.appiconset/512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
## Summary
- remove unnecessary icon copies from `public`
- link browser favicon from `favicon_io`
- point manifest and apple icon at `AppIcons` assets

## Testing
- `npm --prefix front-end test`
- `npm --prefix front-end run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_688685fafe1c832c8f2336ba5a22e6f9