### PR TITLE
Fix CORS credentials in Flask API

### DIFF
--- a/back-end/app/__init__.py
+++ b/back-end/app/__init__.py
@@ -22,7 +22,11 @@ def create_app(cfg_cls: type[Config] = Config) -> Flask:
 
 
 
-    CORS(app, resources={r"/*": {"origins": app.config["CORS_ORIGINS"]}})
+    CORS(
+        app,
+        resources={r"/*": {"origins": app.config["CORS_ORIGINS"]}},
+        supports_credentials=True,
+    )
 
     db.init_app(app)
     cache.init_app(app)


### PR DESCRIPTION
## Summary
- allow cookie credentials for the API by enabling `supports_credentials` in Flask CORS setup

## Testing
- `ruff check back-end coclib db`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_6886ca36a5c0832c902741663b49aa05