### PR TITLE
Fix deploy duplicates and speed up Java builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,6 @@ name: Build and Deploy
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-    types: [closed]
 
 permissions:
   contents: read
@@ -31,7 +28,7 @@ env:
 
 jobs:
   detect:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       app_any_changed: ${{ steps.changes.outputs.app_any_changed }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,5 +33,6 @@ jobs:
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
+          token: ${{ secrets.PR_TOKEN }} 
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   nox:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,6 +33,5 @@ jobs:
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.PR_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash

--- a/messages-java/Dockerfile
+++ b/messages-java/Dockerfile
@@ -1,15 +1,12 @@
-# syntax=docker/dockerfile:1.5
+# syntax=docker/dockerfile:1.7
 FROM gradle:8.7-jdk21 AS build
 WORKDIR /workspace/messages-java
-
 COPY build.gradle settings.gradle ./
-RUN --mount=type=cache,target=/home/gradle/.gradle \
-    gradle --no-daemon build -x test || true
-
+RUN --mount=type=cache,id=gradle-cache,target=/home/gradle/.gradle \
+    gradle --daemon --build-cache dependencies
 COPY src ./src
-RUN --mount=type=cache,target=/home/gradle/.gradle \
-    gradle --no-daemon bootJar
-
+RUN --mount=type=cache,id=gradle-cache,target=/home/gradle/.gradle \
+    gradle --daemon --build-cache bootJar
 
 FROM eclipse-temurin:21-jre-jammy
 WORKDIR /opt/app

--- a/messages-java/gradle.properties
+++ b/messages-java/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching = true

--- a/notifications/Dockerfile
+++ b/notifications/Dockerfile
@@ -1,13 +1,12 @@
-# syntax=docker/dockerfile:1.5
+# syntax=docker/dockerfile:1.7
 FROM gradle:8.7-jdk21 AS build
 WORKDIR /workspace/notifications
 COPY build.gradle settings.gradle ./
-RUN --mount=type=cache,target=/home/gradle/.gradle \
-    gradle --no-daemon build -x test || true
-
+RUN --mount=type=cache,id=gradle-cache,target=/home/gradle/.gradle \
+    gradle --daemon --build-cache dependencies
 COPY src ./src
-RUN --mount=type=cache,target=/home/gradle/.gradle \
-    gradle --no-daemon bootJar
+RUN --mount=type=cache,id=gradle-cache,target=/home/gradle/.gradle \
+    gradle --daemon --build-cache bootJar
 
 FROM eclipse-temurin:21-jre-jammy
 WORKDIR /opt/app

--- a/notifications/gradle.properties
+++ b/notifications/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching = true

--- a/user_service/Dockerfile
+++ b/user_service/Dockerfile
@@ -1,14 +1,12 @@
-# syntax=docker/dockerfile:1.5
+# syntax=docker/dockerfile:1.7
 FROM gradle:8.7-jdk21 AS build
 WORKDIR /workspace/user-service
-
 COPY build.gradle settings.gradle ./
-RUN --mount=type=cache,target=/home/gradle/.gradle \
-    gradle --no-daemon build -x test || true
-
+RUN --mount=type=cache,id=gradle-cache,target=/home/gradle/.gradle \
+    gradle --daemon --build-cache dependencies
 COPY src ./src
-RUN --mount=type=cache,target=/home/gradle/.gradle \
-    gradle --no-daemon bootJar
+RUN --mount=type=cache,id=gradle-cache,target=/home/gradle/.gradle \
+    gradle --daemon --build-cache bootJar
 
 FROM eclipse-temurin:21-jre-jammy
 WORKDIR /opt/app

--- a/user_service/gradle.properties
+++ b/user_service/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching = true


### PR DESCRIPTION
## Summary
- avoid double deploys by only triggering on push to main
- speed up building of Java services with cache mounts
- enable Gradle build caching

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6886cce4c264832ca7b289ca458f7802