### PR TITLE
Fix JWT verification for HS512 tokens

### DIFF
--- a/back-end/app/__init__.py
+++ b/back-end/app/__init__.py
@@ -55,7 +55,7 @@ def create_app(cfg_cls: type[Config] = Config) -> Flask:
         if not token:
             abort(401)
         try:
-            info = jwt.decode(token, signing_key, algorithms=["HS256"])
+            info = jwt.decode(token, signing_key, algorithms=["HS256", "HS384", "HS512"])
         except Exception as exc:
             logger.warning("Token verification failed: %s", exc)
             abort(401)

--- a/tests/test_auth_alg.py
+++ b/tests/test_auth_alg.py
@@ -1,0 +1,36 @@
+import pathlib
+import sys
+import jwt
+from flask.testing import FlaskClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+from app import create_app
+from coclib.config import Config
+from coclib.extensions import db
+from coclib.models import User
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    JWT_SIGNING_KEY = "supersecretkeylongerthan32bytes!"
+
+
+def _make_token(key: str) -> str:
+    return jwt.encode({"sub": "abc"}, key, algorithm="HS512")
+
+
+def test_hs512_token(monkeypatch):
+    app = create_app(TestConfig)
+    client: FlaskClient = app.test_client()
+    with app.app_context():
+        db.create_all()
+        db.session.add(User(id=1, sub="abc", email="u@example.com", name="U", player_tag="AAA"))
+        db.session.commit()
+
+    token = _make_token(TestConfig.JWT_SIGNING_KEY)
+    resp = client.get(
+        "/api/v1/user/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- support HS256, HS384 and HS512 algorithms when verifying JWTs
- test that HS512 session tokens authenticate successfully

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6886d9812a20832cba85836a745ae80f