### PR TITLE
Fix push subscription auth

### DIFF
--- a/notifications/src/main/java/com/clanboards/notifications/config/AuthFilter.java
+++ b/notifications/src/main/java/com/clanboards/notifications/config/AuthFilter.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,9 +29,19 @@ public class AuthFilter extends OncePerRequestFilter {
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     String auth = request.getHeader("Authorization");
-    HttpServletRequest req = request;
+    String token = null;
     if (auth != null && auth.startsWith("Bearer ")) {
-      String token = auth.substring(7);
+      token = auth.substring(7);
+    } else if (request.getCookies() != null) {
+      for (Cookie c : request.getCookies()) {
+        if ("sid".equals(c.getName())) {
+          token = c.getValue();
+          break;
+        }
+      }
+    }
+    HttpServletRequest req = request;
+    if (token != null) {
       try {
         Claims claims =
             Jwts.parserBuilder()

--- a/notifications/src/test/java/com/clanboards/notifications/NotificationControllerAuthTest.java
+++ b/notifications/src/test/java/com/clanboards/notifications/NotificationControllerAuthTest.java
@@ -78,4 +78,14 @@ class NotificationControllerAuthTest {
                 .content("{\"endpoint\":\"e\",\"p256dhKey\":\"k\",\"authKey\":\"a\"}"))
         .andExpect(status().isOk());
   }
+
+  @Test
+  void validCookieSucceeds() throws Exception {
+    mvc.perform(
+            post("/api/v1/notifications/subscribe")
+                .cookie(new jakarta.servlet.http.Cookie("sid", token("1")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"endpoint\":\"e\",\"p256dhKey\":\"k\",\"authKey\":\"a\"}"))
+        .andExpect(status().isOk());
+  }
 }


### PR DESCRIPTION
## Summary
- allow notifications service to read the `sid` cookie
- test cookie-based authentication works

## Testing
- `nox -s lint tests`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886de84f060832c8911b5880c5be646