### PR TITLE
Fix GraphQL auth for cookie-based JWTs

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/config/AuthInterceptor.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/AuthInterceptor.java
@@ -21,9 +21,23 @@ public class AuthInterceptor implements WebGraphQlInterceptor {
 
   @Override
   public Mono<WebGraphQlResponse> intercept(WebGraphQlRequest request, Chain chain) {
+    String token = null;
     String auth = request.getHeaders().getFirst("Authorization");
     if (auth != null && auth.startsWith("Bearer ")) {
-      String token = auth.substring(7);
+      token = auth.substring(7);
+    } else {
+      String cookie = request.getHeaders().getFirst("Cookie");
+      if (cookie != null) {
+        for (String part : cookie.split(";")) {
+          String trimmed = part.trim();
+          if (trimmed.startsWith("sid=")) {
+            token = trimmed.substring(4);
+            break;
+          }
+        }
+      }
+    }
+    if (token != null) {
       try {
         Claims claims =
             Jwts.parserBuilder()


### PR DESCRIPTION
## Summary
- handle JWT auth tokens provided via `sid` cookie in the messages service

## Testing
- `./gradlew test` in `messages-java`
- `ruff check back-end coclib db`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_6886eec6595c832ca076a1c6f2a585e9