### PR TITLE
Fix account page logout

### DIFF
--- a/front-end/src/pages/Account.jsx
+++ b/front-end/src/pages/Account.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useAuth } from '../hooks/useAuth.jsx';
 import { Info } from 'lucide-react';
 import { fetchJSON } from '../lib/api.js';
 import Loading from '../components/Loading.jsx';
@@ -7,6 +8,7 @@ import ChatBadge from '../components/ChatBadge.jsx';
 import RiskPrioritySelect from '../components/RiskPrioritySelect.jsx';
 
 export default function Account({ onVerified }) {
+  const { logout } = useAuth();
   const [profile, setProfile] = useState(null);
   const [saving, setSaving] = useState(false);
   const [token, setToken] = useState('');
@@ -148,8 +150,9 @@ export default function Account({ onVerified }) {
       </button>
       <button
         type="button"
-        onClick={() => {
+        onClick={async () => {
           window.google?.accounts.id.disableAutoSelect();
+          await logout();
           localStorage.removeItem('token');
           window.location.hash = '#/';
           window.location.reload();

--- a/front-end/src/pages/Account.test.jsx
+++ b/front-end/src/pages/Account.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { AuthProvider } from '../hooks/useAuth.jsx';
+import Account from './Account.jsx';
+
+var fetchJSON;
+var fetchJSONWithError;
+
+vi.mock('../lib/api.js', () => {
+  fetchJSON = vi.fn((path) => {
+    if (path === '/user/features') return Promise.resolve({ features: [], all: false });
+    return Promise.resolve({});
+  });
+  fetchJSONWithError = vi.fn(() => Promise.resolve({}));
+  return { fetchJSON, fetchJSONWithError };
+});
+
+describe('Account logout', () => {
+  it('calls backend logout endpoint', async () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...window.location, reload: vi.fn(), hash: '' },
+    });
+
+    render(
+      <AuthProvider>
+        <Account />
+      </AuthProvider>
+    );
+
+    // wait for profile to load
+    await screen.findByText('Profile');
+
+    const button = screen.getByText('Logout');
+    await fireEvent.click(button);
+
+    expect(fetchJSONWithError).toHaveBeenCalledWith('/logout', { method: 'POST' });
+  });
+});


### PR DESCRIPTION
## Summary
- fix logout issue on Account page by calling useAuth.logout
- add regression test for logout behavior

## Testing
- `nox -s lint tests`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68870a7cdd24832c973bd50c22dd9d71