### PR TITLE
Fix league badge icon caching

### DIFF
--- a/front-end/src/components/CachedImage.jsx
+++ b/front-end/src/components/CachedImage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import useCachedIcon from '../hooks/useCachedIcon.js';
 
-export default function CachedImage({ src, ...props }) {
-  const url = useCachedIcon(src);
+export default function CachedImage({ src, strategy = 'indexed', ...props }) {
+  const url = useCachedIcon(src, strategy);
   return <img src={url} {...props} />;
 }

--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import PlayerMini from './PlayerMini.jsx';
 
-export default function ChatMessage({ message, info, isSelf }) {
+export default function ChatMessage({ message, info, isSelf, cacheStrategy = 'indexed' }) {
   const { content } = message;
   const senderTag = message.senderId?.startsWith('#')
     ? message.senderId
@@ -51,6 +51,7 @@ export default function ChatMessage({ message, info, isSelf }) {
             <PlayerMini
               player={{ name: info.name, tag: senderTag, leagueIcon: info.icon }}
               showTag={false}
+              cacheStrategy={cacheStrategy}
             />
           </div>
         )}

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -226,6 +226,7 @@ useEffect(() => {
                       message={m}
                       info={infoMap[sender]}
                       isSelf={sender === userId}
+                      cacheStrategy={tab === 'Global' ? 'memory' : 'indexed'}
                     />
                   );
                 })

--- a/front-end/src/components/PlayerMini.jsx
+++ b/front-end/src/components/PlayerMini.jsx
@@ -7,6 +7,7 @@ export default function PlayerMini({
   player: preload,
   showTag = true,
   showLeague = true,
+  cacheStrategy = 'indexed',
 }) {
   const [player, setPlayer] = useState(preload || null);
 
@@ -43,6 +44,7 @@ export default function PlayerMini({
         <CachedImage
           key={player.tag}
           src={player.leagueIcon}
+          strategy={cacheStrategy}
           alt="league"
           className="w-4 h-4"
         />

--- a/front-end/src/hooks/useCachedIcon.js
+++ b/front-end/src/hooks/useCachedIcon.js
@@ -1,25 +1,29 @@
 import { useEffect, useState } from 'react';
 import { proxyImageUrl, fetchCachedIcon } from '../lib/assets.js';
 
-export default function useCachedIcon(url) {
-  const [src, setSrc] = useState(() => proxyImageUrl(url));
+export default function useCachedIcon(url, strategy = 'indexed') {
+  const [src, setSrc] = useState('');
 
   useEffect(() => {
     if (!url) return;
     let ignore = false;
     let objectUrl;
-    fetchCachedIcon(url)
+    fetchCachedIcon(url, strategy)
       .then((blob) => {
-        if (ignore || !blob) return;
-        objectUrl = URL.createObjectURL(blob);
-        setSrc(objectUrl);
+        if (!blob) return;
+        if (!ignore) {
+          objectUrl = URL.createObjectURL(blob);
+          setSrc(objectUrl);
+        }
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!ignore) setSrc(proxyImageUrl(url));
+      });
     return () => {
       ignore = true;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [url]);
+  }, [url, strategy]);
 
   return src;
 }

--- a/front-end/src/lib/assets.js
+++ b/front-end/src/lib/assets.js
@@ -2,6 +2,10 @@ import { API_URL } from './api.js';
 import { getIconCache, putIconCache } from './db.js';
 
 const ICON_TTL = 30 * 60 * 1000; // 30 minutes
+// in memory cache used for global chat where the number of league
+// badges can grow quickly. Each entry mirrors the structure stored in
+// indexedDB but lives only for the current session.
+const memoryCache = new Map();
 
 const API_PREFIX = '/api/v1';
 
@@ -11,12 +15,38 @@ export function proxyImageUrl(url) {
   return `${API_URL}${API_PREFIX}/assets?url=${encodeURIComponent(url)}`;
 }
 
-export async function fetchCachedIcon(url) {
+export async function fetchCachedIcon(url, strategy = 'indexed') {
   if (!url || !/^https?:\/\//i.test(url)) return undefined;
   const proxied = proxyImageUrl(url);
+  const now = Date.now();
+
+  if (strategy === 'memory') {
+    const cached = memoryCache.get(proxied);
+    if (cached) {
+      const age = now - cached.ts;
+      if (age < ICON_TTL) {
+        // refresh icon in background when stale but still valid
+        if (age > ICON_TTL / 2) {
+          fetch(proxied)
+            .then((res) => (res.ok ? res.blob() : null))
+            .then((blob) => {
+              if (blob) memoryCache.set(proxied, { blob, ts: Date.now() });
+            })
+            .catch(() => {});
+        }
+        return cached.blob;
+      }
+    }
+    const res = await fetch(proxied);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const blob = await res.blob();
+    memoryCache.set(proxied, { blob, ts: now });
+    return blob;
+  }
+
   const cached = await getIconCache(proxied);
   if (cached) {
-    const age = Date.now() - cached.ts;
+    const age = now - cached.ts;
     if (age < ICON_TTL) {
       return cached.blob;
     }
@@ -34,6 +64,6 @@ export async function fetchCachedIcon(url) {
   const res = await fetch(proxied);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const blob = await res.blob();
-  await putIconCache({ url: proxied, ts: Date.now(), blob });
+  await putIconCache({ url: proxied, ts: now, blob });
   return blob;
 }

--- a/front-end/src/lib/assets.test.js
+++ b/front-end/src/lib/assets.test.js
@@ -47,4 +47,21 @@ describe('fetchCachedIcon', () => {
     expect(typeof cached.blob.size).toBe('number');
   });
 
+  it('supports memory caching strategy', async () => {
+    const url = 'https://api-assets.clashofclans.com/mem.png';
+    const proxied = `${API_URL}/api/v1/assets?url=${encodeURIComponent(url)}`;
+    const blob = new Blob(['img'], { type: 'image/png' });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(blob, { status: 200 }));
+    global.fetch = fetchMock;
+
+    const data1 = await fetchCachedIcon(url, 'memory');
+    expect(fetchMock).toHaveBeenCalledWith(proxied);
+    expect(typeof data1.size).toBe('number');
+
+    fetchMock.mockClear();
+    const data2 = await fetchCachedIcon(url, 'memory');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(typeof data2.size).toBe('number');
+  });
+
 });


### PR DESCRIPTION
## Summary
- load cached league icons before making network requests
- support indexedDB or memory caching strategies
- use memory cache for global chat messages
- test memory cache path for icons

## Testing
- `npm install`
- `npm test`
- `npm run build`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_68871809fb98832caa0cdfbbf2ed6888