### PR TITLE
Fix badge visibility and add log endpoint

### DIFF
--- a/back-end/app/__init__.py
+++ b/back-end/app/__init__.py
@@ -44,6 +44,7 @@ def create_app(cfg_cls: type[Config] = Config) -> Flask:
         if (
             request.method == "OPTIONS"
             or path.endswith("/health")
+            or path.endswith("/log")
             or path.startswith(asset_prefix)
         ):
             return

--- a/back-end/app/api/__init__.py
+++ b/back-end/app/api/__init__.py
@@ -9,6 +9,7 @@ from .war_routes import bp as war_bp
 from .health_routes import bp as health_bp
 from .user_routes import bp as user_bp
 from .asset_routes import bp as asset_bp
+from .log_routes import bp as log_bp
 
 
 def register_blueprints(app: Flask):
@@ -18,3 +19,4 @@ def register_blueprints(app: Flask):
     app.register_blueprint(health_bp)
     app.register_blueprint(user_bp)
     app.register_blueprint(asset_bp)
+    app.register_blueprint(log_bp)

--- a/back-end/app/api/log_routes.py
+++ b/back-end/app/api/log_routes.py
@@ -1,0 +1,14 @@
+import logging
+from flask import Blueprint, request, jsonify
+from . import API_PREFIX
+
+bp = Blueprint("log", __name__, url_prefix=f"{API_PREFIX}")
+
+logger = logging.getLogger(__name__)
+
+@bp.post("/log")
+def log_message():
+    data = request.get_json(silent=True) or {}
+    message = data.get("message", "")
+    logger.info("SW log: %s", message)
+    return jsonify({"status": "ok"})

--- a/tests/test_log_route.py
+++ b/tests/test_log_route.py
@@ -1,0 +1,22 @@
+import sys
+import pathlib
+from flask.testing import FlaskClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+
+from app import create_app
+from coclib.config import Config
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    GOOGLE_CLIENT_ID = "dummy"
+
+
+def test_log_endpoint():
+    app = create_app(TestConfig)
+    client: FlaskClient = app.test_client()
+    resp = client.post("/api/v1/log", json={"message": "hello"})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- allow setting client badge on desktop browsers
- update push notifications to use player name in preview
- send service worker errors to new `/api/v1/log` endpoint
- exempt log endpoint from auth
- test log endpoint

## Testing
- `nox -s lint tests`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887ac2b2eec832cba46e412301cdeb9