### PR TITLE
Add player name to push payloads

### DIFF
--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -49,6 +49,20 @@ export default function ChatPanel({
   const containerRef = useRef(null);
 
   useEffect(() => {
+    if (
+      'serviceWorker' in navigator &&
+      tab === 'Friends' &&
+      directChatId
+    ) {
+      navigator.serviceWorker.ready
+        .then((reg) => {
+          reg.active?.postMessage({ type: 'clear-badge' });
+        })
+        .catch(() => {});
+    }
+  }, [tab, directChatId]);
+
+  useEffect(() => {
     const handler = (e) => {
       if (e.detail) {
         setDirectChatId(e.detail);

--- a/notifications/src/main/java/com/clanboards/notifications/repository/PlayerRepository.java
+++ b/notifications/src/main/java/com/clanboards/notifications/repository/PlayerRepository.java
@@ -1,0 +1,6 @@
+package com.clanboards.notifications.repository;
+
+import com.clanboards.notifications.repository.entity.Player;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlayerRepository extends JpaRepository<Player, String> {}

--- a/notifications/src/main/java/com/clanboards/notifications/repository/entity/Player.java
+++ b/notifications/src/main/java/com/clanboards/notifications/repository/entity/Player.java
@@ -1,0 +1,28 @@
+package com.clanboards.notifications.repository.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "players")
+public class Player {
+  @Id private String tag;
+  private String name;
+
+  public String getTag() {
+    return tag;
+  }
+
+  public void setTag(String tag) {
+    this.tag = tag;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}


### PR DESCRIPTION
## Summary
- include Player entity & repository in notifications service
- inject player name into push payloads
- simplify service worker push handling and use name from payload
- reset unread counts when opening a friend chat

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6887b8acaca0832cb60a77a54ecb87ff