### PR TITLE
Add clan mention autocomplete and rendering

### DIFF
--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -3,6 +3,28 @@ import PlayerMini from './PlayerMini.jsx';
 
 export default function ChatMessage({ message, info, isSelf, cacheStrategy = 'indexed' }) {
   const { content } = message;
+  const parts = [];
+  const regex = /@\{(#[^}]+)\}/g;
+  let last = 0;
+  let m;
+  let idx = 0;
+  while ((m = regex.exec(content)) !== null) {
+    if (m.index > last) {
+      parts.push(content.slice(last, m.index));
+    }
+    parts.push(
+      <PlayerMini
+        key={`mention-${idx++}`}
+        tag={m[1]}
+        showTag={false}
+        cacheStrategy={cacheStrategy}
+      />
+    );
+    last = regex.lastIndex;
+  }
+  if (last < content.length) {
+    parts.push(content.slice(last));
+  }
   const senderTag = message.senderId?.startsWith('#')
     ? message.senderId
     : message.userId?.startsWith('#')
@@ -45,7 +67,9 @@ export default function ChatMessage({ message, info, isSelf, cacheStrategy = 'in
       <div
         className={`max-w-[80%] rounded px-2 py-1 select-none ${isSelf ? 'bg-blue-100' : 'bg-slate-100'}`}
       >
-        {content}
+        {parts.map((p, i) => (
+          <React.Fragment key={i}>{p}</React.Fragment>
+        ))}
         {info && (
           <div className="mt-1 text-xs text-slate-500">
             <PlayerMini

--- a/front-end/src/components/ChatMessage.test.jsx
+++ b/front-end/src/components/ChatMessage.test.jsx
@@ -4,8 +4,13 @@ import '@testing-library/jest-dom';
 vi.mock('../hooks/useCachedIcon.js', () => ({
   default: (url) => url,
 }));
+vi.mock('../lib/api.js', () => ({
+  fetchJSONCached: vi.fn(),
+  API_URL: '',
+}));
 
 import ChatMessage from './ChatMessage.jsx';
+import { fetchJSONCached } from '../lib/api.js';
 
 const sample = { name: 'Alice', icon: 'http://ex/icon.png' };
 
@@ -53,5 +58,21 @@ describe('ChatMessage', () => {
     expect(handler).toHaveBeenCalledTimes(1);
     window.removeEventListener('open-friend-add', handler);
     vi.useRealTimers();
+  });
+
+  it('renders mentioned player from tag', async () => {
+    fetchJSONCached.mockResolvedValue({
+      name: 'Bob',
+      tag: '#TAG',
+      leagueIcon: 'http://ex/b.png',
+    });
+    render(
+      <ChatMessage
+        message={{ content: 'hi @{#TAG}', userId: '#A1B2C' }}
+        info={sample}
+      />,
+    );
+    expect(await screen.findByText('Bob')).toBeInTheDocument();
+    expect(fetchJSONCached).toHaveBeenCalledWith('/player/%23TAG');
   });
 });

--- a/front-end/src/components/ChatPanel.jsx
+++ b/front-end/src/components/ChatPanel.jsx
@@ -8,6 +8,8 @@ import ChatMessage from './ChatMessage.jsx';
 import Loading from './Loading.jsx';
 import FriendsPanel from './FriendsPanel.jsx';
 import AddFriendDialog from './AddFriendDialog.jsx';
+import MentionInput from './MentionInput.jsx';
+import useClanMembers from '../hooks/useClanMembers.js';
 
 export default function ChatPanel({
   chatId = null,
@@ -47,6 +49,7 @@ export default function ChatPanel({
   const [loadingMore, setLoadingMore] = useState(false);
   const endRef = useRef(null);
   const containerRef = useRef(null);
+  const clanMembers = useClanMembers(tab === 'Clan' ? chatId : null);
 
   useEffect(() => {
     if (
@@ -251,10 +254,10 @@ useEffect(() => {
         </div>
         {(tab !== 'Friends' || directChatId) && !(tab === 'Clan' && !chatId) && (
           <form onSubmit={handleSubmit} className="flex gap-2 p-2 border-t">
-            <input
-              className="flex-1 border rounded px-2 py-1"
+            <MentionInput
+              members={clanMembers.map((m) => ({ name: m.name, tag: m.tag }))}
               value={text}
-              onChange={(e) => setText(e.target.value)}
+              onChange={setText}
               placeholder="Type a message…"
             />
             <button

--- a/front-end/src/components/MentionInput.jsx
+++ b/front-end/src/components/MentionInput.jsx
@@ -1,0 +1,71 @@
+import React, { useState, useRef } from 'react';
+
+export default function MentionInput({ value, onChange, members = [], ...props }) {
+  const [showList, setShowList] = useState(false);
+  const [query, setQuery] = useState('');
+  const [start, setStart] = useState(0);
+  const ref = useRef(null);
+
+  function update(val, pos) {
+    const at = val.lastIndexOf('@', pos - 1);
+    if (at >= 0 && (at === 0 || /\s/.test(val[at - 1]))) {
+      const q = val.slice(at + 1, pos);
+      if (q.length > 0) {
+        setQuery(q.toLowerCase());
+        setStart(at);
+        setShowList(true);
+        return;
+      }
+    }
+    setShowList(false);
+  }
+
+  function handleChange(e) {
+    const val = e.target.value;
+    onChange(val);
+    update(val, e.target.selectionStart);
+  }
+
+  function select(member) {
+    const before = value.slice(0, start);
+    const after = value.slice(start + query.length + 1);
+    const insert = `@{${member.tag}}`;
+    const newVal = `${before}${insert}${after}`;
+    onChange(newVal);
+    setShowList(false);
+    setQuery('');
+    ref.current?.focus();
+  }
+
+  const filtered = members
+    .filter((m) => m.name.toLowerCase().includes(query))
+    .slice(0, 5);
+
+  return (
+    <div className="relative flex-1">
+      <input
+        ref={ref}
+        className="w-full border rounded px-2 py-1"
+        value={value}
+        onChange={handleChange}
+        {...props}
+      />
+      {showList && filtered.length > 0 && (
+        <ul className="absolute z-10 bg-white border rounded shadow mt-1 w-full max-h-40 overflow-auto">
+          {filtered.map((m) => (
+            <li
+              key={m.tag}
+              className="px-2 py-1 hover:bg-slate-100 cursor-pointer"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                select(m);
+              }}
+            >
+              {m.name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/front-end/src/hooks/useClanMembers.js
+++ b/front-end/src/hooks/useClanMembers.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { fetchJSONCached } from '../lib/api.js';
+import { getClanCache, putClanCache } from '../lib/db.js';
+
+export default function useClanMembers(clanTag) {
+  const [members, setMembers] = useState([]);
+
+  useEffect(() => {
+    if (!clanTag) return;
+    let ignore = false;
+    const key = `members:${clanTag}`;
+    (async () => {
+      const cached = await getClanCache(key);
+      if (cached && !ignore) {
+        setMembers(cached.members || []);
+      }
+      try {
+        const data = await fetchJSONCached(`/clan/${encodeURIComponent(clanTag)}`);
+        if (!ignore) setMembers(data.memberList || []);
+        try {
+          await putClanCache({ key, members: data.memberList || [] });
+        } catch (err) {
+          console.error('Failed to cache clan members', err);
+        }
+      } catch (err) {
+        console.error('Failed to load clan members', err);
+      }
+    })();
+    return () => {
+      ignore = true;
+    };
+  }, [clanTag]);
+
+  return members;
+}


### PR DESCRIPTION
## Summary
- load clan members with a new `useClanMembers` hook
- add `MentionInput` component for chat message entry
- autocomplete clan members when typing '@' in chat
- parse `@{TAG}` mentions in messages and render with `PlayerMini`
- test mention rendering in ChatMessage

## Testing
- `npm install`
- `npm test`
- `npm run build`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6887be4cbf34832cbad85d39eef2213f