### PR TITLE
Fix mention dropdown position

### DIFF
--- a/front-end/src/components/MentionInput.jsx
+++ b/front-end/src/components/MentionInput.jsx
@@ -51,7 +51,7 @@ export default function MentionInput({ value, onChange, members = [], ...props }
         {...props}
       />
       {showList && filtered.length > 0 && (
-        <ul className="absolute z-10 bg-white border rounded shadow mt-1 w-full max-h-40 overflow-auto">
+        <ul className="absolute bottom-full mb-1 z-10 bg-white border rounded shadow w-full max-h-40 overflow-auto">
           {filtered.map((m) => (
             <li
               key={m.tag}


### PR DESCRIPTION
## Summary
- open mention suggestions above the input so they remain visible

## Testing
- `nox -s lint tests`
- `ruff check back-end coclib db`
- `npm install`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887c3322564832cb0b39bef6333747f