### PR TITLE
Implement IndexedDB caching hooks for clan and player info

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -4,7 +4,8 @@ import { ArrowLeft } from 'lucide-react';
 import CachedImage from './components/CachedImage.jsx';
 import Loading from './components/Loading.jsx';
 import PlayerTagForm from './components/PlayerTagForm.jsx';
-import { fetchJSON } from './lib/api.js';
+import usePlayerInfo from './hooks/usePlayerInfo.js';
+import useClanInfo from './hooks/useClanInfo.js';
 import { useAuth } from './hooks/useAuth.jsx';
 import useFeatures from './hooks/useFeatures.js';
 import BottomNav from './components/BottomNav.jsx';
@@ -57,6 +58,9 @@ export default function App() {
   const chatAllowed = hasFeature('chat');
   const menuRef = React.useRef(null);
 
+  const playerInfo = usePlayerInfo(playerTag);
+  const cachedClan = useClanInfo(clanTag);
+
   useEffect(() => {
     if (!('serviceWorker' in navigator)) return;
     function handler(event) {
@@ -85,64 +89,37 @@ export default function App() {
   }, [user]);
 
   useEffect(() => {
-    const updateFromUser = async () => {
-      if (!user) {
-        setPlayerTag(null);
-        setVerified(false);
-        setNumericId(null);
-        setClanTag(null);
-        setHomeClanTag(null);
-        return;
-      }
-      setLoadingUser(true);
-      setPlayerTag(user.player_tag);
-      setVerified(user.verified);
-      setUserId(user.sub);
-      setNumericId(user.id);
-      if (user.player_tag) {
-        try {
-          const player = await fetchJSON(`/player/${encodeURIComponent(user.player_tag)}`);
-          if (player.clanTag) {
-            setClanTag(player.clanTag);
-            setHomeClanTag(player.clanTag);
-          }
-        } catch (err) {
-          console.error('Failed to load clan', err);
-        }
-      }
+    if (!user) {
+      setPlayerTag(null);
+      setVerified(false);
+      setNumericId(null);
+      setClanTag(null);
+      setHomeClanTag(null);
       setLoadingUser(false);
-    };
-    updateFromUser();
+      return;
+    }
+    setLoadingUser(true);
+    setPlayerTag(user.player_tag);
+    setVerified(user.verified);
+    setUserId(user.sub);
+    setNumericId(user.id);
+    setLoadingUser(false);
   }, [user]);
 
   useEffect(() => {
-    const loadClan = async () => {
-      if (!playerTag) return;
-      try {
-        const player = await fetchJSON(`/player/${encodeURIComponent(playerTag)}`);
-        if (player.clanTag) {
-          setClanTag(player.clanTag);
-          if (!homeClanTag) setHomeClanTag(player.clanTag);
-        }
-      } catch (err) {
-        console.error('Failed to load clan', err);
-      }
-    };
-    loadClan();
+    if (playerTag) setLoadingUser(false);
   }, [playerTag]);
 
   useEffect(() => {
-    const loadInfo = async () => {
-      if (!clanTag) return;
-      try {
-        const data = await fetchJSON(`/clan/${encodeURIComponent(clanTag)}`);
-        setClanInfo(data);
-      } catch (err) {
-        console.error('Failed to load clan info', err);
-      }
-    };
-    loadInfo();
-  }, [clanTag]);
+    if (playerInfo && playerInfo.clanTag) {
+      setClanTag(playerInfo.clanTag);
+      if (!homeClanTag) setHomeClanTag(playerInfo.clanTag);
+    }
+  }, [playerInfo]);
+
+  useEffect(() => {
+    if (cachedClan) setClanInfo(cachedClan);
+  }, [cachedClan]);
 
 
 

--- a/front-end/src/hooks/useClanInfo.js
+++ b/front-end/src/hooks/useClanInfo.js
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { fetchJSONCached } from '../lib/api.js';
+import { getClanCache, putClanCache } from '../lib/db.js';
+
+const CLAN_TTL = 5 * 60 * 1000; // 5 minutes
+
+export default function useClanInfo(tag) {
+  const [clan, setClan] = useState(null);
+
+  useEffect(() => {
+    if (!tag) {
+      setClan(null);
+      return;
+    }
+    let cancelled = false;
+    const key = `clan:${tag}`;
+    (async () => {
+      const cached = await getClanCache(key);
+      if (cached && cached.clan) {
+        setClan(cached.clan);
+        if (Date.now() - (cached.ts || 0) < CLAN_TTL) {
+          return;
+        }
+      }
+      fetchJSONCached(`/clan/${encodeURIComponent(tag)}`)
+        .then(async (data) => {
+          if (cancelled) return;
+          setClan(data);
+          try {
+            await putClanCache({ ...(cached || {}), key, clan: data, ts: Date.now() });
+          } catch (err) {
+            console.error('Failed to cache clan info', err);
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to load clan info', err);
+        });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tag]);
+
+  return clan;
+}

--- a/front-end/src/hooks/useClanInfo.test.js
+++ b/front-end/src/hooks/useClanInfo.test.js
@@ -1,0 +1,7 @@
+import useClanInfo from './useClanInfo.js';
+
+describe('useClanInfo hook', () => {
+  it('exports a function', () => {
+    expect(typeof useClanInfo).toBe('function');
+  });
+});

--- a/front-end/src/hooks/usePlayerInfo.js
+++ b/front-end/src/hooks/usePlayerInfo.js
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { fetchJSONCached } from '../lib/api.js';
+import { getPlayerCache, putPlayerCache } from '../lib/db.js';
+
+const PLAYER_TTL = 5 * 60 * 1000; // 5 minutes
+
+export default function usePlayerInfo(tag) {
+  const [player, setPlayer] = useState(null);
+
+  useEffect(() => {
+    if (!tag) {
+      setPlayer(null);
+      return;
+    }
+    let cancelled = false;
+    const key = `player:${tag}`;
+    (async () => {
+      const cached = await getPlayerCache(key);
+      if (cached) {
+        setPlayer(cached.data);
+        if (Date.now() - cached.ts < PLAYER_TTL) {
+          return;
+        }
+      }
+      fetchJSONCached(`/player/${encodeURIComponent(tag)}`)
+        .then(async (data) => {
+          if (cancelled) return;
+          setPlayer(data);
+          try {
+            await putPlayerCache({ key, ts: Date.now(), data });
+          } catch (err) {
+            console.error('Failed to cache player info', err);
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to load player info', err);
+        });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tag]);
+
+  return player;
+}

--- a/front-end/src/hooks/usePlayerInfo.test.js
+++ b/front-end/src/hooks/usePlayerInfo.test.js
@@ -1,0 +1,7 @@
+import usePlayerInfo from './usePlayerInfo.js';
+
+describe('usePlayerInfo hook', () => {
+  it('exports a function', () => {
+    expect(typeof usePlayerInfo).toBe('function');
+  });
+});

--- a/front-end/src/lib/db.js
+++ b/front-end/src/lib/db.js
@@ -1,6 +1,6 @@
 import { openDB } from 'idb';
 
-const dbPromise = openDB('coc-cache', 6, {
+const dbPromise = openDB('coc-cache', 7, {
   upgrade(db, oldVersion, newVersion, transaction) {
     if (oldVersion < 1) {
       db.createObjectStore('api', { keyPath: 'path' });
@@ -21,6 +21,9 @@ const dbPromise = openDB('coc-cache', 6, {
     if (oldVersion < 6) {
       db.createObjectStore('messages', { keyPath: 'chatId' });
     }
+    if (oldVersion < 7) {
+      db.createObjectStore('players', { keyPath: 'key' });
+    }
   },
 });
 
@@ -38,6 +41,14 @@ export async function getClanCache(key) {
 
 export async function putClanCache(record) {
   return (await dbPromise).put('clans', record);
+}
+
+export async function getPlayerCache(key) {
+  return (await dbPromise).get('players', key);
+}
+
+export async function putPlayerCache(record) {
+  return (await dbPromise).put('players', record);
 }
 
 export async function getIconCache(url) {


### PR DESCRIPTION
## Summary
- add `usePlayerInfo` and `useClanInfo` hooks with IndexedDB caching
- upgrade local DB schema and expose player cache helpers
- integrate new hooks in `App` and `Dashboard`
- persist clan cache timestamp and avoid stale reloads
- test hook exports

## Testing
- `npm install`
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_6887c6b86bb0832c8e857c5649806d72