### PR TITLE
Fix mention input display

### DIFF
--- a/front-end/src/components/MentionInput.jsx
+++ b/front-end/src/components/MentionInput.jsx
@@ -29,7 +29,7 @@ export default function MentionInput({ value, onChange, members = [], ...props }
   function select(member) {
     const before = value.slice(0, start);
     const after = value.slice(start + query.length + 1);
-    const insert = `@{${member.tag}}`;
+    const insert = `@${member.name}`;
     const newVal = `${before}${insert}${after}`;
     onChange(newVal);
     setShowList(false);


### PR DESCRIPTION
## Summary
- keep player name visible when selecting a mention

## Testing
- `npm test --silent`
- `npm run build --silent`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6887ce39743c832cace24f4277248f6e