### PR TITLE
Fix legal modal save and clean up TH labels

### DIFF
--- a/front-end/src/components/LegalModal.jsx
+++ b/front-end/src/components/LegalModal.jsx
@@ -1,6 +1,16 @@
 import React from 'react';
+import { fetchJSON } from '../lib/api.js';
 
 export default function LegalModal({ onClose }) {
+  async function accept() {
+    try {
+      await fetchJSON('/user/legal', { method: 'POST' });
+    } catch (err) {
+      console.error('Failed to accept legal', err);
+    }
+    onClose();
+  }
+
   return (
     <>
       <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose}></div>
@@ -16,7 +26,7 @@ export default function LegalModal({ onClose }) {
             <li><a href="#" className="text-blue-600 hover:underline">Privacy Policy</a></li>
             <li><a href="#" className="text-blue-600 hover:underline">Terms of Service</a></li>
           </ul>
-          <button className="mt-2 px-4 py-2 bg-blue-600 text-white rounded" onClick={onClose}>Accept</button>
+          <button className="mt-2 px-4 py-2 bg-blue-600 text-white rounded" onClick={accept}>Accept</button>
         </div>
       </div>
     </>

--- a/front-end/src/components/LegalModal.test.jsx
+++ b/front-end/src/components/LegalModal.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('../lib/api.js', () => ({
+  fetchJSON: vi.fn(),
+  API_URL: '',
+}));
+
+import LegalModal from './LegalModal.jsx';
+import { fetchJSON } from '../lib/api.js';
+
+describe('LegalModal', () => {
+  it('posts acceptance and closes', async () => {
+    const spy = vi.fn();
+    render(<LegalModal onClose={spy} />);
+    screen.getByText('Accept').click();
+    expect(fetchJSON).toHaveBeenCalledWith('/user/legal', { method: 'POST' });
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+  });
+});

--- a/front-end/src/components/MemberList.jsx
+++ b/front-end/src/components/MemberList.jsx
@@ -3,7 +3,6 @@ import { FixedSizeList as List } from 'react-window';
 import RiskRing from './RiskRing.jsx';
 import DonationRing from './DonationRing.jsx';
 import { timeAgo } from '../lib/time.js';
-import { getTownHallIcon } from '../lib/townhall.js';
 import PlayerMini from './PlayerMini.jsx';
 
 function Row({ index, style, data }) {
@@ -17,9 +16,6 @@ function Row({ index, style, data }) {
     >
       <div className="flex flex-col">
         <div className="flex items-center gap-2">
-          <span className="w-5 h-5 flex items-center justify-center font-semibold">
-            {getTownHallIcon(m.townHallLevel)}
-          </span>
           <span className="font-medium">
             <PlayerMini player={m} showTag={false} />
           </span>

--- a/front-end/src/components/ProfileCard.jsx
+++ b/front-end/src/components/ProfileCard.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import RiskRing from './RiskRing.jsx';
 import Loading from './Loading.jsx';
 import { timeAgo } from '../lib/time.js';
-import { getTownHallIcon } from '../lib/townhall.js';
 import PlayerMini from './PlayerMini.jsx';
 
 export default function ProfileCard({ member, onClick, refreshing = false }) {
@@ -19,13 +18,9 @@ export default function ProfileCard({ member, onClick, refreshing = false }) {
       )}
       <div className="flex gap-1 items-center mb-1">
         <PlayerMini player={member} showTag={false} />
-        <span className="w-6 h-6 flex items-center justify-center font-semibold">
-          {getTownHallIcon(member.townHallLevel)}
-        </span>
       </div>
       <RiskRing score={member.risk_score} size={48} />
       <div className="mt-2 text-center space-y-1 w-full">
-        <p>TH{member.townHallLevel}</p>
         <p className="text-xs text-slate-500">
           {member.last_seen ? timeAgo(member.last_seen) : '\u2014'}
         </p>

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -9,7 +9,6 @@ import DonationRing from '../components/DonationRing.jsx';
 import MemberList from '../components/MemberList.jsx';
 import ErrorBoundary from '../components/ErrorBoundary.jsx';
 import ProfileCard from '../components/ProfileCard.jsx';
-import { getTownHallIcon } from '../lib/townhall.js';
 import CachedImage from '../components/CachedImage.jsx';
 import PlayerMini from '../components/PlayerMini.jsx';
 import { Users, SearchX, TrendingUp, Trophy, Shield, ShieldOff } from 'lucide-react';
@@ -296,9 +295,6 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                 >
                                                     <td data-label="Player" className="px-4 py-2 font-medium">
                                                         <span className="flex items-center gap-2">
-                                                            <span className="w-5 h-5 flex items-center justify-center font-semibold">
-                                                                {getTownHallIcon(m.townHallLevel)}
-                                                            </span>
                                                             <PlayerMini player={m} showTag={false} />
                                                         </span>
                                                     </td>
@@ -362,9 +358,6 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                         <td data-label="Player" className="px-3 py-2 font-medium">
                                                             <div className="flex flex-col">
                                                                 <span className="flex items-center gap-2">
-                                                                    <span className="w-5 h-5 flex items-center justify-center font-semibold">
-                                                                        {getTownHallIcon(m.townHallLevel)}
-                                                                    </span>
                                                                     <PlayerMini player={m} showTag={false} />
                                                                 </span>
                                                                 <span className="text-xs text-slate-500">


### PR DESCRIPTION
## Summary
- save legal acceptance by calling `/user/legal`
- remove Town Hall text from member cards and lists
- add LegalModal test

## Testing
- `ruff check back-end coclib db`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_68881ced7574832c96fd110cfdcd3ae3