### PR TITLE
Fix privacy policy acceptance

### DIFF
--- a/back-end/app/api/user_routes.py
+++ b/back-end/app/api/user_routes.py
@@ -143,3 +143,16 @@ def accept_legal():
     db.session.add(rec)
     db.session.commit()
     return jsonify({"status": "ok"})
+
+
+@bp.get("/disclaimer")
+def get_disclaimer():
+    return jsonify({"seen": g.user.seen_supercell_disclaimer})
+
+
+@bp.post("/disclaimer")
+def accept_disclaimer():
+    g.user.seen_supercell_disclaimer = True
+    db.session.add(g.user)
+    db.session.commit()
+    return jsonify({"status": "ok"})

--- a/coclib/models.py
+++ b/coclib/models.py
@@ -103,6 +103,7 @@ class User(db.Model):
     name = db.Column(db.String(255))
     player_tag = db.Column(db.String(15), index=True)
     is_verified = db.Column(db.Boolean, nullable=False, default=False)
+    seen_supercell_disclaimer = db.Column(db.Boolean, nullable=False, default=False)
 
 
 class UserProfile(db.Model):

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -11,10 +11,12 @@ import useFeatures from './hooks/useFeatures.js';
 import BottomNav from './components/BottomNav.jsx';
 import DesktopNav from './components/DesktopNav.jsx';
 import NotificationBanner from './components/NotificationBanner.jsx';
+import { fetchJSON } from './lib/api.js';
 
 const Dashboard = lazy(() => import('./pages/Dashboard.jsx'));
 const ClanModal = lazy(() => import('./components/ClanModal.jsx'));
 const LegalModal = lazy(() => import('./components/LegalModal.jsx'));
+const DisclaimerModal = lazy(() => import('./components/DisclaimerModal.jsx'));
 const DashboardPage = lazy(() => import('./pages/Dashboard.jsx'));
 const ChatPage = lazy(() => import('./pages/ChatPage.jsx'));
 const ScoutPage = lazy(() => import('./pages/Scout.jsx'));
@@ -51,6 +53,7 @@ export default function App() {
   const [clanInfo, setClanInfo] = useState(null);
   const [showClanInfo, setShowClanInfo] = useState(false);
   const [showLegal, setShowLegal] = useState(false);
+  const [showDisclaimer, setShowDisclaimer] = useState(false);
   const [loadingUser, setLoadingUser] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
   const [badgeCount, setBadgeCount] = useState(0);
@@ -71,6 +74,18 @@ export default function App() {
       }
     }
     check();
+  }, []);
+
+  useEffect(() => {
+    async function checkDisc() {
+      try {
+        const res = await fetchJSON('/user/disclaimer');
+        if (!res.seen) setShowDisclaimer(true);
+      } catch (err) {
+        console.error('Failed to check disclaimer', err);
+      }
+    }
+    checkDisc();
   }, []);
 
   const playerInfo = usePlayerInfo(playerTag);
@@ -262,12 +277,21 @@ export default function App() {
           <ClanModal clan={clanInfo} onClose={() => setShowClanInfo(false)} />
         </Suspense>
       )}
+      {showDisclaimer && (
+        <Suspense fallback={<Loading className="h-screen" />}>
+          <DisclaimerModal onClose={() => setShowDisclaimer(false)} />
+        </Suspense>
+      )}
       {showLegal && (
         <Suspense fallback={<Loading className="h-screen" />}>
           <LegalModal
-            onClose={() => {
+            onAccept={() => {
               localStorage.setItem('tosAcceptedVersion', window.__LEGAL_VERSION__);
               setShowLegal(false);
+            }}
+            onDiscard={() => {
+              setShowLegal(false);
+              logout();
             }}
           />
         </Suspense>

--- a/front-end/src/components/DisclaimerModal.jsx
+++ b/front-end/src/components/DisclaimerModal.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { fetchJSON } from '../lib/api.js';
+
+export default function DisclaimerModal({ onClose }) {
+  async function acknowledge() {
+    try {
+      await fetchJSON('/user/disclaimer', { method: 'POST' });
+    } catch (err) {
+      console.error('Failed to record disclaimer', err);
+    }
+    onClose();
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={acknowledge}></div>
+      <div className="fixed inset-0 flex items-center justify-center z-50">
+        <div className="bg-white w-full max-w-sm rounded-xl shadow-xl p-6 relative text-center space-y-4">
+          <button className="absolute top-3 right-3 text-slate-400" onClick={acknowledge}>✕</button>
+          <h3 className="text-xl font-semibold mb-2">Clan Boards</h3>
+          <p className="text-sm">
+            This material is unofficial and is not endorsed by Supercell. For more information see{' '}
+            <a
+              href="https://supercell.com/en/fan-content-policy/"
+              className="text-blue-600 hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Supercell's Fan Content Policy
+            </a>.
+          </p>
+          <button className="mt-2 px-4 py-2 bg-blue-600 text-white rounded" onClick={acknowledge}>OK</button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/front-end/src/components/DisclaimerModal.test.jsx
+++ b/front-end/src/components/DisclaimerModal.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('../lib/api.js', () => ({
+  fetchJSON: vi.fn(),
+  API_URL: '',
+}));
+
+import DisclaimerModal from './DisclaimerModal.jsx';
+import { fetchJSON } from '../lib/api.js';
+
+describe('DisclaimerModal', () => {
+  it('posts on acknowledge and calls onClose', async () => {
+    const spy = vi.fn();
+    render(<DisclaimerModal onClose={spy} />);
+    screen.getByText('OK').click();
+    expect(fetchJSON).toHaveBeenCalledWith('/user/disclaimer', { method: 'POST' });
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+  });
+});

--- a/front-end/src/components/LegalModal.jsx
+++ b/front-end/src/components/LegalModal.jsx
@@ -1,10 +1,7 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { fetchJSON } from '../lib/api.js';
 
-export default function LegalModal({ onClose }) {
-  useEffect(() => {
-    console.log('Legal version', window.__LEGAL_VERSION__);
-  }, []);
+export default function LegalModal({ onAccept, onDiscard }) {
   async function accept() {
     try {
       await fetchJSON('/user/legal', {
@@ -15,30 +12,24 @@ export default function LegalModal({ onClose }) {
     } catch (err) {
       console.error('Failed to accept legal', err);
     }
-    onClose();
+    onAccept();
   }
 
   return (
     <>
-      <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose}></div>
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={onDiscard}></div>
       <div className="fixed inset-0 flex items-center justify-center z-50">
         <div className="bg-white w-full max-w-sm rounded-xl shadow-xl p-6 relative text-center space-y-4">
-          <button className="absolute top-3 right-3 text-slate-400" onClick={onClose}>✕</button>
+          <button className="absolute top-3 right-3 text-slate-400" onClick={onDiscard}>✕</button>
           <h3 className="text-xl font-semibold mb-2">Clan Boards</h3>
           <p className="text-sm">
-            This material is unofficial and is not endorsed by Supercell. For more information see
-            <a href="https://supercell.com/en/fan-content-policy/" className="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer"> Supercell's Fan Content Policy</a>.
+            By using this website, you agree to the storing of cookies on your device to enhance site navigation,
+            analyze site usage, and assist in our marketing efforts. View our{' '}
+            <a href="/privacy-policy" className="text-blue-600 hover:underline">
+              Privacy Policy
+            </a>{' '}
+            for more information.
           </p>
-          <ul className="space-y-1">
-            <li>
-              <a href="/privacy-policy" className="text-blue-600 hover:underline">
-                Privacy Policy
-              </a>
-            </li>
-            <li>
-              <a href="/terms" className="text-blue-600 hover:underline">Terms and Conditions</a>
-            </li>
-          </ul>
           <button className="mt-2 px-4 py-2 bg-blue-600 text-white rounded" onClick={accept}>Accept</button>
         </div>
       </div>

--- a/front-end/src/components/LegalModal.test.jsx
+++ b/front-end/src/components/LegalModal.test.jsx
@@ -11,16 +11,23 @@ import LegalModal from './LegalModal.jsx';
 import { fetchJSON } from '../lib/api.js';
 
 describe('LegalModal', () => {
-  it('posts acceptance and closes', async () => {
+  it('posts acceptance and calls onAccept', async () => {
     const spy = vi.fn();
     window.__LEGAL_VERSION__ = '20250729';
-    render(<LegalModal onClose={spy} />);
+    render(<LegalModal onAccept={spy} onDiscard={() => {}} />);
     screen.getByText('Accept').click();
     expect(fetchJSON).toHaveBeenCalledWith('/user/legal', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ version: '20250729' }),
     });
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+  });
+
+  it('calls onDiscard when closed', async () => {
+    const spy = vi.fn();
+    render(<LegalModal onAccept={() => {}} onDiscard={spy} />);
+    screen.getByRole('button', { name: '✕' }).click();
     await waitFor(() => expect(spy).toHaveBeenCalled());
   });
 });

--- a/migrations/versions/bf74125f_add_disclaimer_seen_to_user.py
+++ b/migrations/versions/bf74125f_add_disclaimer_seen_to_user.py
@@ -1,0 +1,23 @@
+"""add disclaimer seen field to users
+
+Revision ID: bf74125f
+Revises: cad1bc3dd940
+Create Date: 2025-10-06 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'bf74125f'
+down_revision = 'cad1bc3dd940'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('seen_supercell_disclaimer', sa.Boolean(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_column('seen_supercell_disclaimer')

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -79,3 +79,18 @@ def test_requires_accept_on_version_change(monkeypatch):
     data = resp.get_json()
     assert data["accepted"] is False
     assert data["version"] == "20250728"
+
+
+def test_disclaimer_endpoints(monkeypatch):
+    app = setup_app(monkeypatch)
+    client: FlaskClient = app.test_client()
+    hdrs = {"Authorization": "Bearer t"}
+
+    resp = client.get("/api/v1/user/disclaimer", headers=hdrs)
+    assert resp.get_json()["seen"] is False
+
+    resp = client.post("/api/v1/user/disclaimer", headers=hdrs)
+    assert resp.status_code == 200
+
+    resp = client.get("/api/v1/user/disclaimer", headers=hdrs)
+    assert resp.get_json()["seen"] is True


### PR DESCRIPTION
## Summary
- show separate Supercell disclaimer modal with OK button
- persist disclaimer acknowledgment in users table
- expose `/user/disclaimer` API endpoints
- handle disclaimer modal in the app
- test new routes and component

## Testing
- `ruff check back-end coclib db`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_68884aedc070832c9f63661b1c6b5b68