### PR TITLE
Fix duplicate column migration

### DIFF
--- a/migrations/versions/02f5fd601c20_add_legal_version.py
+++ b/migrations/versions/02f5fd601c20_add_legal_version.py
@@ -10,7 +10,9 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('legal', sa.Column('version', sa.String(length=20), nullable=True))
+    op.execute(
+        "ALTER TABLE legal ADD COLUMN IF NOT EXISTS version VARCHAR(20)"
+    )
 
 
 def downgrade():

--- a/migrations/versions/dc26f00e_add_legal_version.py
+++ b/migrations/versions/dc26f00e_add_legal_version.py
@@ -14,7 +14,9 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('legal', sa.Column('version', sa.String(length=20), nullable=True))
+    op.execute(
+        "ALTER TABLE legal ADD COLUMN IF NOT EXISTS version VARCHAR(20)"
+    )
     op.execute("UPDATE legal SET version='20250729'")
     op.alter_column('legal', 'version', nullable=False)
 


### PR DESCRIPTION
## Summary
- resolve DuplicateColumn error by adding IF NOT EXISTS checks in duplicate migrations

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6888cf066ea4832c8816336ffb94c191