### PR TITLE
Fix mention highlight in clan chat

### DIFF
--- a/front-end/src/components/ChatMessage.jsx
+++ b/front-end/src/components/ChatMessage.jsx
@@ -4,7 +4,7 @@ import PlayerMini from './PlayerMini.jsx';
 export default function ChatMessage({ message, info, isSelf, cacheStrategy = 'indexed' }) {
   const { content } = message;
   const parts = [];
-  const regex = /@\{(#[^}]+)\}/g;
+  const regex = /@(?:\{(#[^}]+)\}|(\w+))/g;
   let last = 0;
   let m;
   let idx = 0;
@@ -12,18 +12,29 @@ export default function ChatMessage({ message, info, isSelf, cacheStrategy = 'in
     if (m.index > last) {
       parts.push(content.slice(last, m.index));
     }
-    parts.push(
-      <strong
-        key={`mention-${idx++}`}
-        className="font-bold text-slate-900 underline decoration-1"
-      >
-        <PlayerMini
-          tag={m[1]}
-          showTag={false}
-          cacheStrategy={cacheStrategy}
-        />
-      </strong>
-    );
+    if (m[1]) {
+      parts.push(
+        <strong
+          key={`mention-${idx++}`}
+          className="font-bold text-slate-900 underline decoration-1"
+        >
+          <PlayerMini
+            tag={m[1]}
+            showTag={false}
+            cacheStrategy={cacheStrategy}
+          />
+        </strong>
+      );
+    } else if (m[2]) {
+      parts.push(
+        <strong
+          key={`mention-${idx++}`}
+          className="font-bold text-slate-900 underline decoration-1"
+        >
+          @{m[2]}
+        </strong>
+      );
+    }
     last = regex.lastIndex;
   }
   if (last < content.length) {

--- a/front-end/src/components/ChatMessage.test.jsx
+++ b/front-end/src/components/ChatMessage.test.jsx
@@ -80,4 +80,17 @@ describe('ChatMessage', () => {
     expect(strong).toHaveClass('underline');
     expect(fetchJSONCached).toHaveBeenCalledWith('/player/%23TAG');
   });
+
+  it('renders mention by player name', () => {
+    render(
+      <ChatMessage
+        message={{ content: 'hi @Alice', userId: '#A1B2C' }}
+        info={sample}
+      />,
+    );
+    const mention = screen.getByText('@Alice');
+    const strong = mention.closest('strong');
+    expect(strong).toBeInTheDocument();
+    expect(strong).toHaveClass('underline');
+  });
 });


### PR DESCRIPTION
## Summary
- detect @username in chat messages and highlight
- add test covering display of @name mentions

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_6888d53a79e0832c8247f3d36e3530f4