### PR TITLE
Fix login page blank screen and API calls before auth

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -22,7 +22,7 @@ const ChatPage = lazy(() => import('./pages/ChatPage.jsx'));
 const ScoutPage = lazy(() => import('./pages/Scout.jsx'));
 const StatsPage = lazy(() => import('./pages/Stats.jsx'));
 const AccountPage = lazy(() => import('./pages/Account.jsx'));
-const LoginPage = lazy(() => import('./pages/Login.jsx'));
+import LoginPage from './pages/Login.jsx';
 const PushDebugPage = lazy(() => import('./pages/PushDebug.jsx'));
 
 function getInitialsFromName(name) {
@@ -62,6 +62,7 @@ export default function App() {
   const menuRef = React.useRef(null);
 
   useEffect(() => {
+    if (!user) return;
     async function check() {
       try {
         const res = await fetchJSON('/user/legal');
@@ -74,9 +75,10 @@ export default function App() {
       }
     }
     check();
-  }, []);
+  }, [user]);
 
   useEffect(() => {
+    if (!user) return;
     async function checkDisc() {
       try {
         const res = await fetchJSON('/user/disclaimer');
@@ -86,7 +88,7 @@ export default function App() {
       }
     }
     checkDisc();
-  }, []);
+  }, [user]);
 
   const playerInfo = usePlayerInfo(playerTag);
   const cachedClan = useClanInfo(clanTag);

--- a/front-end/src/hooks/useAuth.jsx
+++ b/front-end/src/hooks/useAuth.jsx
@@ -8,6 +8,14 @@ export function AuthProvider({ children }) {
   const [loading, setLoading] = useState(true);
 
   async function loadMe() {
+    const hasSession = document.cookie
+      .split(';')
+      .some((c) => c.trim().startsWith('sid='));
+    if (!hasSession) {
+      setUser(null);
+      setLoading(false);
+      return;
+    }
     try {
       const me = await fetchJSON('/user/me');
       setUser(me);

--- a/front-end/src/hooks/useAuth.test.jsx
+++ b/front-end/src/hooks/useAuth.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import React from 'react';
+
+vi.mock('../lib/api.js', () => ({
+  fetchJSON: vi.fn(() => Promise.resolve({})),
+  fetchJSONWithError: vi.fn(() => Promise.resolve()),
+  API_URL: '',
+}));
+
+import { AuthProvider, useAuth } from './useAuth.jsx';
+import { fetchJSON } from '../lib/api.js';
+
+function Status() {
+  const { loading } = useAuth();
+  return <div>{loading ? 'loading' : 'done'}</div>;
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips user check when no session cookie', async () => {
+    document.cookie = '';
+    render(
+      <AuthProvider>
+        <Status />
+      </AuthProvider>
+    );
+    await screen.findByText('done');
+    expect(fetchJSON).not.toHaveBeenCalled();
+  });
+
+  it('calls /user/me when session cookie present', async () => {
+    document.cookie = 'sid=abc';
+    render(
+      <AuthProvider>
+        <Status />
+      </AuthProvider>
+    );
+    await screen.findByText('done');
+    expect(fetchJSON).toHaveBeenCalledWith('/user/me');
+  });
+});

--- a/front-end/src/main.jsx
+++ b/front-end/src/main.jsx
@@ -13,7 +13,7 @@ if (import.meta.env.VITE_COMMIT_HASH) {
 }
 
 if (import.meta.env.VITE_LEGAL_VERSION) {
-  window.__LEGAL_VERSION = import.meta.env.VITE_LEGAL_VERSION;
+  window.__LEGAL_VERSION__ = import.meta.env.VITE_LEGAL_VERSION;
 }
 
 checkForStaleBuild();


### PR DESCRIPTION
## Summary
- avoid hitting `/user/me` when no sid cookie is present
- only check legal or disclaimer after a user logs in
- fix global `__LEGAL_VERSION__` variable
- eagerly import the login page to prevent blank screen
- add tests for the auth provider

## Testing
- `ruff check back-end coclib db`
- `nox -s lint tests`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888e2ef5da8832cb41e396c49df914a