### PR TITLE
Fix privacy policy and disclaimer checks

### DIFF
--- a/coclib/models.py
+++ b/coclib/models.py
@@ -208,6 +208,7 @@ class Legal(db.Model):
     user_id = db.Column(db.BigInteger, db.ForeignKey("users.id"), nullable=False)
     accepted = db.Column(db.Boolean, nullable=False, default=False)
     version = db.Column(db.String(20))
+    acknowledged_disclaimer = db.Column(db.Boolean, nullable=False, default=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
     user = db.relationship("User", backref=db.backref("legal_records", lazy="dynamic"))

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -15,8 +15,8 @@ import { fetchJSON } from './lib/api.js';
 
 const Dashboard = lazy(() => import('./pages/Dashboard.jsx'));
 const ClanModal = lazy(() => import('./components/ClanModal.jsx'));
-const LegalModal = lazy(() => import('./components/LegalModal.jsx'));
-const DisclaimerModal = lazy(() => import('./components/DisclaimerModal.jsx'));
+import LegalModal from './components/LegalModal.jsx';
+import DisclaimerModal from './components/DisclaimerModal.jsx';
 const DashboardPage = lazy(() => import('./pages/Dashboard.jsx'));
 const ChatPage = lazy(() => import('./pages/ChatPage.jsx'));
 const ScoutPage = lazy(() => import('./pages/Scout.jsx'));
@@ -67,8 +67,10 @@ export default function App() {
       try {
         const res = await fetchJSON('/user/legal');
         const accepted = res.version === window.__LEGAL_VERSION__;
-        if (!accepted || localStorage.getItem('tosAcceptedVersion') !== window.__LEGAL_VERSION__) {
+        if (!accepted) {
           setShowLegal(true);
+        } else {
+          localStorage.setItem('tosAcceptedVersion', window.__LEGAL_VERSION__);
         }
       } catch (err) {
         console.error('Failed to check legal', err);
@@ -280,23 +282,19 @@ export default function App() {
         </Suspense>
       )}
       {showDisclaimer && (
-        <Suspense fallback={<Loading className="h-screen" />}>
-          <DisclaimerModal onClose={() => setShowDisclaimer(false)} />
-        </Suspense>
+        <DisclaimerModal onClose={() => setShowDisclaimer(false)} />
       )}
       {showLegal && (
-        <Suspense fallback={<Loading className="h-screen" />}>
-          <LegalModal
-            onAccept={() => {
-              localStorage.setItem('tosAcceptedVersion', window.__LEGAL_VERSION__);
-              setShowLegal(false);
-            }}
-            onDiscard={() => {
-              setShowLegal(false);
-              logout();
-            }}
-          />
-        </Suspense>
+        <LegalModal
+          onAccept={() => {
+            localStorage.setItem('tosAcceptedVersion', window.__LEGAL_VERSION__);
+            setShowLegal(false);
+          }}
+          onDiscard={() => {
+            setShowLegal(false);
+            logout();
+          }}
+        />
       )}
     </Router>
   );

--- a/migrations/versions/aacbd672d8f0_add_disclaimer_column_to_legal.py
+++ b/migrations/versions/aacbd672d8f0_add_disclaimer_column_to_legal.py
@@ -1,0 +1,24 @@
+"""add disclaimer column to legal
+
+Revision ID: aacbd672d8f0
+Revises: 02f5fd601c20
+Create Date: 2025-07-29 12:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'aacbd672d8f0'
+down_revision = '02f5fd601c20'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('legal', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('acknowledged_disclaimer', sa.Boolean(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    with op.batch_alter_table('legal', schema=None) as batch_op:
+        batch_op.drop_column('acknowledged_disclaimer')

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -92,5 +92,10 @@ def test_disclaimer_endpoints(monkeypatch):
     resp = client.post("/api/v1/user/disclaimer", headers=hdrs)
     assert resp.status_code == 200
 
+    with app.app_context():
+        assert (
+            Legal.query.filter_by(user_id=1, acknowledged_disclaimer=True).count() == 1
+        )
+
     resp = client.get("/api/v1/user/disclaimer", headers=hdrs)
     assert resp.get_json()["seen"] is True


### PR DESCRIPTION
## Summary
- add column to track disclaimer acknowledgements
- record disclaimers in the legal table and check it on login
- show legal modal only when the current version isn't accepted
- load legal and disclaimer components eagerly so Accept works during initial load

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_6888f3d71e1c832cbfd04c862aa5fbb9