### PR TITLE
Fix correct app link for lower environments

### DIFF
--- a/front-end/public-home/pages/index.js
+++ b/front-end/public-home/pages/index.js
@@ -14,11 +14,6 @@ export default function Home() {
     }
   }, []);
 
-  const appUrl =
-    typeof window === 'undefined'
-      ? 'https://app.clan-boards.com'
-      : `${window.location.protocol}//app.${window.location.hostname.replace(/^www\./, '')}`;
-
   useEffect(() => {
     if (typeof window !== 'undefined') {
       if (localStorage.getItem('disclaimerSeen') !== 'true') {


### PR DESCRIPTION
## Summary
- fix environment-specific app URL calculation for public-home

## Testing
- `nox -s lint tests`
- `ruff check back-end coclib db`
- `npm run build` in `front-end/public-home`

------
https://chatgpt.com/codex/tasks/task_e_68898a7192d0832cb7ace1539d533051