### PR TITLE
Add REDIS_URL support to messages service

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The user service issues signed JWT cookies for authentication. Configure the fol
 - `SESSION_MAX_AGE` – Lifetime of a session in seconds.
 - `COOKIE_DOMAIN` – Domain attribute for the `sid` cookie.
 - `COOKIE_SECURE` – Set to `false` to disable the `Secure` flag during local development.
+- `REDIS_URL` – Connection string for the messages service Redis instance.
 These variables are generally injected from AWS Secrets Manager at runtime.
 
 ## Clash of Clans asset links

--- a/messages-java/src/main/java/com/clanboards/messages/config/RedisConfig.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/RedisConfig.java
@@ -1,12 +1,33 @@
 package com.clanboards.messages.config;
 
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 @Configuration
 public class RedisConfig {
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory(
+      @Value("${REDIS_URL:redis://localhost:6379}") String url) {
+    URI uri = URI.create(url);
+    RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+    config.setHostName(uri.getHost());
+    if (uri.getPort() != -1) {
+      config.setPort(uri.getPort());
+    }
+    if (uri.getUserInfo() != null && uri.getUserInfo().contains(":")) {
+      String[] parts = uri.getUserInfo().split(":", 2);
+      config.setUsername(parts[0]);
+      config.setPassword(parts[1]);
+    }
+    return new LettuceConnectionFactory(config);
+  }
+
   @Bean
   public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory factory) {
     return new StringRedisTemplate(factory);


### PR DESCRIPTION
## Summary
- configure messages-java to parse redis url from `REDIS_URL`
- document `REDIS_URL` env variable in the README

## Testing
- `nox -s lint tests`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_688a2a7262e4832c842cda8e2662c858