### PR TITLE
Add moderation tables and policy engine

### DIFF
--- a/coclib/models.py
+++ b/coclib/models.py
@@ -213,3 +213,39 @@ class Legal(db.Model):
 
     user = db.relationship("User", backref=db.backref("legal_records", lazy="dynamic"))
 
+
+
+class ModerationRecord(db.Model):
+    """Store scores for rejected chat messages."""
+
+    __tablename__ = "moderation"
+
+    id = db.Column(db.BigInteger, primary_key=True)
+    user_id = db.Column(db.String(255), index=True, nullable=False)
+    content = db.Column(db.Text, nullable=False)
+    categories = db.Column(db.JSON, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class BlockedUser(db.Model):
+    """Users blocked or muted by policy engine."""
+
+    __tablename__ = "blocked"
+
+    user_id = db.Column(db.String(255), primary_key=True)
+    until = db.Column(db.DateTime)
+    permanent = db.Column(db.Boolean, default=False)
+    reason = db.Column(db.String(50))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class ModerationRule(db.Model):
+    """JSON-driven policy rules."""
+
+    __tablename__ = "rules"
+
+    id = db.Column(db.BigInteger, primary_key=True)
+    name = db.Column(db.String(50), nullable=False)
+    definition = db.Column(db.JSON, nullable=False)
+    active = db.Column(db.Boolean, default=True)
+

--- a/coclib/policy.py
+++ b/coclib/policy.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict, Iterable
+
+from coclib.extensions import db
+from .models import BlockedUser, ModerationRecord, ModerationRule
+
+
+class PolicyEngine:
+    """Evaluate moderation events against database-driven rules."""
+
+    def __init__(self, session: db.session.__class__):
+        self.session = session
+
+    def load_rules(self) -> Iterable[ModerationRule]:
+        return self.session.query(ModerationRule).filter_by(active=True).all()
+
+    def apply(self, record: ModerationRecord) -> None:
+        for rule in self.load_rules():
+            cfg: Dict = rule.definition or {}
+            rtype = cfg.get("type")
+            if rtype == "category_threshold":
+                cat = cfg.get("category")
+                threshold = cfg.get("threshold", 1.0)
+                score = record.categories.get(cat, 0)
+                if score >= threshold:
+                    self._block(record.user_id, cfg)
+            elif rtype == "category_any":
+                threshold = cfg.get("threshold", 1.0)
+                if any(v >= threshold for v in record.categories.values()):
+                    self._mute(record.user_id, cfg)
+            elif rtype == "toxicity_warning":
+                min_v = cfg.get("min", 0.0)
+                max_v = cfg.get("max", 1.0)
+                tox = record.categories.get("toxicity", 0)
+                if min_v <= tox < max_v:
+                    record.action_taken = "toast"
+            elif rtype == "duplicate":
+                window = int(cfg.get("window", 10))
+                since = datetime.utcnow() - timedelta(seconds=window)
+                dup = (
+                    self.session.query(ModerationRecord)
+                    .filter(
+                        ModerationRecord.user_id == record.user_id,
+                        ModerationRecord.content == record.content,
+                        ModerationRecord.created_at >= since,
+                    )
+                    .first()
+                )
+                if dup is not None:
+                    self._readonly(record.user_id, cfg)
+        self.session.commit()
+
+    def _block(self, user_id: str, cfg: Dict) -> None:
+        user = self.session.get(BlockedUser, user_id) or BlockedUser(user_id=user_id)
+        user.permanent = True
+        user.reason = cfg.get("reason", "policy")
+        user.created_at = datetime.utcnow()
+        self.session.merge(user)
+
+    def _mute(self, user_id: str, cfg: Dict) -> None:
+        duration = int(cfg.get("duration", 86400))
+        user = self.session.get(BlockedUser, user_id) or BlockedUser(user_id=user_id)
+        user.until = datetime.utcnow() + timedelta(seconds=duration)
+        user.reason = cfg.get("reason", "mute")
+        user.permanent = False
+        self.session.merge(user)
+
+    def _readonly(self, user_id: str, cfg: Dict) -> None:
+        duration = int(cfg.get("duration", 600))
+        user = self.session.get(BlockedUser, user_id) or BlockedUser(user_id=user_id)
+        user.until = datetime.utcnow() + timedelta(seconds=duration)
+        user.reason = cfg.get("reason", "readonly")
+        user.permanent = False
+        self.session.merge(user)

--- a/messages-java/build.gradle
+++ b/messages-java/build.gradle
@@ -28,12 +28,15 @@ dependencies {
     implementation 'software.amazon.awssdk:dynamodb-enhanced'
     implementation 'software.amazon.awssdk:secretsmanager'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.openai:openai-java:2.19.2'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.graphql:spring-graphql-test'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 test {

--- a/messages-java/src/main/java/com/clanboards/messages/model/ModerationRecord.java
+++ b/messages-java/src/main/java/com/clanboards/messages/model/ModerationRecord.java
@@ -1,0 +1,62 @@
+package com.clanboards.messages.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "moderation")
+public class ModerationRecord {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String userId;
+
+  @Column(columnDefinition = "text")
+  private String content;
+
+  @Column(columnDefinition = "jsonb")
+  private String categories;
+
+  private Instant createdAt = Instant.now();
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public void setContent(String content) {
+    this.content = content;
+  }
+
+  public String getCategories() {
+    return categories;
+  }
+
+  public void setCategories(String categories) {
+    this.categories = categories;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(Instant createdAt) {
+    this.createdAt = createdAt;
+  }
+}

--- a/messages-java/src/main/java/com/clanboards/messages/repository/ModerationRepository.java
+++ b/messages-java/src/main/java/com/clanboards/messages/repository/ModerationRepository.java
@@ -1,0 +1,6 @@
+package com.clanboards.messages.repository;
+
+import com.clanboards.messages.model.ModerationRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ModerationRepository extends JpaRepository<ModerationRecord, Long> {}

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -17,8 +17,10 @@ class ChatServiceTest {
     ChatRepository repo = Mockito.mock(ChatRepository.class);
     ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
     ModerationService moderation = Mockito.mock(ModerationService.class);
+    com.clanboards.messages.repository.ModerationRepository modRepo =
+        Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
     Mockito.when(moderation.verify("u", "hello")).thenReturn(ModerationResult.ALLOW);
-    ChatService service = new ChatService(repo, events, moderation);
+    ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     ChatMessage msg = service.publish("1", "hello", "u");
     assertEquals("1", msg.channel());
@@ -31,10 +33,12 @@ class ChatServiceTest {
     ChatRepository repo = Mockito.mock(ChatRepository.class);
     ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
     ModerationService moderation = Mockito.mock(ModerationService.class);
+    com.clanboards.messages.repository.ModerationRepository modRepo =
+        Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
     List<ChatMessage> expected = List.of(new ChatMessage("m1", "1", "u", "hi", Instant.now()));
     Mockito.when(repo.listMessages("1", 2, null)).thenReturn(expected);
 
-    ChatService service = new ChatService(repo, events, moderation);
+    ChatService service = new ChatService(repo, events, moderation, modRepo);
     List<ChatMessage> result = service.history("1", 2, null);
     assertSame(expected, result);
   }
@@ -44,8 +48,10 @@ class ChatServiceTest {
     ChatRepository repo = Mockito.mock(ChatRepository.class);
     ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
     ModerationService moderation = Mockito.mock(ModerationService.class);
+    com.clanboards.messages.repository.ModerationRepository modRepo =
+        Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
     Mockito.when(moderation.verify("user1", "hi")).thenReturn(ModerationResult.ALLOW);
-    ChatService service = new ChatService(repo, events, moderation);
+    ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     ChatMessage msg = service.publishGlobal("hi", "user1");
     assertEquals(ChatRepository.globalShardKey("user1"), msg.channel());
@@ -57,8 +63,10 @@ class ChatServiceTest {
     ChatRepository repo = Mockito.mock(ChatRepository.class);
     ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
     ModerationService moderation = Mockito.mock(ModerationService.class);
+    com.clanboards.messages.repository.ModerationRepository modRepo =
+        Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
     Mockito.when(moderation.verify("u", "hi")).thenReturn(ModerationResult.ALLOW);
-    ChatService service = new ChatService(repo, events, moderation);
+    ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     service.publish("1", "hi", "u");
 
@@ -70,8 +78,10 @@ class ChatServiceTest {
     ChatRepository repo = Mockito.mock(ChatRepository.class);
     ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
     ModerationService moderation = Mockito.mock(ModerationService.class);
+    com.clanboards.messages.repository.ModerationRepository modRepo =
+        Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
     Mockito.when(moderation.verify("u", "hi")).thenReturn(ModerationResult.BLOCK);
-    ChatService service = new ChatService(repo, events, moderation);
+    ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     assertThrows(RuntimeException.class, () -> service.publish("1", "hi", "u"));
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
@@ -82,7 +92,9 @@ class ChatServiceTest {
     ChatRepository repo = Mockito.mock(ChatRepository.class);
     ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
     ModerationService moderation = Mockito.mock(ModerationService.class);
-    ChatService service = new ChatService(repo, events, moderation);
+    com.clanboards.messages.repository.ModerationRepository modRepo =
+        Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
+    ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     String id = service.createDirectChat("a", "b");
     assertEquals(ChatRepository.directChatId("a", "b"), id);

--- a/messages-java/src/test/resources/application.properties
+++ b/messages-java/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.jpa.hibernate.ddl-auto=none
+spring.graphql.path=/api/v1/chat/graphql

--- a/migrations/versions/a1e6e2f7b8c3_add_moderation_tables.py
+++ b/migrations/versions/a1e6e2f7b8c3_add_moderation_tables.py
@@ -1,0 +1,49 @@
+"""add moderation tables
+
+Revision ID: a1e6e2f7b8c3
+Revises: f9040a4059c4
+Create Date: 2025-07-30 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'a1e6e2f7b8c3'
+down_revision = 'f9040a4059c4'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'moderation',
+        sa.Column('id', sa.BigInteger(), primary_key=True),
+        sa.Column('user_id', sa.String(length=255), nullable=False),
+        sa.Column('content', sa.Text(), nullable=False),
+        sa.Column('categories', sa.JSON(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+    )
+    op.create_index('ix_moderation_user_id', 'moderation', ['user_id'])
+
+    op.create_table(
+        'blocked',
+        sa.Column('user_id', sa.String(length=255), primary_key=True),
+        sa.Column('until', sa.DateTime(), nullable=True),
+        sa.Column('permanent', sa.Boolean(), nullable=True),
+        sa.Column('reason', sa.String(length=50), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+    )
+
+    op.create_table(
+        'rules',
+        sa.Column('id', sa.BigInteger(), primary_key=True),
+        sa.Column('name', sa.String(length=50), nullable=False),
+        sa.Column('definition', sa.JSON(), nullable=False),
+        sa.Column('active', sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('rules')
+    op.drop_table('blocked')
+    op.drop_index('ix_moderation_user_id', table_name='moderation')
+    op.drop_table('moderation')


### PR DESCRIPTION
## Summary
- add ModerationRecord, BlockedUser and ModerationRule models
- create Alembic migration for moderation tables
- add policy engine to evaluate moderation rules
- persist blocked messages in ChatService and wire new JPA repo
- provide H2 config for message service tests

## Testing
- `ruff check back-end coclib db`
- `npm install`/`npm test`/`npm run build` in front-end
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_688a38a844e0832c823d1116a09bddf4