### PR TITLE
Fix messages-java datasource boot issue

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/config/DatabaseConfig.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/DatabaseConfig.java
@@ -1,0 +1,45 @@
+package com.clanboards.messages.config;
+
+import java.net.URI;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DatabaseConfig {
+  @Bean
+  public DataSource dataSource(
+      @Value("${DATABASE_URL:}") String databaseUrl,
+      @Value("${DATABASE_USERNAME:}") String username,
+      @Value("${DATABASE_PASSWORD:}") String password)
+      throws Exception {
+    if (databaseUrl == null || databaseUrl.isBlank()) {
+      return DataSourceBuilder.create()
+          .driverClassName("org.h2.Driver")
+          .url("jdbc:h2:mem:testdb")
+          .username("sa")
+          .password("")
+          .build();
+    }
+    URI uri = new URI(databaseUrl);
+    String userInfo = uri.getUserInfo();
+    if (userInfo != null && (username == null || username.isBlank())) {
+      String[] parts = userInfo.split(":", 2);
+      username = parts[0];
+      if (parts.length > 1) password = parts[1];
+    }
+    String jdbcUrl =
+        "jdbc:postgresql://"
+            + uri.getHost()
+            + (uri.getPort() > 0 ? ":" + uri.getPort() : "")
+            + uri.getPath();
+    return DataSourceBuilder.create()
+        .driverClassName("org.postgresql.Driver")
+        .url(jdbcUrl)
+        .username(username)
+        .password(password)
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary
- add a `DatabaseConfig` in messages-java so JPA repositories initialize

## Testing
- `./gradlew test` in `messages-java`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_688a4e3dc484832cb61064aa06530fc6