### PR TITLE
Fix moderation error handling

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/config/ModerationExceptionResolver.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/ModerationExceptionResolver.java
@@ -1,0 +1,24 @@
+package com.clanboards.messages.config;
+
+import com.clanboards.messages.service.ModerationException;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import graphql.schema.DataFetchingEnvironment;
+import org.springframework.graphql.execution.DataFetcherExceptionResolverAdapter;
+import org.springframework.graphql.execution.ErrorType;
+import org.springframework.stereotype.Component;
+
+/** Resolves ModerationException to GraphQL errors. */
+@Component
+public class ModerationExceptionResolver extends DataFetcherExceptionResolverAdapter {
+  @Override
+  protected GraphQLError resolveToSingleError(Throwable ex, DataFetchingEnvironment env) {
+    if (ex instanceof ModerationException me) {
+      return GraphqlErrorBuilder.newError(env)
+          .message(me.getMessage())
+          .errorType(ErrorType.BAD_REQUEST)
+          .build();
+    }
+    return null;
+  }
+}

--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -40,11 +40,12 @@ public class ChatService {
   public ChatMessage publish(String chatId, String text, String userId) {
     log.info("Publishing message to chat {} by {}", chatId, userId);
     try {
-      if (moderation.verify(userId, text) == ModerationResult.BLOCK) {
+      ModerationDetails details = moderation.moderate(userId, text);
+      if (details.result() == ModerationResult.BLOCK) {
         ModerationRecord rec = new ModerationRecord();
         rec.setUserId(userId);
         rec.setContent(text);
-        rec.setCategories("{}");
+        rec.setCategories(details.categories());
         modRepo.save(rec);
         throw new ModerationException("BANNED");
       }
@@ -65,11 +66,12 @@ public class ChatService {
   public ChatMessage publishGlobal(String text, String userId) {
     log.info("Publishing global message by {}", userId);
     try {
-      if (moderation.verify(userId, text) == ModerationResult.BLOCK) {
+      ModerationDetails details = moderation.moderate(userId, text);
+      if (details.result() == ModerationResult.BLOCK) {
         ModerationRecord rec = new ModerationRecord();
         rec.setUserId(userId);
         rec.setContent(text);
-        rec.setCategories("{}");
+        rec.setCategories(details.categories());
         modRepo.save(rec);
         throw new ModerationException("BANNED");
       }

--- a/messages-java/src/main/java/com/clanboards/messages/service/ModerationDetails.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ModerationDetails.java
@@ -1,0 +1,4 @@
+package com.clanboards.messages.service;
+
+/** Result of moderation with categories. */
+public record ModerationDetails(ModerationResult result, String categories) {}

--- a/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
@@ -1,5 +1,7 @@
 package com.clanboards.messages.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.models.moderations.ModerationCreateParams;
@@ -9,6 +11,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -37,11 +41,20 @@ public class ModerationService {
 
   /** Returns BLOCK when the message should be rejected. */
   public ModerationResult verify(String userId, String text) {
+    return moderate(userId, text).result();
+  }
+
+  /** Performs moderation and returns details including category scores. */
+  public ModerationDetails moderate(String userId, String text) {
+    boolean blocked = false;
+    Map<String, Double> categories = new HashMap<>();
     if (checkSpam(userId, text)) {
-      return ModerationResult.BLOCK;
+      blocked = true;
+      categories.put("spam", 1.0);
     }
     if (BAD_WORDS.matcher(text).find()) {
-      return ModerationResult.BLOCK;
+      blocked = true;
+      categories.put("explicit", 1.0);
     }
     if (openai != null) {
       ModerationCreateParams req =
@@ -50,11 +63,29 @@ public class ModerationService {
               .model(ModerationModel.OMNI_MODERATION_LATEST)
               .build();
       var resp = openai.moderations().create(req);
-      if (!resp.results().isEmpty() && resp.results().get(0).flagged()) {
-        return ModerationResult.BLOCK;
+      if (!resp.results().isEmpty()) {
+        var result = resp.results().get(0);
+        if (result.flagged()) {
+          blocked = true;
+        }
+        try {
+          // best effort include raw scores as JSON
+          var field = result.getClass().getMethod("categoryScores");
+          Object scores = field.invoke(result);
+          if (scores != null) {
+            categories.putAll(new ObjectMapper().convertValue(scores, Map.class));
+          }
+        } catch (Exception ignored) {
+        }
       }
     }
-    return ModerationResult.ALLOW;
+    String json;
+    try {
+      json = new ObjectMapper().writeValueAsString(categories);
+    } catch (JsonProcessingException e) {
+      json = "{}";
+    }
+    return new ModerationDetails(blocked ? ModerationResult.BLOCK : ModerationResult.ALLOW, json);
   }
 
   /**

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -19,7 +19,8 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
-    Mockito.when(moderation.verify("u", "hello")).thenReturn(ModerationResult.ALLOW);
+    Mockito.when(moderation.moderate("u", "hello"))
+        .thenReturn(new ModerationDetails(ModerationResult.ALLOW, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     ChatMessage msg = service.publish("1", "hello", "u");
@@ -50,7 +51,8 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
-    Mockito.when(moderation.verify("user1", "hi")).thenReturn(ModerationResult.ALLOW);
+    Mockito.when(moderation.moderate("user1", "hi"))
+        .thenReturn(new ModerationDetails(ModerationResult.ALLOW, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     ChatMessage msg = service.publishGlobal("hi", "user1");
@@ -65,12 +67,13 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
-    Mockito.when(moderation.verify("u", "hi")).thenReturn(ModerationResult.ALLOW);
+    Mockito.when(moderation.moderate("u", "hi"))
+        .thenReturn(new ModerationDetails(ModerationResult.ALLOW, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     service.publish("1", "hi", "u");
 
-    Mockito.verify(moderation).verify("u", "hi");
+    Mockito.verify(moderation).moderate("u", "hi");
   }
 
   @Test
@@ -80,7 +83,8 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
-    Mockito.when(moderation.verify("u", "hi")).thenReturn(ModerationResult.BLOCK);
+    Mockito.when(moderation.moderate("u", "hi"))
+        .thenReturn(new ModerationDetails(ModerationResult.BLOCK, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));


### PR DESCRIPTION
## Summary
- handle ModerationException for GraphQL
- return moderation categories when blocking a message
- store moderation categories with blocked messages
- update tests

## Testing
- `nox -s lint tests`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_688a5e4872a4832c95c3f74aeafdd1a6