### PR TITLE
Fix moderation exception handling and categories

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/controller/ErrorHandler.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/ErrorHandler.java
@@ -1,5 +1,6 @@
 package com.clanboards.messages.controller;
 
+import com.clanboards.messages.service.ModerationException;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +17,12 @@ public class ErrorHandler {
   public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException ex) {
     log.warn("Bad request", ex);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", ex.getMessage()));
+  }
+
+  @ExceptionHandler(ModerationException.class)
+  public ResponseEntity<Map<String, String>> handleModeration(ModerationException ex) {
+    log.info("Message blocked", ex);
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", ex.getMessage()));
   }
 
   @ExceptionHandler(Exception.class)

--- a/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLExceptionHandler.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.clanboards.messages.controller;
+
+import com.clanboards.messages.service.ModerationException;
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import org.springframework.graphql.data.method.annotation.GraphQlExceptionHandler;
+import org.springframework.stereotype.Controller;
+
+/** Maps service exceptions to GraphQL errors. */
+@Controller
+public class GraphQLExceptionHandler {
+  @GraphQlExceptionHandler(ModerationException.class)
+  public GraphQLError handle(ModerationException ex) {
+    return GraphqlErrorBuilder.newError()
+        .errorType(ErrorType.DataFetchingException)
+        .message(ex.getMessage())
+        .build();
+  }
+}

--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -40,11 +40,12 @@ public class ChatService {
   public ChatMessage publish(String chatId, String text, String userId) {
     log.info("Publishing message to chat {} by {}", chatId, userId);
     try {
-      if (moderation.verify(userId, text) == ModerationResult.BLOCK) {
+      ModerationOutcome res = moderation.verify(userId, text);
+      if (res.result() == ModerationResult.BLOCK) {
         ModerationRecord rec = new ModerationRecord();
         rec.setUserId(userId);
         rec.setContent(text);
-        rec.setCategories("{}");
+        rec.setCategories(res.categories());
         modRepo.save(rec);
         throw new ModerationException("BANNED");
       }
@@ -65,11 +66,12 @@ public class ChatService {
   public ChatMessage publishGlobal(String text, String userId) {
     log.info("Publishing global message by {}", userId);
     try {
-      if (moderation.verify(userId, text) == ModerationResult.BLOCK) {
+      ModerationOutcome res = moderation.verify(userId, text);
+      if (res.result() == ModerationResult.BLOCK) {
         ModerationRecord rec = new ModerationRecord();
         rec.setUserId(userId);
         rec.setContent(text);
-        rec.setCategories("{}");
+        rec.setCategories(res.categories());
         modRepo.save(rec);
         throw new ModerationException("BANNED");
       }

--- a/messages-java/src/main/java/com/clanboards/messages/service/ModerationOutcome.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ModerationOutcome.java
@@ -1,0 +1,4 @@
+package com.clanboards.messages.service;
+
+/** Moderation result with category JSON. */
+public record ModerationOutcome(ModerationResult result, String categories) {}

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -19,7 +19,8 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
-    Mockito.when(moderation.verify("u", "hello")).thenReturn(ModerationResult.ALLOW);
+    Mockito.when(moderation.verify("u", "hello"))
+        .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     ChatMessage msg = service.publish("1", "hello", "u");
@@ -50,7 +51,8 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
-    Mockito.when(moderation.verify("user1", "hi")).thenReturn(ModerationResult.ALLOW);
+    Mockito.when(moderation.verify("user1", "hi"))
+        .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     ChatMessage msg = service.publishGlobal("hi", "user1");
@@ -65,7 +67,8 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
-    Mockito.when(moderation.verify("u", "hi")).thenReturn(ModerationResult.ALLOW);
+    Mockito.when(moderation.verify("u", "hi"))
+        .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     service.publish("1", "hi", "u");
@@ -80,7 +83,8 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
-    Mockito.when(moderation.verify("u", "hi")).thenReturn(ModerationResult.BLOCK);
+    Mockito.when(moderation.verify("u", "hi"))
+        .thenReturn(new ModerationOutcome(ModerationResult.BLOCK, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo);
 
     assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));


### PR DESCRIPTION
## Summary
- improve ModerationService so that category scores are captured in JSON
- record categories when moderation fails
- surface moderation errors in REST & GraphQL controllers
- update unit tests

## Testing
- `nox -s lint tests`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_688a5e4872a4832c95c3f74aeafdd1a6