### PR TITLE
Improve moderation handling

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLExceptionHandler.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLExceptionHandler.java
@@ -5,10 +5,10 @@ import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorBuilder;
 import org.springframework.graphql.data.method.annotation.GraphQlExceptionHandler;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ControllerAdvice;
 
 /** Maps service exceptions to GraphQL errors. */
-@Controller
+@ControllerAdvice
 public class GraphQLExceptionHandler {
   @GraphQlExceptionHandler(ModerationException.class)
   public GraphQLError handle(ModerationException ex) {

--- a/messages-java/src/main/java/com/clanboards/messages/model/BlockedUser.java
+++ b/messages-java/src/main/java/com/clanboards/messages/model/BlockedUser.java
@@ -1,0 +1,58 @@
+package com.clanboards.messages.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "blocked")
+public class BlockedUser {
+  @Id private String userId;
+
+  private Instant until;
+
+  private Boolean permanent = Boolean.FALSE;
+
+  private String reason;
+
+  private Instant createdAt = Instant.now();
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
+
+  public Instant getUntil() {
+    return until;
+  }
+
+  public void setUntil(Instant until) {
+    this.until = until;
+  }
+
+  public Boolean getPermanent() {
+    return permanent;
+  }
+
+  public void setPermanent(Boolean permanent) {
+    this.permanent = permanent;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public void setReason(String reason) {
+    this.reason = reason;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(Instant createdAt) {
+    this.createdAt = createdAt;
+  }
+}

--- a/messages-java/src/main/java/com/clanboards/messages/repository/BlockedUserRepository.java
+++ b/messages-java/src/main/java/com/clanboards/messages/repository/BlockedUserRepository.java
@@ -1,0 +1,6 @@
+package com.clanboards.messages.repository;
+
+import com.clanboards.messages.model.BlockedUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlockedUserRepository extends JpaRepository<BlockedUser, String> {}

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -19,9 +19,11 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
+    com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
+        Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hello"))
         .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
-    ChatService service = new ChatService(repo, events, moderation, modRepo);
+    ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     ChatMessage msg = service.publish("1", "hello", "u");
     assertEquals("1", msg.channel());
@@ -36,10 +38,12 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
+    com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
+        Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     List<ChatMessage> expected = List.of(new ChatMessage("m1", "1", "u", "hi", Instant.now()));
     Mockito.when(repo.listMessages("1", 2, null)).thenReturn(expected);
 
-    ChatService service = new ChatService(repo, events, moderation, modRepo);
+    ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
     List<ChatMessage> result = service.history("1", 2, null);
     assertSame(expected, result);
   }
@@ -51,9 +55,11 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
+    com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
+        Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("user1", "hi"))
         .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
-    ChatService service = new ChatService(repo, events, moderation, modRepo);
+    ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     ChatMessage msg = service.publishGlobal("hi", "user1");
     assertEquals(ChatRepository.globalShardKey("user1"), msg.channel());
@@ -67,9 +73,11 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
+    com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
+        Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hi"))
         .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
-    ChatService service = new ChatService(repo, events, moderation, modRepo);
+    ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     service.publish("1", "hi", "u");
 
@@ -83,9 +91,11 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
+    com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
+        Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hi"))
         .thenReturn(new ModerationOutcome(ModerationResult.BLOCK, "{}"));
-    ChatService service = new ChatService(repo, events, moderation, modRepo);
+    ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
@@ -98,7 +108,9 @@ class ChatServiceTest {
     ModerationService moderation = Mockito.mock(ModerationService.class);
     com.clanboards.messages.repository.ModerationRepository modRepo =
         Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
-    ChatService service = new ChatService(repo, events, moderation, modRepo);
+    com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
+        Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
+    ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     String id = service.createDirectChat("a", "b");
     assertEquals(ChatRepository.directChatId("a", "b"), id);


### PR DESCRIPTION
## Summary
- add `BlockedUser` entity and repository
- log OpenAI moderation responses
- handle blocked users and store bans when moderation fails
- fix GraphQL exception handling
- update tests

## Testing
- `messages-java/gradlew -p messages-java test`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_688a6a6263a4832caa2db48400d36d3b