### PR TITLE
Fix moderation escalation bug

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/service/ModerationResult.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ModerationResult.java
@@ -3,5 +3,8 @@ package com.clanboards.messages.service;
 /** Result of message moderation. */
 public enum ModerationResult {
   ALLOW,
+  WARNING,
+  READONLY,
+  MUTE,
   BLOCK
 }

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -102,6 +102,40 @@ class ChatServiceTest {
   }
 
   @Test
+  void publishHandlesMute() {
+    ChatRepository repo = Mockito.mock(ChatRepository.class);
+    ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
+    ModerationService moderation = Mockito.mock(ModerationService.class);
+    com.clanboards.messages.repository.ModerationRepository modRepo =
+        Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
+    com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
+        Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
+    Mockito.when(moderation.verify("u", "hi"))
+        .thenReturn(new ModerationOutcome(ModerationResult.MUTE, "{}"));
+    ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
+
+    assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));
+    Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
+  }
+
+  @Test
+  void publishHandlesReadonly() {
+    ChatRepository repo = Mockito.mock(ChatRepository.class);
+    ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
+    ModerationService moderation = Mockito.mock(ModerationService.class);
+    com.clanboards.messages.repository.ModerationRepository modRepo =
+        Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
+    com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
+        Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
+    Mockito.when(moderation.verify("u", "hi"))
+        .thenReturn(new ModerationOutcome(ModerationResult.READONLY, "{}"));
+    ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
+
+    assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));
+    Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
+  }
+
+  @Test
   void createDirectChatCreatesChat() {
     ChatRepository repo = Mockito.mock(ChatRepository.class);
     ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);


### PR DESCRIPTION
## Summary
- differentiate moderation results instead of always banning users
- implement mute and readonly actions
- expand moderation enum and logic
- test handling of mute/readonly

## Testing
- `./gradlew test`
- `nox -s lint tests`
- `ruff check back-end coclib db`

------
https://chatgpt.com/codex/tasks/task_e_688a7856c224832c8a2fe5fca26b72dc