### PR TITLE
Add log for OpenAI moderation response

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
@@ -62,6 +62,7 @@ public class ModerationService {
               .build();
       var resp = openai.moderations().create(req);
       log.debug("OpenAI moderation response for {}: {}", userId, resp);
+      log.info("OpenAI moderation response for {}: {}", userId, resp);
       if (!resp.results().isEmpty()) {
         var result = resp.results().get(0);
         var scores = result.categoryScores();


### PR DESCRIPTION
## Summary
- log the raw OpenAI moderation response in `ModerationService`

## Testing
- `./messages-java/gradlew -p messages-java test`

------
https://chatgpt.com/codex/tasks/task_e_688a8207a784832c981e3d6fa67a857c