### PR TITLE
Fix missing GraphQL context

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLController.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLController.java
@@ -45,7 +45,8 @@ public class GraphQLController {
 
   @MutationMapping
   public Chat createDirectChat(
-      @Argument String recipientId, @ContextValue("userId") String userId) {
+      @Argument String recipientId,
+      @ContextValue(value = "userId", required = false) String userId) {
     if (userId == null || userId.isBlank()) {
       throw new RuntimeException("Unauthenticated");
     }
@@ -67,7 +68,9 @@ public class GraphQLController {
 
   @MutationMapping
   public Message sendMessage(
-      @Argument String chatId, @Argument String content, @ContextValue("userId") String userId) {
+      @Argument String chatId,
+      @Argument String content,
+      @ContextValue(value = "userId", required = false) String userId) {
     if (userId == null || userId.isBlank()) {
       throw new RuntimeException("Unauthenticated");
     }


### PR DESCRIPTION
## Summary
- allow GraphQL mutations to omit `userId` context

## Testing
- `./gradlew -p messages-java test`

------
https://chatgpt.com/codex/tasks/task_e_688a97322a64832c9cc04b402671e6a3