### PR TITLE
Fix moderation logging and add restriction endpoint

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
@@ -65,7 +65,9 @@ public class ChatController {
     }
     String status = Boolean.TRUE.equals(info.getPermanent()) ? "BANNED" : "MUTED";
     long remaining =
-        info.getUntil() != null ? Math.max(0, info.getUntil().getEpochSecond() - Instant.now().getEpochSecond()) : 0;
+        info.getUntil() != null
+            ? Math.max(0, info.getUntil().getEpochSecond() - Instant.now().getEpochSecond())
+            : 0;
     return ResponseEntity.ok(Map.of("status", status, "remaining", remaining));
   }
 

--- a/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
@@ -56,6 +56,19 @@ public class ChatController {
     return ResponseEntity.ok(body);
   }
 
+  /** Return restriction info for a user if active. */
+  @GetMapping("/restrictions/{userId}")
+  public ResponseEntity<Map<String, Object>> restriction(@PathVariable String userId) {
+    var info = chatService.getRestriction(userId);
+    if (info == null) {
+      return ResponseEntity.ok(Map.of("status", "NONE"));
+    }
+    String status = Boolean.TRUE.equals(info.getPermanent()) ? "BANNED" : "MUTED";
+    long remaining =
+        info.getUntil() != null ? Math.max(0, info.getUntil().getEpochSecond() - Instant.now().getEpochSecond()) : 0;
+    return ResponseEntity.ok(Map.of("status", status, "remaining", remaining));
+  }
+
   public static record PublishRequest(String chatId, String text, String userId) {}
 
   public static record GlobalRequest(String text, String userId) {}

--- a/messages-java/src/main/java/com/clanboards/messages/repository/BlockedUserRepository.java
+++ b/messages-java/src/main/java/com/clanboards/messages/repository/BlockedUserRepository.java
@@ -1,6 +1,29 @@
 package com.clanboards.messages.repository;
 
 import com.clanboards.messages.model.BlockedUser;
+import java.time.Instant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface BlockedUserRepository extends JpaRepository<BlockedUser, String> {}
+public interface BlockedUserRepository extends JpaRepository<BlockedUser, String> {
+
+  /** Insert or update a blocked user record atomically. */
+  @Modifying
+  @org.springframework.transaction.annotation.Transactional
+  @Query(
+      value =
+          "insert into blocked (user_id, until, permanent, reason, created_at) "
+              + "values (:userId, :until, :permanent, :reason, :createdAt) "
+              + "on conflict (user_id) do update set "
+              + "until=excluded.until, permanent=excluded.permanent, "
+              + "reason=excluded.reason, created_at=excluded.created_at",
+      nativeQuery = true)
+  void upsert(
+      @Param("userId") String userId,
+      @Param("until") Instant until,
+      @Param("permanent") Boolean permanent,
+      @Param("reason") String reason,
+      @Param("createdAt") Instant createdAt);
+}

--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -156,32 +156,29 @@ public class ChatService {
         .orElse(false);
   }
 
+  /** Return the active restriction for a user or null when none apply. */
+  public BlockedUser getRestriction(String userId) {
+    return blockedRepo
+        .findById(userId)
+        .filter(
+            b ->
+                Boolean.TRUE.equals(b.getPermanent())
+                    || (b.getUntil() != null && b.getUntil().isAfter(Instant.now())))
+        .orElse(null);
+  }
+
   private void saveBan(String userId, String reason) {
-    BlockedUser user = blockedRepo.findById(userId).orElse(new BlockedUser());
-    user.setUserId(userId);
-    user.setPermanent(true);
-    user.setReason(reason);
-    user.setCreatedAt(Instant.now());
-    blockedRepo.save(user);
+    Instant now = Instant.now();
+    blockedRepo.upsert(userId, null, true, reason, now);
   }
 
   private void saveMute(String userId, Duration duration, String reason) {
-    BlockedUser user = blockedRepo.findById(userId).orElse(new BlockedUser());
-    user.setUserId(userId);
-    user.setPermanent(false);
-    user.setUntil(Instant.now().plus(duration));
-    user.setReason(reason);
-    user.setCreatedAt(Instant.now());
-    blockedRepo.save(user);
+    Instant now = Instant.now();
+    blockedRepo.upsert(userId, now.plus(duration), false, reason, now);
   }
 
   private void saveReadonly(String userId, Duration duration, String reason) {
-    BlockedUser user = blockedRepo.findById(userId).orElse(new BlockedUser());
-    user.setUserId(userId);
-    user.setPermanent(false);
-    user.setUntil(Instant.now().plus(duration));
-    user.setReason(reason);
-    user.setCreatedAt(Instant.now());
-    blockedRepo.save(user);
+    Instant now = Instant.now();
+    blockedRepo.upsert(userId, now.plus(duration), false, reason, now);
   }
 }

--- a/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
@@ -94,6 +94,8 @@ public class ModerationService {
           flagged = true;
         }
       }
+    } else {
+      log.debug("OpenAI moderation disabled; skipping API call for {}", userId);
     }
     String json;
     try {

--- a/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
@@ -77,4 +77,13 @@ class ChatControllerTest {
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.error").value("bad"));
   }
+
+  @Test
+  void restrictionEndpointReturnsNone() throws Exception {
+    Mockito.when(chatService.getRestriction("u")).thenReturn(null);
+
+    mvc.perform(get("/api/v1/chat/restrictions/u"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("NONE"));
+  }
 }

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -99,6 +99,13 @@ class ChatServiceTest {
 
     assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
+    Mockito.verify(blockedRepo)
+        .upsert(
+            Mockito.eq("u"),
+            Mockito.isNull(),
+            Mockito.eq(true),
+            Mockito.anyString(),
+            Mockito.any());
   }
 
   @Test
@@ -116,6 +123,8 @@ class ChatServiceTest {
 
     assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
+    Mockito.verify(blockedRepo)
+        .upsert(Mockito.eq("u"), Mockito.any(), Mockito.eq(false), Mockito.anyString(), Mockito.any());
   }
 
   @Test
@@ -133,6 +142,8 @@ class ChatServiceTest {
 
     assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
+    Mockito.verify(blockedRepo)
+        .upsert(Mockito.eq("u"), Mockito.any(), Mockito.eq(false), Mockito.anyString(), Mockito.any());
   }
 
   @Test
@@ -149,5 +160,20 @@ class ChatServiceTest {
     String id = service.createDirectChat("a", "b");
     assertEquals(ChatRepository.directChatId("a", "b"), id);
     Mockito.verify(repo).createChatIfAbsent(id);
+  }
+
+  @Test
+  void getRestrictionReturnsNullWhenNotBlocked() {
+    ChatRepository repo = Mockito.mock(ChatRepository.class);
+    ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
+    ModerationService moderation = Mockito.mock(ModerationService.class);
+    com.clanboards.messages.repository.ModerationRepository modRepo =
+        Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
+    com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
+        Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
+    Mockito.when(blockedRepo.findById("u")).thenReturn(java.util.Optional.empty());
+    ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
+
+    assertNull(service.getRestriction("u"));
   }
 }

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -124,7 +124,8 @@ class ChatServiceTest {
     assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
     Mockito.verify(blockedRepo)
-        .upsert(Mockito.eq("u"), Mockito.any(), Mockito.eq(false), Mockito.anyString(), Mockito.any());
+        .upsert(
+            Mockito.eq("u"), Mockito.any(), Mockito.eq(false), Mockito.anyString(), Mockito.any());
   }
 
   @Test
@@ -143,7 +144,8 @@ class ChatServiceTest {
     assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
     Mockito.verify(blockedRepo)
-        .upsert(Mockito.eq("u"), Mockito.any(), Mockito.eq(false), Mockito.anyString(), Mockito.any());
+        .upsert(
+            Mockito.eq("u"), Mockito.any(), Mockito.eq(false), Mockito.anyString(), Mockito.any());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- upsert blocked users to avoid duplicate key errors
- expose an API to query user restrictions
- log when OpenAI moderation is disabled
- add tests for new logic

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_688a99d350a0832cb574709bda6d75c5