### PR TITLE
Add scouting templates and UI

### DIFF
--- a/coclib/models.py
+++ b/coclib/models.py
@@ -249,3 +249,16 @@ class ModerationRule(db.Model):
     definition = db.Column(db.JSON, nullable=False)
     active = db.Column(db.Boolean, default=True)
 
+
+class Scouting(db.Model):
+    """Templates for clan recruiting."""
+
+    __tablename__ = "scouting"
+
+    id = db.Column(db.BigInteger, primary_key=True)
+    user_id = db.Column(db.BigInteger, db.ForeignKey("users.id"), nullable=False)
+    description = db.Column(db.JSON, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    user = db.relationship("User", backref=db.backref("scouting_templates", lazy="dynamic"))
+

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -1,5 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
+import MobileTabs from '../components/MobileTabs.jsx';
 
 export default function Scout() {
-  return <div className="p-4">Coming soon...</div>;
+  const [active, setActive] = useState('find');
+  return (
+    <div className="p-4">
+      <MobileTabs
+        tabs={[
+          { value: 'find', label: 'Find a Clan' },
+          { value: 'need', label: 'Need a Clan' },
+        ]}
+        active={active}
+        onChange={setActive}
+      />
+      {active === 'find' && <p>Coming soon...</p>}
+      {active === 'need' && <p>Coming soon...</p>}
+    </div>
+  );
 }

--- a/front-end/app/src/pages/Scout.test.jsx
+++ b/front-end/app/src/pages/Scout.test.jsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Scout from './Scout.jsx';
+
+describe('Scout page', () => {
+  it('renders tabs', () => {
+    render(<Scout />);
+    expect(screen.getByText('Find a Clan')).toBeInTheDocument();
+    expect(screen.getByText('Need a Clan')).toBeInTheDocument();
+  });
+});

--- a/migrations/versions/f901db3f1df2_add_scouting_table.py
+++ b/migrations/versions/f901db3f1df2_add_scouting_table.py
@@ -1,0 +1,31 @@
+"""add scouting table
+
+Revision ID: f901db3f1df2
+Revises: ecede0180c1d
+Create Date: 2025-07-30 00:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'f901db3f1df2'
+down_revision = 'ecede0180c1d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'scouting',
+        sa.Column('id', sa.BigInteger(), nullable=False),
+        sa.Column('user_id', sa.BigInteger(), nullable=False),
+        sa.Column('description', sa.JSON(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade():
+    op.drop_table('scouting')

--- a/tests/test_scouting_model.py
+++ b/tests/test_scouting_model.py
@@ -1,0 +1,29 @@
+import pathlib
+from datetime import datetime
+
+from flask.testing import FlaskClient
+
+import sys
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+from app import create_app
+from coclib.config import Config
+from coclib.extensions import db
+from coclib.models import User, Scouting
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+
+
+def test_scouting_table_creation():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        db.session.add(User(id=1, sub="s", email="u@example.com"))
+        db.session.add(
+            Scouting(id=1, user_id=1, description={"msg": "hi"}, created_at=datetime.utcnow())
+        )
+        db.session.commit()
+        assert Scouting.query.count() == 1
+


### PR DESCRIPTION
## Summary
- implement tabs on the Scout page for finding or requesting a clan
- introduce Scouting model for storing recruiting templates
- add database migration for new table
- test new model and page behaviour

## Testing
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_688aa9a41558832cbcdbaf8724bc03f9