### PR TITLE
Fix chat moderation escalation

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -63,7 +63,7 @@ public class ChatService {
           throw new ModerationException("BANNED");
         }
         case MUTE -> {
-          saveMute(userId, Duration.ofHours(24), "moderation");
+          saveMute(userId, Duration.ofHours(6), "moderation");
           throw new ModerationException("MUTED");
         }
         case READONLY -> {
@@ -107,7 +107,7 @@ public class ChatService {
           throw new ModerationException("BANNED");
         }
         case MUTE -> {
-          saveMute(userId, Duration.ofHours(24), "moderation");
+          saveMute(userId, Duration.ofHours(6), "moderation");
           throw new ModerationException("MUTED");
         }
         case READONLY -> {

--- a/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
@@ -107,10 +107,19 @@ public class ModerationService {
       json = "{}";
     }
 
+    double sexualMinors = categories.getOrDefault("sexual_minors", 0.0);
+    double extremism = categories.getOrDefault("extremism", 0.0);
+    double highest =
+        categories.entrySet().stream()
+            .filter(e -> !"toxicity".equals(e.getKey()))
+            .mapToDouble(java.util.Map.Entry::getValue)
+            .max()
+            .orElse(0.0);
+
     ModerationResult result;
-    if (flagged) {
+    if (sexualMinors >= 0.8 || extremism >= 0.8) {
       result = ModerationResult.BLOCK;
-    } else if (profanity) {
+    } else if (highest >= 0.8) {
       result = ModerationResult.MUTE;
     } else if (spam) {
       result = ModerationResult.READONLY;


### PR DESCRIPTION
## Summary
- update moderation logic to use thresholds for sexual content and general flagged categories
- shorten mute duration to 6h

## Testing
- `nox -s lint tests`
- `ruff check back-end coclib db`
- `npm test --silent`
- `npm run build --silent`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_688ab35528f8832c9e7cdf5e947ecca0