### PR TITLE
Fix chat restrictions and caching issues

### DIFF
--- a/front-end/app/public/sw.js
+++ b/front-end/app/public/sw.js
@@ -209,7 +209,11 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(cacheFirst(COOKIE_PATH));
     return;
   }
-  if (url.origin === self.location.origin && url.pathname.startsWith('/api/')) {
+  if (
+    url.origin === self.location.origin &&
+    url.pathname.startsWith('/api/') &&
+    event.request.method === 'GET'
+  ) {
     event.respondWith(staleWhileRevalidate(event.request));
     return;
   }

--- a/front-end/app/src/components/ChatPanel.jsx
+++ b/front-end/app/src/components/ChatPanel.jsx
@@ -194,10 +194,13 @@ useEffect(() => {
         window.dispatchEvent(new CustomEvent('toast', { detail: 'Keep it civil' }));
       } else if (msg.includes('READONLY')) {
         window.dispatchEvent(new CustomEvent('toast', { detail: 'You are temporarily read-only' }));
+        updateMessage(localMsg.ts, { status: 'failed' });
       } else if (msg.includes('MUTED')) {
         window.dispatchEvent(new CustomEvent('toast', { detail: 'You are muted for 24h' }));
+        updateMessage(localMsg.ts, { status: 'failed' });
       } else if (msg.includes('BANNED')) {
         window.dispatchEvent(new CustomEvent('toast', { detail: 'You have been banned' }));
+        updateMessage(localMsg.ts, { status: 'failed' });
       } else {
         const failed = { ...localMsg, status: 'failed' };
         await addOutboxMessage(failed);

--- a/front-end/app/src/hooks/useChat.js
+++ b/front-end/app/src/hooks/useChat.js
@@ -47,7 +47,18 @@ export default function useChat(chatId) {
           setMessages((m) => m.filter((x) => x.ts !== msg.ts));
         } catch (err) {
           console.error('Failed to resend message', err);
-          break;
+          const m = err.message || '';
+          if (
+            m.includes('BANNED') ||
+            m.includes('MUTED') ||
+            m.includes('READONLY') ||
+            m.includes('TOXICITY_WARNING')
+          ) {
+            await removeOutboxMessage(msg.id);
+            setMessages((msgs) => msgs.filter((x) => x.ts !== msg.ts));
+          } else {
+            break;
+          }
         }
       }
     }

--- a/front-end/app/src/hooks/useRestrictions.js
+++ b/front-end/app/src/hooks/useRestrictions.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { fetchJSON } from '../lib/api.js';
+
+export default function useRestrictions(userId) {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    if (!userId) return;
+    let ignore = false;
+    (async () => {
+      try {
+        const res = await fetchJSON(`/chat/restrictions/${encodeURIComponent(userId)}`);
+        if (!ignore) setData(res);
+      } catch (err) {
+        console.error('Failed to fetch restrictions', err);
+      }
+    })();
+    return () => {
+      ignore = true;
+    };
+  }, [userId]);
+
+  return data;
+}
+

--- a/front-end/app/src/pages/ChatPage.jsx
+++ b/front-end/app/src/pages/ChatPage.jsx
@@ -2,6 +2,7 @@ import React, { Suspense, lazy, useEffect, useState, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import Loading from '../components/Loading.jsx';
 import { graphqlRequest } from '../lib/gql.js';
+import useRestrictions from '../hooks/useRestrictions.js';
 
 const ChatPanel = lazy(() => import('../components/ChatPanel.jsx'));
 
@@ -9,6 +10,7 @@ export default function ChatPage({ verified, chatId, userId }) {
   const location = useLocation();
   const [globalIds, setGlobalIds] = useState([]);
   const [friendIds, setFriendIds] = useState([]);
+  const restriction = useRestrictions(userId);
   const search = new URLSearchParams(location.search);
   const initialTab = search.get('tab');
   const initialUser = search.get('user');
@@ -55,6 +57,13 @@ export default function ChatPage({ verified, chatId, userId }) {
 
   return (
     <div className="h-[calc(100dvh-8rem)] flex flex-col overflow-y-auto overscroll-y-contain">
+      {restriction && restriction.status !== 'NONE' && (
+        <div className="bg-yellow-100 text-yellow-800 text-center text-sm p-2">
+          {restriction.status === 'BANNED'
+            ? 'You are banned from chat.'
+            : `You are muted for ${Math.ceil((restriction.remaining || 0) / 60)}m`}
+        </div>
+      )}
       <Suspense fallback={<Loading className="py-20" />}>
         {verified ? (
           <ChatPanel

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import MobileTabs from '../components/MobileTabs.jsx';
+import Tabs from '../components/Tabs.jsx';
 
 export default function Scout() {
   const [active, setActive] = useState('find');
   return (
     <div className="p-4">
-      <MobileTabs
+      <Tabs
         tabs={[
           { value: 'find', label: 'Find a Clan' },
           { value: 'need', label: 'Need a Clan' },


### PR DESCRIPTION
## Summary
- style Scout page tabs like other pages
- ensure moderated message errors mark messages as failed
- avoid resending moderated messages from the outbox
- fetch chat restrictions and show banner in chat
- only cache GET API requests in the service worker

## Testing
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_688ab4c69c90832c9a43d24c0d38b4ed