### PR TITLE
Improve moderation handling

### DIFF
--- a/coclib/models.py
+++ b/coclib/models.py
@@ -224,6 +224,8 @@ class ModerationRecord(db.Model):
     user_id = db.Column(db.String(255), index=True, nullable=False)
     content = db.Column(db.Text, nullable=False)
     categories = db.Column(db.JSON, nullable=False)
+    ip = db.Column(db.String(45))
+    user_agent = db.Column(db.String(255))
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 

--- a/front-end/app/src/App.jsx
+++ b/front-end/app/src/App.jsx
@@ -13,6 +13,8 @@ import DesktopNav from './components/DesktopNav.jsx';
 import NotificationBanner from './components/NotificationBanner.jsx';
 import Toast from './components/Toast.jsx';
 import { fetchJSON } from './lib/api.js';
+import useRestrictions from './hooks/useRestrictions.js';
+const BannedPage = lazy(() => import('./pages/Banned.jsx'));
 
 const Dashboard = lazy(() => import('./pages/Dashboard.jsx'));
 const ClanModal = lazy(() => import('./components/ClanModal.jsx'));
@@ -58,6 +60,7 @@ export default function App() {
   const [loadingUser, setLoadingUser] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
   const [badgeCount, setBadgeCount] = useState(0);
+  const restriction = useRestrictions(user ? user.sub : null);
   const { enabled: hasFeature } = useFeatures(user);
   const chatAllowed = hasFeature('chat');
   const menuRef = React.useRef(null);
@@ -183,6 +186,18 @@ export default function App() {
     return (
       <Suspense fallback={<Loading className="h-screen" />}>
         <LoginPage />
+      </Suspense>
+    );
+  }
+
+  if (
+    restriction &&
+    restriction.status === 'BANNED' &&
+    (restriction.remaining || 0) === 0
+  ) {
+    return (
+      <Suspense fallback={<Loading className="h-screen" />}>
+        <BannedPage />
       </Suspense>
     );
   }

--- a/front-end/app/src/components/ChatPanel.jsx
+++ b/front-end/app/src/components/ChatPanel.jsx
@@ -18,6 +18,7 @@ export default function ChatPanel({
   friendIds = [],
   initialTab = null,
   initialDirectId = null,
+  restriction = null,
 }) {
   const [tab, setTab] = useState(
     initialDirectId ? 'Friends' : initialTab || (chatId ? 'Clan' : 'Global')
@@ -280,21 +281,29 @@ useEffect(() => {
           )}
         </div>
         {(tab !== 'Friends' || directChatId) && !(tab === 'Clan' && !chatId) && (
-          <form onSubmit={handleSubmit} className="flex gap-2 p-2 border-t">
-            <MentionInput
-              members={clanMembers.map((m) => ({ name: m.name, tag: m.tag }))}
-              value={text}
-              onChange={setText}
-              placeholder="Type a message…"
-            />
-            <button
-              type="submit"
-              className="px-3 py-1 rounded bg-blue-600 text-white"
-              disabled={sending}
-            >
-              {sending ? 'Sending…' : 'Send'}
-            </button>
-          </form>
+          restriction && restriction.status !== 'NONE' ? (
+            <div className="p-2 border-t text-sm text-center bg-yellow-100 text-yellow-800">
+              {restriction.status === 'BANNED'
+                ? 'You are banned from chat.'
+                : `You are muted for ${Math.ceil((restriction.remaining || 0) / 60)}m`}
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="flex gap-2 p-2 border-t">
+              <MentionInput
+                members={clanMembers.map((m) => ({ name: m.name, tag: m.tag }))}
+                value={text}
+                onChange={setText}
+                placeholder="Type a message…"
+              />
+              <button
+                type="submit"
+                className="px-3 py-1 rounded bg-blue-600 text-white"
+                disabled={sending}
+              >
+                {sending ? 'Sending…' : 'Send'}
+              </button>
+            </form>
+          )
         )}
         </>
       )}

--- a/front-end/app/src/components/ChatPanel.test.jsx
+++ b/front-end/app/src/components/ChatPanel.test.jsx
@@ -54,4 +54,10 @@ describe('ChatPanel component', () => {
     fireEvent.scroll(container, { target: { scrollTop: 50 } });
     expect(loadMoreMock).toHaveBeenCalled();
   });
+
+  it('shows restriction message instead of input', () => {
+    render(<ChatPanel restriction={{ status: 'BANNED', remaining: 0 }} />);
+    expect(screen.getByText('You are banned from chat.')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Type a message…')).not.toBeInTheDocument();
+  });
 });

--- a/front-end/app/src/pages/Banned.jsx
+++ b/front-end/app/src/pages/Banned.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function Banned() {
+  return (
+    <div className="min-h-[100dvh] flex flex-col text-center">
+      <header className="banner bg-gradient-to-r from-blue-600 via-blue-700 to-slate-800 text-white p-4 shadow-md">
+        <h1 className="text-lg font-semibold">Clan Dashboard</h1>
+      </header>
+      <main className="flex-1 flex flex-col justify-center items-center px-4 space-y-4">
+        <h2 className="text-2xl font-bold">Access Denied</h2>
+        <p className="max-w-md text-sm text-slate-600">
+          Your account has been permanently banned for violations of our code of conduct.
+          Continued use of this site is prohibited by our legal terms.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/front-end/app/src/pages/ChatPage.jsx
+++ b/front-end/app/src/pages/ChatPage.jsx
@@ -57,13 +57,6 @@ export default function ChatPage({ verified, chatId, userId }) {
 
   return (
     <div className="h-[calc(100dvh-8rem)] flex flex-col overflow-y-auto overscroll-y-contain">
-      {restriction && restriction.status !== 'NONE' && (
-        <div className="bg-yellow-100 text-yellow-800 text-center text-sm p-2">
-          {restriction.status === 'BANNED'
-            ? 'You are banned from chat.'
-            : `You are muted for ${Math.ceil((restriction.remaining || 0) / 60)}m`}
-        </div>
-      )}
       <Suspense fallback={<Loading className="py-20" />}>
         {verified ? (
           <ChatPanel
@@ -73,6 +66,7 @@ export default function ChatPage({ verified, chatId, userId }) {
           friendIds={friendIds}
           initialTab={initialTab ? initialTab.charAt(0).toUpperCase() + initialTab.slice(1) : undefined}
           initialDirectId={initialDirectId}
+          restriction={restriction}
         />
         ) : (
           <div className="p-4">Verify your account to chat.</div>

--- a/messages-java/src/main/java/com/clanboards/messages/config/AuthInterceptor.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/AuthInterceptor.java
@@ -47,8 +47,18 @@ public class AuthInterceptor implements WebGraphQlInterceptor {
                 .getBody();
         String sub = claims.get("sub", String.class);
         if (sub != null) {
+          String ip = request.getHeaders().getFirst("X-Forwarded-For");
+          String ua = request.getHeaders().getFirst("User-Agent");
           request.configureExecutionInput(
-              (ei, builder) -> builder.graphQLContext(ctx -> ctx.put("userId", sub)).build());
+              (ei, builder) ->
+                  builder
+                      .graphQLContext(
+                          ctx -> {
+                            ctx.put("userId", sub);
+                            if (ip != null) ctx.put("ip", ip);
+                            if (ua != null) ctx.put("ua", ua);
+                          })
+                      .build());
         }
       } catch (Exception ignored) {
       }

--- a/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/ChatController.java
@@ -22,16 +22,22 @@ public class ChatController {
   }
 
   @PostMapping("/publish")
-  public ResponseEntity<Map<String, String>> publish(@RequestBody PublishRequest req) {
+  public ResponseEntity<Map<String, String>> publish(
+      @RequestBody PublishRequest req,
+      @RequestHeader(value = "User-Agent", required = false) String ua,
+      @RequestHeader(value = "X-Forwarded-For", required = false) String ip) {
     log.info("Received publish request for chat {}", req.chatId());
-    ChatMessage msg = chatService.publish(req.chatId(), req.text(), req.userId());
+    ChatMessage msg = chatService.publish(req.chatId(), req.text(), req.userId(), ip, ua);
     return ResponseEntity.ok(Map.of("status", "ok", "ts", msg.ts().toString()));
   }
 
   @PostMapping("/publish/global")
-  public ResponseEntity<Map<String, String>> publishGlobal(@RequestBody GlobalRequest req) {
+  public ResponseEntity<Map<String, String>> publishGlobal(
+      @RequestBody GlobalRequest req,
+      @RequestHeader(value = "User-Agent", required = false) String ua,
+      @RequestHeader(value = "X-Forwarded-For", required = false) String ip) {
     log.info("Received global publish request by {}", req.userId());
-    ChatMessage msg = chatService.publishGlobal(req.text(), req.userId());
+    ChatMessage msg = chatService.publishGlobal(req.text(), req.userId(), ip, ua);
     return ResponseEntity.ok(Map.of("status", "ok", "ts", msg.ts().toString()));
   }
 

--- a/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLController.java
+++ b/messages-java/src/main/java/com/clanboards/messages/controller/GraphQLController.java
@@ -70,16 +70,18 @@ public class GraphQLController {
   public Message sendMessage(
       @Argument String chatId,
       @Argument String content,
-      @ContextValue(value = "userId", required = false) String userId) {
+      @ContextValue(value = "userId", required = false) String userId,
+      @ContextValue(value = "ip", required = false) String ip,
+      @ContextValue(value = "ua", required = false) String ua) {
     if (userId == null || userId.isBlank()) {
       throw new RuntimeException("Unauthenticated");
     }
     log.info("GraphQL sendMessage to {} by {}", chatId, userId);
     ChatMessage saved;
     if (chatId.startsWith("global#")) {
-      saved = chatService.publishGlobal(content, userId);
+      saved = chatService.publishGlobal(content, userId, ip, ua);
     } else {
-      saved = chatService.publish(chatId, content, userId);
+      saved = chatService.publish(chatId, content, userId, ip, ua);
     }
     return new Message(saved.id(), saved.channel(), saved.ts(), saved.userId(), saved.content());
   }

--- a/messages-java/src/main/java/com/clanboards/messages/model/ModerationRecord.java
+++ b/messages-java/src/main/java/com/clanboards/messages/model/ModerationRecord.java
@@ -21,6 +21,10 @@ public class ModerationRecord {
   @Column(columnDefinition = "jsonb")
   private String categories;
 
+  private String ip;
+
+  private String userAgent;
+
   private Instant createdAt = Instant.now();
 
   public Long getId() {
@@ -53,6 +57,22 @@ public class ModerationRecord {
 
   public void setCategories(String categories) {
     this.categories = categories;
+  }
+
+  public String getIp() {
+    return ip;
+  }
+
+  public void setIp(String ip) {
+    this.ip = ip;
+  }
+
+  public String getUserAgent() {
+    return userAgent;
+  }
+
+  public void setUserAgent(String userAgent) {
+    this.userAgent = userAgent;
   }
 
   public Instant getCreatedAt() {

--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -43,7 +43,8 @@ public class ChatService {
     return id;
   }
 
-  public ChatMessage publish(String chatId, String text, String userId) {
+  public ChatMessage publish(
+      String chatId, String text, String userId, String ip, String userAgent) {
     log.info("Publishing message to chat {} by {}", chatId, userId);
     try {
       if (isBlocked(userId)) {
@@ -55,6 +56,8 @@ public class ChatService {
         rec.setUserId(userId);
         rec.setContent(text);
         rec.setCategories(res.categories());
+        rec.setIp(ip);
+        rec.setUserAgent(userAgent);
         modRepo.save(rec);
       }
       switch (res.result()) {
@@ -87,7 +90,7 @@ public class ChatService {
     }
   }
 
-  public ChatMessage publishGlobal(String text, String userId) {
+  public ChatMessage publishGlobal(String text, String userId, String ip, String userAgent) {
     log.info("Publishing global message by {}", userId);
     try {
       if (isBlocked(userId)) {
@@ -99,6 +102,8 @@ public class ChatService {
         rec.setUserId(userId);
         rec.setContent(text);
         rec.setCategories(res.categories());
+        rec.setIp(ip);
+        rec.setUserAgent(userAgent);
         modRepo.save(rec);
       }
       switch (res.result()) {

--- a/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/ChatControllerTest.java
@@ -27,7 +27,7 @@ class ChatControllerTest {
   @Test
   void publishReturnsOk() throws Exception {
     Instant ts = Instant.parse("2024-01-01T00:00:00Z");
-    Mockito.when(chatService.publish("1", "hi", "u"))
+    Mockito.when(chatService.publish("1", "hi", "u", null, null))
         .thenReturn(new ChatMessage("m1", "1", "u", "hi", ts));
 
     mvc.perform(
@@ -54,7 +54,7 @@ class ChatControllerTest {
   @Test
   void publishGlobalReturnsOk() throws Exception {
     Instant ts = Instant.parse("2024-01-01T00:00:00Z");
-    Mockito.when(chatService.publishGlobal("hi", "u"))
+    Mockito.when(chatService.publishGlobal("hi", "u", null, null))
         .thenReturn(new ChatMessage("m3", "global#shard-1", "u", "hi", ts));
 
     mvc.perform(
@@ -67,7 +67,7 @@ class ChatControllerTest {
 
   @Test
   void publishHandlesBadRequest() throws Exception {
-    Mockito.when(chatService.publish("1", "hi", "u"))
+    Mockito.when(chatService.publish("1", "hi", "u", null, null))
         .thenThrow(new IllegalArgumentException("bad"));
 
     mvc.perform(

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -25,7 +25,7 @@ class ChatServiceTest {
         .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
-    ChatMessage msg = service.publish("1", "hello", "u");
+    ChatMessage msg = service.publish("1", "hello", "u", null, null);
     assertEquals("1", msg.channel());
     Mockito.verify(repo).saveMessage(Mockito.any(ChatMessage.class));
     Mockito.verify(events).publishEvent(Mockito.any(MessageSavedEvent.class));
@@ -61,7 +61,7 @@ class ChatServiceTest {
         .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
-    ChatMessage msg = service.publishGlobal("hi", "user1");
+    ChatMessage msg = service.publishGlobal("hi", "user1", null, null);
     assertEquals(ChatRepository.globalShardKey("user1"), msg.channel());
     Mockito.verify(repo).saveMessage(Mockito.any(ChatMessage.class));
   }
@@ -79,7 +79,7 @@ class ChatServiceTest {
         .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
-    service.publish("1", "hi", "u");
+    service.publish("1", "hi", "u", null, null);
 
     Mockito.verify(moderation).verify("u", "hi");
   }
@@ -97,7 +97,7 @@ class ChatServiceTest {
         .thenReturn(new ModerationOutcome(ModerationResult.BLOCK, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
-    assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));
+    assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u", null, null));
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
     Mockito.verify(blockedRepo)
         .upsert(
@@ -121,7 +121,7 @@ class ChatServiceTest {
         .thenReturn(new ModerationOutcome(ModerationResult.MUTE, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
-    assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));
+    assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u", null, null));
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
     Mockito.verify(blockedRepo)
         .upsert(
@@ -141,7 +141,7 @@ class ChatServiceTest {
         .thenReturn(new ModerationOutcome(ModerationResult.READONLY, "{}"));
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
-    assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u"));
+    assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u", null, null));
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
     Mockito.verify(blockedRepo)
         .upsert(

--- a/migrations/versions/d9ddc8754765_add_ip_user_agent_to_moderation.py
+++ b/migrations/versions/d9ddc8754765_add_ip_user_agent_to_moderation.py
@@ -1,0 +1,26 @@
+"""add ip and user_agent columns to moderation table
+
+Revision ID: d9ddc8754765
+Revises: b7028ae0d5e1
+Create Date: 2025-07-31 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'd9ddc8754765'
+down_revision = 'b7028ae0d5e1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('moderation') as batch_op:
+        batch_op.add_column(sa.Column('ip', sa.String(length=45), nullable=True))
+        batch_op.add_column(sa.Column('user_agent', sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('moderation') as batch_op:
+        batch_op.drop_column('user_agent')
+        batch_op.drop_column('ip')


### PR DESCRIPTION
## Summary
- add IP and user agent to moderation model
- display chat restrictions in the input area
- block permanently banned users with a simple page
- store moderation metadata in Java service
- pass restriction data to chat components

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_688abe348180832ca464b4e2ef678aa2