### PR TITLE
Fix chat restrictions refresh

### DIFF
--- a/front-end/app/src/App.jsx
+++ b/front-end/app/src/App.jsx
@@ -178,8 +178,30 @@ export default function App() {
     }
   }, []);
 
+  useEffect(() => {
+    if (
+      restriction &&
+      restriction.status === 'BANNED' &&
+      (restriction.remaining || 0) === 0
+    ) {
+      window.google?.accounts.id.disableAutoSelect();
+      logout();
+      window.location.hash = '#/banned';
+    }
+  }, [restriction, logout]);
+
   if (loading) {
     return <Loading className="h-screen" />;
+  }
+
+  const currentHash = window.location.hash.slice(1);
+
+  if (!user && currentHash === '/banned') {
+    return (
+      <Suspense fallback={<Loading className="h-screen" />}>
+        <BannedPage />
+      </Suspense>
+    );
   }
 
   if (!user) {
@@ -190,17 +212,6 @@ export default function App() {
     );
   }
 
-  if (
-    restriction &&
-    restriction.status === 'BANNED' &&
-    (restriction.remaining || 0) === 0
-  ) {
-    return (
-      <Suspense fallback={<Loading className="h-screen" />}>
-        <BannedPage />
-      </Suspense>
-    );
-  }
 
   return (
     <Router>
@@ -287,6 +298,7 @@ export default function App() {
               {import.meta.env.DEV && (
                 <Route path="/push-debug" element={<PushDebugPage />} />
               )}
+              <Route path="/banned" element={<BannedPage />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           </Suspense>

--- a/front-end/app/src/App.test.jsx
+++ b/front-end/app/src/App.test.jsx
@@ -1,18 +1,68 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
-import { AuthProvider } from './hooks/useAuth.jsx';
+
+// mocks must be defined before importing the component
+const logoutSpy = vi.fn();
+var restrictionsMock = vi.fn(() => null);
+let currentUser = null;
+
+vi.mock('./hooks/useRestrictions.js', () => ({
+  default: (...args) => restrictionsMock(...args),
+}));
+
+vi.mock('./hooks/useAuth.jsx', () => {
+  return {
+    AuthProvider: ({ children }) => <>{children}</>,
+    useAuth: () => ({
+      user: currentUser,
+      logout: () => {
+        logoutSpy();
+        currentUser = null;
+      },
+      loading: false,
+    }),
+  };
+});
+
 import App from './App.jsx';
 
 describe('App authentication', () => {
+  beforeEach(() => {
+    restrictionsMock.mockReset();
+    logoutSpy.mockClear();
+    currentUser = null;
+  });
   it('shows login page when not authenticated', async () => {
     vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, status: 401, text: () => Promise.resolve(''), json: () => Promise.resolve({}) })));
+    currentUser = null;
     render(
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      <App />
     );
     expect(await screen.findByText(/login or register/i)).toBeInTheDocument();
     vi.unstubAllGlobals();
+  });
+
+  it('shows banned page when hash is set', async () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...window.location, hash: '#/banned' },
+    });
+    currentUser = null;
+    render(<App />);
+    expect(await screen.findByText(/access denied/i)).toBeInTheDocument();
+  });
+
+  it('logs out and redirects when restrictions report a ban', async () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...window.location, hash: '' },
+    });
+    currentUser = { sub: 'u1', id: 1, name: 'Test' };
+    restrictionsMock.mockReturnValue({ status: 'BANNED', remaining: 0 });
+    render(<App />);
+    expect(await screen.findByText(/access denied/i)).toBeInTheDocument();
+    expect(logoutSpy).toHaveBeenCalled();
+    expect(window.location.hash).toBe('#/banned');
   });
 });

--- a/front-end/app/src/components/ChatPanel.jsx
+++ b/front-end/app/src/components/ChatPanel.jsx
@@ -194,13 +194,22 @@ useEffect(() => {
       if (msg.includes('TOXICITY_WARNING')) {
         window.dispatchEvent(new CustomEvent('toast', { detail: 'Keep it civil' }));
       } else if (msg.includes('READONLY')) {
-        window.dispatchEvent(new CustomEvent('toast', { detail: 'You are temporarily read-only' }));
+        window.dispatchEvent(
+          new CustomEvent('toast', { detail: 'You are temporarily read-only' }),
+        );
+        window.dispatchEvent(new Event('restriction-updated'));
         updateMessage(localMsg.ts, { status: 'failed' });
       } else if (msg.includes('MUTED')) {
-        window.dispatchEvent(new CustomEvent('toast', { detail: 'You are muted for 24h' }));
+        window.dispatchEvent(
+          new CustomEvent('toast', { detail: 'You are muted for 24h' }),
+        );
+        window.dispatchEvent(new Event('restriction-updated'));
         updateMessage(localMsg.ts, { status: 'failed' });
       } else if (msg.includes('BANNED')) {
-        window.dispatchEvent(new CustomEvent('toast', { detail: 'You have been banned' }));
+        window.dispatchEvent(
+          new CustomEvent('toast', { detail: 'You have been banned' }),
+        );
+        window.dispatchEvent(new Event('restriction-updated'));
         updateMessage(localMsg.ts, { status: 'failed' });
       } else {
         const failed = { ...localMsg, status: 'failed' };

--- a/front-end/app/src/hooks/useChat.js
+++ b/front-end/app/src/hooks/useChat.js
@@ -54,6 +54,9 @@ export default function useChat(chatId) {
             m.includes('READONLY') ||
             m.includes('TOXICITY_WARNING')
           ) {
+            if (m.includes('BANNED') || m.includes('MUTED') || m.includes('READONLY')) {
+              window.dispatchEvent(new Event('restriction-updated'));
+            }
             await removeOutboxMessage(msg.id);
             setMessages((msgs) => msgs.filter((x) => x.ts !== msg.ts));
           } else {

--- a/front-end/app/src/hooks/useRestrictions.js
+++ b/front-end/app/src/hooks/useRestrictions.js
@@ -5,18 +5,33 @@ export default function useRestrictions(userId) {
   const [data, setData] = useState(null);
 
   useEffect(() => {
-    if (!userId) return;
-    let ignore = false;
-    (async () => {
+    if (!userId) {
+      setData(null);
+      return;
+    }
+    let cancelled = false;
+
+    const load = async () => {
       try {
-        const res = await fetchJSON(`/chat/restrictions/${encodeURIComponent(userId)}`);
-        if (!ignore) setData(res);
+        const res = await fetchJSON(
+          `/chat/restrictions/${encodeURIComponent(userId)}`,
+        );
+        if (!cancelled) setData(res);
       } catch (err) {
         console.error('Failed to fetch restrictions', err);
       }
-    })();
+    };
+
+    load();
+
+    const handler = () => {
+      if (!cancelled) load();
+    };
+    window.addEventListener('restriction-updated', handler);
+
     return () => {
-      ignore = true;
+      cancelled = true;
+      window.removeEventListener('restriction-updated', handler);
     };
   }, [userId]);
 


### PR DESCRIPTION
## Summary
- update useRestrictions hook so it refreshes when the `restriction-updated` event fires
- dispatch a `restriction-updated` event whenever message sending fails due to READONLY/MUTED/BANNED
- also dispatch that event if resending queued messages fails for these reasons
- log out and redirect when a ban is detected

## Testing
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_688ac91acb2c832cbc5d63900441b622