### PR TITLE
Fix banned login handling

### DIFF
--- a/front-end/app/src/hooks/useAuth.jsx
+++ b/front-end/app/src/hooks/useAuth.jsx
@@ -11,10 +11,13 @@ export function AuthProvider({ children }) {
     try {
       const me = await fetchJSON('/user/me');
       setUser(me);
+      return me;
     } catch {
       setUser(null);
+      return null;
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   }
 
   useEffect(() => {
@@ -35,7 +38,7 @@ export function AuthProvider({ children }) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ idToken }),
     });
-    await loadMe();
+    return loadMe();
   }
 
   async function logout() {

--- a/front-end/app/src/pages/Login.test.jsx
+++ b/front-end/app/src/pages/Login.test.jsx
@@ -1,0 +1,52 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+var loginMock = vi.fn();
+var fetchJSONMock;
+
+vi.mock('../hooks/useAuth.jsx', () => ({
+  useAuth: () => ({
+    login: (...args) => loginMock(...args),
+  }),
+}));
+
+vi.mock('../lib/api.js', () => {
+  fetchJSONMock = vi.fn();
+  const fetchJSON = (...args) => fetchJSONMock(...args);
+  return { fetchJSON };
+});
+
+import Login from './Login.jsx';
+
+describe('Login redirect', () => {
+  beforeEach(() => {
+    loginMock.mockReset();
+    fetchJSONMock.mockReset();
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...window.location, hash: '', reload: vi.fn() },
+    });
+    window.google = {
+      accounts: {
+        id: {
+          initialize: vi.fn((opts) => {
+            window.__loginCallback = opts.callback;
+          }),
+          renderButton: vi.fn(),
+          prompt: vi.fn(),
+        },
+      },
+    };
+  });
+
+  it('navigates to banned page when account is banned', async () => {
+    loginMock.mockResolvedValue({ sub: 'u1' });
+    fetchJSONMock.mockResolvedValue({ status: 'BANNED', remaining: 0 });
+
+    render(<Login />);
+    await window.__loginCallback({ credential: 'tok' });
+
+    expect(window.location.hash).toBe('#/banned');
+  });
+});


### PR DESCRIPTION
## Summary
- return user from AuthProvider login helper
- check restrictions after login and redirect banned users
- add regression test for login page

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_688adc45a154832cb45d146db0deb12e