### PR TITLE
Add Google Perspective moderation

### DIFF
--- a/migrations/versions/61545e86c9d9_seed_perspective_rules.py
+++ b/migrations/versions/61545e86c9d9_seed_perspective_rules.py
@@ -1,0 +1,42 @@
+"""seed perspective moderation rules
+
+Revision ID: 61545e86c9d9
+Revises: d9ddc8754765
+Create Date: 2025-10-10 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+import json
+
+revision = '61545e86c9d9'
+down_revision = 'd9ddc8754765'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    rules = sa.table(
+        'rules',
+        sa.column('name', sa.String()),
+        sa.column('definition', sa.JSON()),
+        sa.column('active', sa.Boolean()),
+    )
+    op.bulk_insert(
+        rules,
+        [
+            {
+                'name': 'ban profanity (perspective)',
+                'definition': json.dumps({'type': 'category_threshold', 'category': 'profanity', 'threshold': 0.9, 'reason': 'banned'}),
+                'active': True,
+            },
+            {
+                'name': 'mute perspective flagged',
+                'definition': json.dumps({'type': 'category_any', 'threshold': 0.9, 'duration': 86400, 'reason': 'mute'}),
+                'active': True,
+            },
+        ]
+    )
+
+
+def downgrade():
+    op.execute("delete from rules where name like 'ban profanity (perspective)' or name like 'mute perspective flagged'")

--- a/migrations/versions/eb52c625672e_extend_perspective_rules.py
+++ b/migrations/versions/eb52c625672e_extend_perspective_rules.py
@@ -1,0 +1,73 @@
+"""add individual perspective rules
+
+Revision ID: eb52c625672e
+Revises: 61545e86c9d9
+Create Date: 2025-10-11 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+import json
+
+revision = 'eb52c625672e'
+down_revision = '61545e86c9d9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    rules = sa.table(
+        'rules',
+        sa.column('name', sa.String()),
+        sa.column('definition', sa.JSON()),
+        sa.column('active', sa.Boolean()),
+    )
+    op.bulk_insert(
+        rules,
+        [
+            {
+                'name': 'mute toxicity (perspective)',
+                'definition': json.dumps({'type': 'category_threshold', 'category': 'toxicity', 'threshold': 0.9, 'duration': 86400, 'reason': 'mute'}),
+                'active': True,
+            },
+            {
+                'name': 'mute severe toxicity (perspective)',
+                'definition': json.dumps({'type': 'category_threshold', 'category': 'severe_toxicity', 'threshold': 0.9, 'duration': 86400, 'reason': 'mute'}),
+                'active': True,
+            },
+            {
+                'name': 'mute insult (perspective)',
+                'definition': json.dumps({'type': 'category_threshold', 'category': 'insult', 'threshold': 0.9, 'duration': 86400, 'reason': 'mute'}),
+                'active': True,
+            },
+            {
+                'name': 'mute threat (perspective)',
+                'definition': json.dumps({'type': 'category_threshold', 'category': 'threat', 'threshold': 0.9, 'duration': 86400, 'reason': 'mute'}),
+                'active': True,
+            },
+            {
+                'name': 'mute identity attack (perspective)',
+                'definition': json.dumps({'type': 'category_threshold', 'category': 'identity_attack', 'threshold': 0.9, 'duration': 86400, 'reason': 'mute'}),
+                'active': True,
+            },
+            {
+                'name': 'mute sexually explicit (perspective)',
+                'definition': json.dumps({'type': 'category_threshold', 'category': 'sexually_explicit', 'threshold': 0.9, 'duration': 86400, 'reason': 'mute'}),
+                'active': True,
+            },
+            {
+                'name': 'mute flirtation (perspective)',
+                'definition': json.dumps({'type': 'category_threshold', 'category': 'flirtation', 'threshold': 0.9, 'duration': 86400, 'reason': 'mute'}),
+                'active': True,
+            },
+            {
+                'name': 'mute spam (perspective)',
+                'definition': json.dumps({'type': 'category_threshold', 'category': 'spam', 'threshold': 0.9, 'duration': 86400, 'reason': 'mute'}),
+                'active': True,
+            },
+        ]
+    )
+
+
+def downgrade():
+    op.execute("delete from rules where name like 'mute % (perspective)'")
+


### PR DESCRIPTION
## Summary
- integrate Google Perspective API in `ModerationService`
- track toxicity and profanity based on Perspective scores
- seed DB with Perspective-specific rules

## Testing
- `nox -s lint tests`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_688ae31b19c0832cac690c97d40e0d9a