### PR TITLE
Show clan tenure in member tables

### DIFF
--- a/front-end/app/src/components/LoyaltyBadge.jsx
+++ b/front-end/app/src/components/LoyaltyBadge.jsx
@@ -1,23 +1,8 @@
 import React from 'react';
-
-function formatDuration(days) {
-  if (days >= 365) {
-    const years = Math.floor(days / 365);
-    return `${years}y`;
-  }
-  if (days >= 30) {
-    const months = Math.floor(days / 30);
-    return `${months}m`;
-  }
-  if (days >= 7) {
-    const weeks = Math.floor(days / 7);
-    return `${weeks}w`;
-  }
-  return `${days}d`;
-}
+import { formatDays } from '../lib/time.js';
 
 export default function LoyaltyBadge({ days, size = 60 }) {
-  const label = formatDuration(days);
+  const label = formatDays(days);
   return (
     <div
       className="flex items-center justify-center rounded-full bg-white text-slate-800 font-semibold"

--- a/front-end/app/src/components/MemberList.jsx
+++ b/front-end/app/src/components/MemberList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { FixedSizeList as List } from 'react-window';
 import RiskRing from './RiskRing.jsx';
 import DonationRing from './DonationRing.jsx';
-import { timeAgo } from '../lib/time.js';
+import { timeAgo, formatDays } from '../lib/time.js';
 import PlayerMini from './PlayerMini.jsx';
 
 function Row({ index, style, data }) {
@@ -25,6 +25,10 @@ function Row({ index, style, data }) {
         </span>
       </div>
       <div className="flex items-center gap-2">
+        <div className="flex flex-col items-center text-xs mr-1">
+          <span>{formatDays(m.loyalty)}</span>
+          <span className="text-slate-500">In Clan</span>
+        </div>
         <RiskRing score={m.risk_score} size={32} />
         <div className="hidden md:block">
           <DonationRing

--- a/front-end/app/src/components/MemberList.test.jsx
+++ b/front-end/app/src/components/MemberList.test.jsx
@@ -17,6 +17,7 @@ const members = [
     risk_score: 5,
     donations: 0,
     donationsReceived: 0,
+    loyalty: 40,
   },
 ];
 
@@ -28,5 +29,6 @@ describe('MemberList', () => {
     expect(spy).toHaveBeenCalledWith('#B');
     expect(screen.getByAltText('league')).toHaveAttribute('src', members[0].leagueIcon);
     expect(screen.queryByText('#B')).not.toBeInTheDocument();
+    expect(screen.getByText('In Clan')).toBeInTheDocument();
   });
 });

--- a/front-end/app/src/lib/time.js
+++ b/front-end/app/src/lib/time.js
@@ -33,3 +33,19 @@ export function shortTimeAgo(date) {
     const diffDay = Math.floor(diffHr / 24);
     return `${diffDay}d`;
 }
+
+export function formatDays(days) {
+    if (days >= 365) {
+        const years = Math.floor(days / 365);
+        return `${years}y`;
+    }
+    if (days >= 30) {
+        const months = Math.floor(days / 30);
+        return `${months}m`;
+    }
+    if (days >= 7) {
+        const weeks = Math.floor(days / 7);
+        return `${weeks}w`;
+    }
+    return `${days}d`;
+}

--- a/front-end/app/src/pages/Dashboard.jsx
+++ b/front-end/app/src/pages/Dashboard.jsx
@@ -2,7 +2,7 @@ import React, {useState, useEffect, useMemo, Suspense, lazy} from 'react';
 import Loading from '../components/Loading.jsx';
 import {fetchJSONCached} from '../lib/api.js';
 import { getClanCache, putClanCache } from '../lib/db.js';
-import { timeAgo } from '../lib/time.js';
+import { timeAgo, formatDays } from '../lib/time.js';
 import Tabs from '../components/Tabs.jsx';
 import RiskRing from '../components/RiskRing.jsx';
 import DonationRing from '../components/DonationRing.jsx';
@@ -54,8 +54,8 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
     const [refreshing, setRefreshing] = useState(false);
 
     const [selected, setSelected] = useState(null);
-    const [sortField, setSortField] = useState('');
-    const [sortDir, setSortDir] = useState('asc');
+    const [sortField, setSortField] = useState('loyalty');
+    const [sortDir, setSortDir] = useState('desc');
     const [activeSection, setActiveSection] = useState('health');
     const [isDesktop, setIsDesktop] = useState(() => window.matchMedia('(min-width:640px)').matches);
     const [listHeight, setListHeight] = useState(() => Math.min(500, window.innerHeight - 200));
@@ -376,11 +376,17 @@ export default function Dashboard({ defaultTag, showSearchForm = true, onClanLoa
                                                         </td>
                                                         <td data-label="Days in Clan" className="px-3 py-2 text-center hidden sm:table-cell">{m.loyalty}</td>
                                                         <td data-label="Risk" className="px-3 py-2 text-center">
-                                                            {refreshing && !loading ? (
-                                                                <Loading size={36} />
-                                                            ) : (
-                                                                <RiskRing score={m.risk_score} size={36} />
-                                                            )}
+                                                            <div className="flex items-center justify-center gap-2">
+                                                                <div className="flex flex-col items-center text-xs">
+                                                                    <span>{formatDays(m.loyalty)}</span>
+                                                                    <span className="text-slate-500">In Clan</span>
+                                                                </div>
+                                                                {refreshing && !loading ? (
+                                                                    <Loading size={36} />
+                                                                ) : (
+                                                                    <RiskRing score={m.risk_score} size={36} />
+                                                                )}
+                                                            </div>
                                                         </td>
                                                     </tr>
                                                 ))}


### PR DESCRIPTION
## Summary
- allow frontend lib to format days into short strings
- reuse formatter in `LoyaltyBadge`
- display member tenure next to risk ring
- default sort by tenure descending
- update member list tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b73c19c74832c85fa76778be6a319