### PR TITLE
Warn before chat moderation actions

### DIFF
--- a/front-end/app/src/hooks/useChat.js
+++ b/front-end/app/src/hooks/useChat.js
@@ -54,6 +54,9 @@ export default function useChat(chatId) {
             m.includes('READONLY') ||
             m.includes('TOXICITY_WARNING')
           ) {
+            if (m.includes('TOXICITY_WARNING')) {
+              window.dispatchEvent(new CustomEvent('toast', { detail: 'Keep it civil' }));
+            }
             if (m.includes('BANNED') || m.includes('MUTED') || m.includes('READONLY')) {
               window.dispatchEvent(new Event('restriction-updated'));
             }

--- a/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ChatService.java
@@ -66,14 +66,25 @@ public class ChatService {
           throw new ModerationException("BANNED");
         }
         case MUTE -> {
+          if (!moderation.hasWarning(userId)) {
+            moderation.markWarning(userId);
+            throw new ModerationException("TOXICITY_WARNING");
+          }
           saveMute(userId, Duration.ofHours(6), "moderation");
           throw new ModerationException("MUTED");
         }
         case READONLY -> {
+          if (!moderation.hasWarning(userId)) {
+            moderation.markWarning(userId);
+            throw new ModerationException("TOXICITY_WARNING");
+          }
           saveReadonly(userId, Duration.ofMinutes(10), "moderation");
           throw new ModerationException("READONLY");
         }
-        case WARNING -> throw new ModerationException("TOXICITY_WARNING");
+        case WARNING -> {
+          moderation.markWarning(userId);
+          throw new ModerationException("TOXICITY_WARNING");
+        }
         default -> {}
       }
       Instant ts = Instant.now();
@@ -112,14 +123,25 @@ public class ChatService {
           throw new ModerationException("BANNED");
         }
         case MUTE -> {
+          if (!moderation.hasWarning(userId)) {
+            moderation.markWarning(userId);
+            throw new ModerationException("TOXICITY_WARNING");
+          }
           saveMute(userId, Duration.ofHours(6), "moderation");
           throw new ModerationException("MUTED");
         }
         case READONLY -> {
+          if (!moderation.hasWarning(userId)) {
+            moderation.markWarning(userId);
+            throw new ModerationException("TOXICITY_WARNING");
+          }
           saveReadonly(userId, Duration.ofMinutes(10), "moderation");
           throw new ModerationException("READONLY");
         }
-        case WARNING -> throw new ModerationException("TOXICITY_WARNING");
+        case WARNING -> {
+          moderation.markWarning(userId);
+          throw new ModerationException("TOXICITY_WARNING");
+        }
         default -> {}
       }
       Instant ts = Instant.now();

--- a/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
@@ -36,6 +36,7 @@ public class ModerationService {
   private static final Pattern BAD_WORDS =
       Pattern.compile("(?i)(viagra|free money|http[s]?://[^ ]+|fuck|shit|spam)");
   private static final Logger log = LoggerFactory.getLogger(ModerationService.class);
+  private static final String WARN_PREFIX = "chat:warn:";
 
   public ModerationService(
       StringRedisTemplate redis,
@@ -241,5 +242,15 @@ public class ModerationService {
     } catch (NumberFormatException ex) {
       return 0;
     }
+  }
+
+  /** Return true when a recent warning exists for the user. */
+  public boolean hasWarning(String userId) {
+    return Boolean.TRUE.equals(redis.hasKey(WARN_PREFIX + userId));
+  }
+
+  /** Record a warning for the user with a one hour expiry. */
+  public void markWarning(String userId) {
+    redis.opsForValue().set(WARN_PREFIX + userId, "1", Duration.ofHours(1));
   }
 }


### PR DESCRIPTION
## Summary
- add warning cache to `ModerationService`
- delay muting and readonly in `ChatService` until a prior warning exists
- show toxicity warning toast when resending unsent messages
- update `ChatServiceTest` for new moderation flow

## Testing
- `./gradlew test`
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_688baf22bc48832c85169c066664c097