### PR TITLE
Stop resending moderated chat messages

### DIFF
--- a/front-end/app/src/components/ChatPanel.jsx
+++ b/front-end/app/src/components/ChatPanel.jsx
@@ -193,6 +193,7 @@ useEffect(() => {
       const msg = err.message || '';
       if (msg.includes('TOXICITY_WARNING')) {
         window.dispatchEvent(new CustomEvent('toast', { detail: 'Keep it civil' }));
+        updateMessage(localMsg.ts, { status: 'failed' });
       } else if (msg.includes('READONLY')) {
         window.dispatchEvent(
           new CustomEvent('toast', { detail: 'You are temporarily read-only' }),

--- a/front-end/app/src/hooks/useMultiChat.js
+++ b/front-end/app/src/hooks/useMultiChat.js
@@ -68,7 +68,26 @@ export default function useMultiChat(ids = []) {
           setMessages((m) => m.filter((x) => x.ts !== msg.ts));
         } catch (err) {
           console.error('Failed to resend message', err);
-          break;
+          const m = err.message || '';
+          if (
+            m.includes('BANNED') ||
+            m.includes('MUTED') ||
+            m.includes('READONLY') ||
+            m.includes('TOXICITY_WARNING')
+          ) {
+            if (m.includes('TOXICITY_WARNING')) {
+              window.dispatchEvent(
+                new CustomEvent('toast', { detail: 'Keep it civil' }),
+              );
+            }
+            if (m.includes('BANNED') || m.includes('MUTED') || m.includes('READONLY')) {
+              window.dispatchEvent(new Event('restriction-updated'));
+            }
+            await removeOutboxMessage(msg.id);
+            setMessages((msgs) => msgs.filter((x) => x.ts !== msg.ts));
+          } else {
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- mark toxicity warnings as failed so they aren't retried
- drop messages from `useMultiChat` outbox when moderation errors occur

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_688d0536dd38832c8aaa8a19147d6b02