### PR TITLE
Fix saving of perspective moderation results

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/model/ModerationRecord.java
+++ b/messages-java/src/main/java/com/clanboards/messages/model/ModerationRecord.java
@@ -19,7 +19,7 @@ public class ModerationRecord {
 
   @JdbcTypeCode(SqlTypes.JSON)
   @Column(columnDefinition = "jsonb")
-  private String categories;
+  private java.util.Map<String, Double> categories;
 
   private String ip;
 
@@ -51,11 +51,11 @@ public class ModerationRecord {
     this.content = content;
   }
 
-  public String getCategories() {
+  public java.util.Map<String, Double> getCategories() {
     return categories;
   }
 
-  public void setCategories(String categories) {
+  public void setCategories(java.util.Map<String, Double> categories) {
     this.categories = categories;
   }
 

--- a/messages-java/src/main/java/com/clanboards/messages/service/ModerationOutcome.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ModerationOutcome.java
@@ -1,4 +1,6 @@
 package com.clanboards.messages.service;
 
-/** Moderation result with category JSON. */
-public record ModerationOutcome(ModerationResult result, String categories) {}
+import java.util.Map;
+
+/** Moderation result with category scores. */
+public record ModerationOutcome(ModerationResult result, Map<String, Double> categories) {}

--- a/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
+++ b/messages-java/src/main/java/com/clanboards/messages/service/ModerationService.java
@@ -155,7 +155,7 @@ public class ModerationService {
     }
     String json;
     try {
-      json = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(categories);
+      json = mapper.writeValueAsString(categories);
     } catch (Exception ex) {
       json = "{}";
     }
@@ -182,7 +182,7 @@ public class ModerationService {
       result = ModerationResult.ALLOW;
     }
     log.info("Moderation outcome for {}: {} {}", userId, result, json);
-    return new ModerationOutcome(result, json);
+    return new ModerationOutcome(result, categories);
   }
 
   /**

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -22,7 +22,7 @@ class ChatServiceTest {
     com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
         Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hello"))
-        .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
+        .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, java.util.Map.of()));
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     ChatMessage msg = service.publish("1", "hello", "u", null, null);
@@ -58,7 +58,7 @@ class ChatServiceTest {
     com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
         Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("user1", "hi"))
-        .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
+        .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, java.util.Map.of()));
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     ChatMessage msg = service.publishGlobal("hi", "user1", null, null);
@@ -76,7 +76,7 @@ class ChatServiceTest {
     com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
         Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hi"))
-        .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, "{}"));
+        .thenReturn(new ModerationOutcome(ModerationResult.ALLOW, java.util.Map.of()));
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     service.publish("1", "hi", "u", null, null);
@@ -94,7 +94,7 @@ class ChatServiceTest {
     com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
         Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hi"))
-        .thenReturn(new ModerationOutcome(ModerationResult.BLOCK, "{}"));
+        .thenReturn(new ModerationOutcome(ModerationResult.BLOCK, java.util.Map.of()));
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u", null, null));
@@ -118,7 +118,7 @@ class ChatServiceTest {
     com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
         Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hi"))
-        .thenReturn(new ModerationOutcome(ModerationResult.MUTE, "{}"));
+        .thenReturn(new ModerationOutcome(ModerationResult.MUTE, java.util.Map.of()));
     Mockito.when(moderation.hasWarning("u")).thenReturn(true);
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
@@ -141,7 +141,7 @@ class ChatServiceTest {
     com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
         Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hi"))
-        .thenReturn(new ModerationOutcome(ModerationResult.MUTE, "{}"));
+        .thenReturn(new ModerationOutcome(ModerationResult.MUTE, java.util.Map.of()));
     Mockito.when(moderation.hasWarning("u")).thenReturn(false);
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
@@ -164,7 +164,7 @@ class ChatServiceTest {
     com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
         Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hi"))
-        .thenReturn(new ModerationOutcome(ModerationResult.READONLY, "{}"));
+        .thenReturn(new ModerationOutcome(ModerationResult.READONLY, java.util.Map.of()));
     Mockito.when(moderation.hasWarning("u")).thenReturn(true);
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
@@ -187,7 +187,7 @@ class ChatServiceTest {
     com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
         Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hi"))
-        .thenReturn(new ModerationOutcome(ModerationResult.READONLY, "{}"));
+        .thenReturn(new ModerationOutcome(ModerationResult.READONLY, java.util.Map.of()));
     Mockito.when(moderation.hasWarning("u")).thenReturn(false);
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 


### PR DESCRIPTION
## Summary
- store moderation categories as a map instead of JSON string
- include perspective scores when persisting ModerationRecord
- update tests for new moderation outcome type

## Testing
- `./gradlew test --no-daemon` in `messages-java`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_688d1f718dfc832cb4442ed8b5b7bc65