### PR TITLE
Fix resend of moderated messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ fabric.properties
 .idea
 /db/.env
 !front-end/src/lib/
+!front-end/app/src/lib/
 
 .DS_Store
 # Java build artifacts

--- a/front-end/app/src/hooks/useChat.js
+++ b/front-end/app/src/hooks/useChat.js
@@ -8,6 +8,7 @@ import {
   removeOutboxMessage,
   getMessageCache,
   putMessageCache,
+  removeMessageFromCache,
 } from '../lib/db.js';
 
 const PAGE_SIZE = 20;
@@ -62,6 +63,11 @@ export default function useChat(chatId) {
             }
             await removeOutboxMessage(msg.id);
             setMessages((msgs) => msgs.filter((x) => x.ts !== msg.ts));
+            try {
+              await removeMessageFromCache(msg.chatId, msg.ts);
+            } catch (err2) {
+              console.error('Failed to update message cache', err2);
+            }
           } else {
             break;
           }

--- a/front-end/app/src/hooks/useMultiChat.js
+++ b/front-end/app/src/hooks/useMultiChat.js
@@ -8,6 +8,7 @@ import {
   removeOutboxMessage,
   getMessageCache,
   putMessageCache,
+  removeMessageFromCache,
 } from '../lib/db.js';
 
 const PAGE_SIZE = 20;
@@ -85,6 +86,11 @@ export default function useMultiChat(ids = []) {
             }
             await removeOutboxMessage(msg.id);
             setMessages((msgs) => msgs.filter((x) => x.ts !== msg.ts));
+            try {
+              await removeMessageFromCache(msg.chatId, msg.ts);
+            } catch (err2) {
+              console.error('Failed to update message cache', err2);
+            }
           } else {
             break;
           }

--- a/front-end/app/src/lib/db.js
+++ b/front-end/app/src/lib/db.js
@@ -78,3 +78,11 @@ export async function getMessageCache(chatId) {
 export async function putMessageCache(record) {
   return (await dbPromise).put('messages', record);
 }
+
+export async function removeMessageFromCache(chatId, ts) {
+  const db = await dbPromise;
+  const record = await db.get('messages', chatId);
+  if (!record) return;
+  record.messages = (record.messages || []).filter((m) => m.ts !== ts);
+  return db.put('messages', record);
+}

--- a/front-end/app/src/lib/db.test.js
+++ b/front-end/app/src/lib/db.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getMessageCache, putMessageCache, removeMessageFromCache } from './db.js';
+
+describe('removeMessageFromCache', () => {
+  beforeEach(async () => {
+    const record = await getMessageCache('1');
+    if (record) {
+      await putMessageCache({ chatId: '1', messages: [] });
+    }
+  });
+
+  it('removes a message by ts', async () => {
+    await putMessageCache({ chatId: '1', messages: [{ ts: 'a' }, { ts: 'b' }] });
+    await removeMessageFromCache('1', 'a');
+    const rec = await getMessageCache('1');
+    expect(rec.messages).toEqual([{ ts: 'b' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent moderated messages from being cached and re-sent
- update `.gitignore` so lib tests aren't excluded
- test cache removal logic

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_688d4e61d708832c9a5afe9acbfa7b4c