### PR TITLE
feat: enhance chat moderation and spam controls

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/repository/ModerationRepository.java
+++ b/messages-java/src/main/java/com/clanboards/messages/repository/ModerationRepository.java
@@ -3,4 +3,7 @@ package com.clanboards.messages.repository;
 import com.clanboards.messages.model.ModerationRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ModerationRepository extends JpaRepository<ModerationRecord, Long> {}
+public interface ModerationRepository extends JpaRepository<ModerationRecord, Long> {
+
+  long countByUserId(String userId);
+}

--- a/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
+++ b/messages-java/src/test/java/com/clanboards/messages/service/ChatServiceTest.java
@@ -119,39 +119,21 @@ class ChatServiceTest {
         Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hi"))
         .thenReturn(new ModerationOutcome(ModerationResult.MUTE, java.util.Map.of()));
-    Mockito.when(moderation.hasWarning("u")).thenReturn(true);
+    Mockito.when(modRepo.countByUserId("u")).thenReturn(0L);
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     ModerationException ex =
         assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u", null, null));
     assertEquals("MUTED", ex.getMessage());
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
+    org.mockito.ArgumentCaptor<java.time.Instant> until =
+        org.mockito.ArgumentCaptor.forClass(java.time.Instant.class);
     Mockito.verify(blockedRepo)
         .upsert(
-            Mockito.eq("u"), Mockito.any(), Mockito.eq(false), Mockito.anyString(), Mockito.any());
-  }
-
-  @Test
-  void publishWarnsBeforeMute() {
-    ChatRepository repo = Mockito.mock(ChatRepository.class);
-    ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
-    ModerationService moderation = Mockito.mock(ModerationService.class);
-    com.clanboards.messages.repository.ModerationRepository modRepo =
-        Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
-    com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
-        Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
-    Mockito.when(moderation.verify("u", "hi"))
-        .thenReturn(new ModerationOutcome(ModerationResult.MUTE, java.util.Map.of()));
-    Mockito.when(moderation.hasWarning("u")).thenReturn(false);
-    ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
-
-    ModerationException ex =
-        assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u", null, null));
-    assertEquals("TOXICITY_WARNING", ex.getMessage());
-    Mockito.verify(blockedRepo, Mockito.never())
-        .upsert(
-            Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.anyString(), Mockito.any());
-    Mockito.verify(moderation).markWarning("u");
+            Mockito.eq("u"), until.capture(), Mockito.eq(false), Mockito.anyString(), Mockito.any());
+    long mins =
+        java.time.Duration.between(java.time.Instant.now(), until.getValue()).toMinutes();
+    assertTrue(mins >= 29 && mins <= 31);
   }
 
   @Test
@@ -165,20 +147,20 @@ class ChatServiceTest {
         Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hi"))
         .thenReturn(new ModerationOutcome(ModerationResult.READONLY, java.util.Map.of()));
-    Mockito.when(moderation.hasWarning("u")).thenReturn(true);
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     ModerationException ex =
         assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u", null, null));
     assertEquals("READONLY", ex.getMessage());
     Mockito.verify(repo, Mockito.never()).saveMessage(Mockito.any());
-    Mockito.verify(blockedRepo)
+    Mockito.verify(modRepo, Mockito.never()).save(Mockito.any());
+    Mockito.verify(blockedRepo, Mockito.never())
         .upsert(
-            Mockito.eq("u"), Mockito.any(), Mockito.eq(false), Mockito.anyString(), Mockito.any());
+            Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.anyString(), Mockito.any());
   }
 
   @Test
-  void publishWarnsBeforeReadonly() {
+  void publishMuteEscalatesTo24Hours() {
     ChatRepository repo = Mockito.mock(ChatRepository.class);
     ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
     ModerationService moderation = Mockito.mock(ModerationService.class);
@@ -187,17 +169,48 @@ class ChatServiceTest {
     com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
         Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
     Mockito.when(moderation.verify("u", "hi"))
-        .thenReturn(new ModerationOutcome(ModerationResult.READONLY, java.util.Map.of()));
-    Mockito.when(moderation.hasWarning("u")).thenReturn(false);
+        .thenReturn(new ModerationOutcome(ModerationResult.MUTE, java.util.Map.of()));
+    Mockito.when(modRepo.countByUserId("u")).thenReturn(2L);
     ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
 
     ModerationException ex =
         assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u", null, null));
-    assertEquals("TOXICITY_WARNING", ex.getMessage());
-    Mockito.verify(blockedRepo, Mockito.never())
+    assertEquals("MUTED", ex.getMessage());
+    org.mockito.ArgumentCaptor<java.time.Instant> until =
+        org.mockito.ArgumentCaptor.forClass(java.time.Instant.class);
+    Mockito.verify(blockedRepo)
         .upsert(
-            Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.anyString(), Mockito.any());
-    Mockito.verify(moderation).markWarning("u");
+            Mockito.eq("u"), until.capture(), Mockito.eq(false), Mockito.anyString(), Mockito.any());
+    long hrs =
+        java.time.Duration.between(java.time.Instant.now(), until.getValue()).toHours();
+    assertTrue(hrs >= 23 && hrs <= 25);
+  }
+
+  @Test
+  void publishSpamMuteIsTwoHours() {
+    ChatRepository repo = Mockito.mock(ChatRepository.class);
+    ApplicationEventPublisher events = Mockito.mock(ApplicationEventPublisher.class);
+    ModerationService moderation = Mockito.mock(ModerationService.class);
+    com.clanboards.messages.repository.ModerationRepository modRepo =
+        Mockito.mock(com.clanboards.messages.repository.ModerationRepository.class);
+    com.clanboards.messages.repository.BlockedUserRepository blockedRepo =
+        Mockito.mock(com.clanboards.messages.repository.BlockedUserRepository.class);
+    Mockito.when(moderation.verify("u", "hi"))
+        .thenReturn(new ModerationOutcome(ModerationResult.MUTE, java.util.Map.of("spam", 1.0)));
+    Mockito.when(modRepo.countByUserId("u")).thenReturn(0L);
+    ChatService service = new ChatService(repo, events, moderation, modRepo, blockedRepo);
+
+    ModerationException ex =
+        assertThrows(ModerationException.class, () -> service.publish("1", "hi", "u", null, null));
+    assertEquals("MUTED", ex.getMessage());
+    org.mockito.ArgumentCaptor<java.time.Instant> until =
+        org.mockito.ArgumentCaptor.forClass(java.time.Instant.class);
+    Mockito.verify(blockedRepo)
+        .upsert(
+            Mockito.eq("u"), until.capture(), Mockito.eq(false), Mockito.anyString(), Mockito.any());
+    long hrs =
+        java.time.Duration.between(java.time.Instant.now(), until.getValue()).toHours();
+    assertTrue(hrs >= 1 && hrs <= 3);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- escalate moderation mutes to 30m/2h/24h with counts stored in DB
- tighten spam filter to slow repeated or rapid messages and mute for 2h on third strike
- add Redis-based rate limiting for >20 messages per minute and broaden tests

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_688e8e3518f8832c8b3ab3498026d980