### PR TITLE
Implement virtualized clan recruitment feed

### DIFF
--- a/front-end/app/package-lock.json
+++ b/front-end/app/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@stomp/stompjs": "^7.1.1",
+        "@tanstack/react-virtual": "^3.1.0",
+        "fuse.js": "^7.0.0",
         "idb": "^7.1.1",
         "lucide-react": "^0.367.0",
         "react": "^18.2.0",
@@ -1258,6 +1260,33 @@
       "integrity": "sha512-chcDs6YkAnKp1FqzwhGvh3i7v0+/ytzqWdKYw6XzINEKAzke/iD00dNgFPWSZEqktHOK+C1gSzXhLkLbARIaZw==",
       "license": "Apache-2.0"
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -2029,6 +2058,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {

--- a/front-end/app/package.json
+++ b/front-end/app/package.json
@@ -18,7 +18,9 @@
     "react-router-dom": "^6.23.0",
     "react-window": "^1.8.8",
     "sockjs-client": "^1.6.1",
-    "idb": "^7.1.1"
+    "idb": "^7.1.1",
+    "@tanstack/react-virtual": "^3.1.0",
+    "fuse.js": "^7.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/front-end/app/src/components/DiscoveryBar.jsx
+++ b/front-end/app/src/components/DiscoveryBar.jsx
@@ -1,0 +1,83 @@
+import React, { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const leagues = ['None', 'Bronze', 'Silver', 'Gold', 'Crystal', 'Master', 'Champion'];
+const languages = ['Any', 'English', 'Spanish', 'French'];
+const warTypes = ['Any', 'Casual', 'Competitive'];
+
+export default function DiscoveryBar({ onChange }) {
+  const [params, setParams] = useSearchParams();
+  const filters = {
+    league: params.get('league') || 'None',
+    language: params.get('lang') || 'Any',
+    war: params.get('war') || 'Any',
+    q: params.get('q') || '',
+    sort: params.get('sort') || 'open',
+  };
+
+  useEffect(() => {
+    onChange?.(filters);
+  }, [params]);
+
+  function update(key, value) {
+    const next = new URLSearchParams(params);
+    next.set(key, value);
+    setParams(next);
+    if (Notification && Notification.permission === 'default') {
+      Notification.requestPermission();
+    }
+  }
+
+  return (
+    <div className="sticky top-0 z-10 bg-white p-2 shadow flex gap-2 overflow-x-auto">
+      <select
+        value={filters.league}
+        onChange={(e) => update('league', e.target.value)}
+        className="border rounded p-1 text-sm"
+      >
+        {leagues.map((l) => (
+          <option key={l} value={l}>
+            {l}
+          </option>
+        ))}
+      </select>
+      <select
+        value={filters.language}
+        onChange={(e) => update('lang', e.target.value)}
+        className="border rounded p-1 text-sm"
+      >
+        {languages.map((l) => (
+          <option key={l} value={l}>
+            {l}
+          </option>
+        ))}
+      </select>
+      <select
+        value={filters.war}
+        onChange={(e) => update('war', e.target.value)}
+        className="border rounded p-1 text-sm"
+      >
+        {warTypes.map((l) => (
+          <option key={l} value={l}>
+            {l}
+          </option>
+        ))}
+      </select>
+      <input
+        value={filters.q}
+        onChange={(e) => update('q', e.target.value)}
+        placeholder="Search"
+        className="flex-1 border rounded p-1 text-sm"
+      />
+      <button
+        type="button"
+        onClick={() =>
+          update('sort', filters.sort === 'open' ? 'new' : 'open')
+        }
+        className="border rounded px-2 text-sm"
+      >
+        Sort: {filters.sort}
+      </button>
+    </div>
+  );
+}

--- a/front-end/app/src/components/PageChip.jsx
+++ b/front-end/app/src/components/PageChip.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function PageChip({ page }) {
+  return (
+    <div className="flex justify-center my-2">
+      <Link
+        to={`?page=${page}`}
+        className="px-3 py-1 text-sm bg-slate-200 rounded-full"
+      >
+        Page {page}
+      </Link>
+    </div>
+  );
+}

--- a/front-end/app/src/components/RecruitCard.jsx
+++ b/front-end/app/src/components/RecruitCard.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+export default function RecruitCard({
+  id,
+  badge,
+  name,
+  tags = [],
+  openSlots,
+  totalSlots,
+  age,
+  description,
+  onJoin,
+}) {
+  const pct = totalSlots ? (openSlots / totalSlots) * 100 : 0;
+  return (
+    <button
+      type="button"
+      aria-label={`Join ${name}`}
+      onClick={onJoin}
+      className="w-full text-left p-3 border-b flex gap-3 bg-white"
+    >
+      <img src={badge} alt="badge" className="w-12 h-12" />
+      <div className="flex-1">
+        <div className="flex items-center justify-between">
+          <h3 className="font-semibold">{name}</h3>
+          <span className="text-xs text-slate-500">{age}</span>
+        </div>
+        <div className="flex flex-wrap gap-1 my-1">
+          {tags.map((t) => (
+            <span
+              key={t}
+              className="text-xs bg-slate-200 rounded px-1 py-0.5"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+        <div className="h-2 bg-slate-200 rounded">
+          <div
+            className="h-full bg-green-500 rounded"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <p className="text-sm line-clamp-2 mt-1 text-slate-700">{description}</p>
+      </div>
+    </button>
+  );
+}

--- a/front-end/app/src/components/RecruitCard.test.jsx
+++ b/front-end/app/src/components/RecruitCard.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import RecruitCard from './RecruitCard.jsx';
+
+test('renders recruit card with aria label', () => {
+  render(
+    <RecruitCard
+      id="1"
+      badge="/badge.png"
+      name="Example Clan"
+      tags={['war', 'chill']}
+      openSlots={10}
+      totalSlots={50}
+      age="1d"
+      description="Join us"
+    />
+  );
+  expect(screen.getByRole('button', { name: /Join Example Clan/ })).toBeInTheDocument();
+});

--- a/front-end/app/src/components/RecruitFeed.jsx
+++ b/front-end/app/src/components/RecruitFeed.jsx
@@ -1,0 +1,67 @@
+import React, { useRef, useEffect } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import RecruitCard from './RecruitCard.jsx';
+import PageChip from './PageChip.jsx';
+import RecruitSkeleton from './RecruitSkeleton.jsx';
+
+const ROW_HEIGHT = 112;
+
+export default function RecruitFeed({ items, loadMore, hasMore, onJoin, initialPage = 1 }) {
+  const parentRef = useRef(null);
+  const withChips = [];
+  items.forEach((item, i) => {
+    if (i > 0 && i % 100 === 0) {
+      withChips.push({ type: 'chip', page: i / 100 + 1 });
+    }
+    withChips.push({ type: 'card', data: item });
+  });
+
+  const count = hasMore ? withChips.length + 1 : withChips.length;
+
+  const virtualizer = useVirtualizer({
+    count,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 8,
+    initialOffset: (initialPage - 1) * ROW_HEIGHT * 100,
+  });
+
+  const itemsVirtual = virtualizer.getVirtualItems();
+
+  useEffect(() => {
+    const last = itemsVirtual[itemsVirtual.length - 1];
+    if (last && last.index >= withChips.length - 1 && hasMore) {
+      loadMore();
+    }
+  }, [itemsVirtual, hasMore]);
+
+  return (
+    <div ref={parentRef} className="h-full overflow-auto">
+      <div tabIndex="0" className="sr-only" aria-hidden="true" />
+      <a href="#" className="block p-2 text-center text-sm">
+        Load previous
+      </a>
+      <div
+        style={{ height: virtualizer.getTotalSize(), width: '100%', position: 'relative' }}
+      >
+        {itemsVirtual.map((virtual) => {
+          const item = withChips[virtual.index];
+          return (
+            <div
+              key={virtual.index}
+              className="absolute top-0 left-0 w-full"
+              style={{ transform: `translateY(${virtual.start}px)` }}
+            >
+              {!item && <RecruitSkeleton />}
+              {item &&
+                item.type === 'card' && (
+                  <RecruitCard {...item.data} onJoin={() => onJoin?.(item.data)} />
+                )}
+              {item && item.type === 'chip' && <PageChip page={item.page} />}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/front-end/app/src/components/RecruitSkeleton.jsx
+++ b/front-end/app/src/components/RecruitSkeleton.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function RecruitSkeleton() {
+  return (
+    <div className="animate-pulse h-[112px] flex items-center gap-3 p-3">
+      <div className="w-12 h-12 bg-slate-300 rounded" />
+      <div className="flex-1 space-y-2">
+        <div className="h-4 bg-slate-300 rounded w-1/2" />
+        <div className="h-3 bg-slate-200 rounded w-3/4" />
+        <div className="h-2 bg-slate-200 rounded" />
+        <div className="h-3 bg-slate-200 rounded w-5/6" />
+      </div>
+    </div>
+  );
+}

--- a/front-end/app/src/hooks/useRecruitFeed.js
+++ b/front-end/app/src/hooks/useRecruitFeed.js
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+export default function useRecruitFeed(filters) {
+  const [items, setItems] = useState([]);
+  const [cursor, setCursor] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  async function fetchPage(c) {
+    setLoading(true);
+    const url = `/recruit?pageCursor=${c || ''}`;
+    let data;
+    if (typeof window !== 'undefined' && 'caches' in window && (!c || c === '')) {
+      const cache = await caches.open('recruit');
+      const cached = await cache.match(url);
+      if (cached) {
+        data = await cached.json();
+        fetch(url)
+          .then((r) => cache.put(url, r.clone()))
+          .catch(() => {});
+      } else {
+        const res = await fetch(url).catch(() => null);
+        if (res) {
+          cache.put(url, res.clone());
+          data = await res.json();
+        } else {
+          data = { items: [], nextCursor: null };
+        }
+      }
+    } else {
+      const res = await fetch(url).catch(() => null);
+      data = res ? await res.json() : { items: [], nextCursor: null };
+    }
+    setItems((prev) => [...prev, ...data.items]);
+    setCursor(data.nextCursor || '');
+    setHasMore(Boolean(data.nextCursor));
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    setItems([]);
+    setCursor('');
+    setHasMore(true);
+    fetchPage('');
+  }, [filters.league, filters.language, filters.war, filters.q, filters.sort]);
+
+  return { items, loadMore: () => fetchPage(cursor), hasMore, loading };
+}

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -1,10 +1,51 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import Tabs from '../components/Tabs.jsx';
+import DiscoveryBar from '../components/DiscoveryBar.jsx';
+import RecruitFeed from '../components/RecruitFeed.jsx';
+import useRecruitFeed from '../hooks/useRecruitFeed.js';
+import Fuse from 'fuse.js';
 
 export default function Scout() {
   const [active, setActive] = useState('find');
+  const [filters, setFilters] = useState({});
+  const feed = useRecruitFeed(filters);
+  const [params] = useSearchParams();
+  const page = parseInt(params.get('page') || '1', 10);
+
+  function joinClan(clan) {
+    if (!navigator.onLine && 'serviceWorker' in navigator && 'SyncManager' in window) {
+      navigator.serviceWorker.ready.then((sw) => sw.sync.register(`join-${clan.id}`));
+    } else {
+      fetch(`/join/${clan.id}`, { method: 'POST' });
+    }
+  }
+
+  const items = useMemo(() => {
+    let data = feed.items;
+    if (filters.q) {
+      const fuse = new Fuse(data, { keys: ['name', 'description', 'tags'] });
+      data = fuse.search(filters.q).map((r) => r.item);
+    }
+    if (filters.league && filters.league !== 'None') {
+      data = data.filter((d) => d.league === filters.league);
+    }
+    if (filters.language && filters.language !== 'Any') {
+      data = data.filter((d) => d.language === filters.language);
+    }
+    if (filters.war && filters.war !== 'Any') {
+      data = data.filter((d) => d.war === filters.war);
+    }
+    if (filters.sort === 'new') {
+      data = [...data].sort((a, b) => b.ageValue - a.ageValue);
+    } else {
+      data = [...data].sort((a, b) => b.openSlots - a.openSlots);
+    }
+    return data;
+  }, [feed.items, filters]);
+
   return (
-    <div className="p-4">
+    <div className="h-full flex flex-col">
       <Tabs
         tabs={[
           { value: 'find', label: 'Find a Clan' },
@@ -13,7 +54,20 @@ export default function Scout() {
         active={active}
         onChange={setActive}
       />
-      {active === 'find' && <p>Coming soon...</p>}
+      {active === 'find' && (
+        <>
+          <DiscoveryBar onChange={setFilters} />
+          <div className="flex-1">
+            <RecruitFeed
+              items={items}
+              loadMore={feed.loadMore}
+              hasMore={feed.hasMore}
+              onJoin={joinClan}
+              initialPage={page}
+            />
+          </div>
+        </>
+      )}
       {active === 'need' && <p>Coming soon...</p>}
     </div>
   );

--- a/front-end/app/src/pages/Scout.test.jsx
+++ b/front-end/app/src/pages/Scout.test.jsx
@@ -1,10 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
 import Scout from './Scout.jsx';
 
 describe('Scout page', () => {
   it('renders tabs', () => {
-    render(<Scout />);
+    render(
+      <MemoryRouter>
+        <Scout />
+      </MemoryRouter>
+    );
     expect(screen.getByText('Find a Clan')).toBeInTheDocument();
     expect(screen.getByText('Need a Clan')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- add recruit card and discovery bar components
- virtualized recruit feed with page chips and skeleton loader
- integrate filter/search/sort and offline handling on Scout page

## Testing
- `nox -s lint tests`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688eb76b6bb8832c8fe9ea757711b686