### PR TITLE
feat: improve recruit feed caching

### DIFF
--- a/front-end/app/src/components/RecruitFeed.jsx
+++ b/front-end/app/src/components/RecruitFeed.jsx
@@ -30,7 +30,7 @@ export default function RecruitFeed({ items, loadMore, hasMore, onJoin, initialP
 
   useEffect(() => {
     const last = itemsVirtual[itemsVirtual.length - 1];
-    if (last && last.index >= withChips.length - 1 && hasMore) {
+    if (last && last.index >= withChips.length - 5 && hasMore) {
       loadMore();
     }
   }, [itemsVirtual, hasMore]);

--- a/front-end/app/src/hooks/useRecruitFeed.js
+++ b/front-end/app/src/hooks/useRecruitFeed.js
@@ -8,7 +8,14 @@ export default function useRecruitFeed(filters) {
 
   async function fetchPage(c) {
     setLoading(true);
-    const url = `/recruit?pageCursor=${c || ''}`;
+    const params = new URLSearchParams();
+    params.set('pageCursor', c || '');
+    if (filters.league) params.set('league', filters.league);
+    if (filters.language) params.set('language', filters.language);
+    if (filters.war) params.set('war', filters.war);
+    if (filters.q) params.set('q', filters.q);
+    if (filters.sort) params.set('sort', filters.sort);
+    const url = `/recruit?${params.toString()}`;
     let data;
     if (typeof window !== 'undefined' && 'caches' in window && (!c || c === '')) {
       const cache = await caches.open('recruit');

--- a/front-end/app/src/hooks/useRecruitFeed.test.jsx
+++ b/front-end/app/src/hooks/useRecruitFeed.test.jsx
@@ -1,0 +1,48 @@
+import { render, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import React from 'react';
+import useRecruitFeed from './useRecruitFeed.js';
+
+function Wrapper({ filters }) {
+  useRecruitFeed(filters);
+  return null;
+}
+
+describe('useRecruitFeed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ items: [], nextCursor: null }), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    global.caches = {
+      open: vi.fn(() =>
+        Promise.resolve({
+          match: vi.fn(() => Promise.resolve(undefined)),
+          put: vi.fn(() => Promise.resolve()),
+        })
+      ),
+    };
+  });
+
+  it('sends filters as query params', async () => {
+    const filters = {
+      league: 'Gold',
+      language: 'EN',
+      war: 'always',
+      q: 'abc',
+      sort: 'new',
+    };
+    render(<Wrapper filters={filters} />);
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    const url = fetch.mock.calls[0][0];
+    expect(url).toContain('league=Gold');
+    expect(url).toContain('language=EN');
+    expect(url).toContain('war=always');
+    expect(url).toContain('q=abc');
+    expect(url).toContain('sort=new');
+  });
+});

--- a/front-end/app/src/sw.test.js
+++ b/front-end/app/src/sw.test.js
@@ -1,0 +1,77 @@
+import { vi } from 'vitest';
+
+function setup() {
+  vi.resetModules();
+  const listeners = {};
+  let recruitCache;
+  global.fetch = vi.fn(() => Promise.resolve(new Response('ok')));
+  global.caches = {
+    open: vi.fn(() => {
+      if (!recruitCache) {
+        recruitCache = {
+          store: new Map(),
+          match(req) {
+            return Promise.resolve(this.store.get(req.url));
+          },
+          put(req, resp) {
+            this.store.set(req.url, resp);
+            return Promise.resolve();
+          },
+          keys() {
+            return Promise.resolve(
+              Array.from(this.store.keys()).map((url) => new Request(url))
+            );
+          },
+        };
+      }
+      return Promise.resolve(recruitCache);
+    }),
+  };
+  global.self = {
+    addEventListener: (type, handler) => {
+      listeners[type] = handler;
+    },
+    registration: { sync: { register: vi.fn(() => Promise.resolve()) } },
+    clients: { matchAll: vi.fn(() => Promise.resolve([])) },
+    location: { origin: 'https://example.com' },
+  };
+  return listeners;
+}
+
+describe('service worker', () => {
+  it('replays join requests on sync', async () => {
+    const listeners = setup();
+    await import('../public/sw.js');
+    await listeners.sync({ tag: 'join-1', waitUntil: (p) => p });
+    expect(fetch).toHaveBeenCalledWith('/join/1', { method: 'POST' });
+  });
+
+  it('caches only first two recruit pages', async () => {
+    const listeners = setup();
+    await import('../public/sw.js');
+    const handler = listeners.fetch;
+    const cache = await caches.open('recruit');
+    let responsePromise;
+    await handler({
+      request: new Request('https://example.com/recruit'),
+      respondWith: (p) => (responsePromise = p),
+      waitUntil: (p) => p,
+    });
+    await responsePromise;
+    expect((await cache.keys()).length).toBe(1);
+    await handler({
+      request: new Request('https://example.com/recruit?pageCursor=abc'),
+      respondWith: (p) => (responsePromise = p),
+      waitUntil: (p) => p,
+    });
+    await responsePromise;
+    expect((await cache.keys()).length).toBe(2);
+    await handler({
+      request: new Request('https://example.com/recruit?pageCursor=def'),
+      respondWith: (p) => (responsePromise = p),
+      waitUntil: (p) => p,
+    });
+    await responsePromise;
+    expect((await cache.keys()).length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- send all filter options to recruit API and prefetch pages sooner
- cache first two recruit pages and replay offline join requests via service worker
- add tests for recruit feed hook and service worker sync/caching

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ec2dd9dd8832c89d76c4d3e082d6d