### PR TITLE
feat: add player recruit feed

### DIFF
--- a/front-end/app/src/components/PlayerRecruitCard.jsx
+++ b/front-end/app/src/components/PlayerRecruitCard.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default function PlayerRecruitCard({
+  id,
+  avatar,
+  name,
+  tag,
+  age,
+  description,
+  onInvite,
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={`Invite ${name}`}
+      onClick={onInvite}
+      className="w-full text-left p-3 border-b flex gap-3 bg-white"
+    >
+      {avatar && <img src={avatar} alt="avatar" className="w-12 h-12 rounded" />}
+      <div className="flex-1">
+        <div className="flex items-center justify-between">
+          <h3 className="font-semibold">{name}</h3>
+          <span className="text-xs text-slate-500">{age}</span>
+        </div>
+        {tag && <p className="text-xs text-slate-500">{tag}</p>}
+        <p className="text-sm line-clamp-2 mt-1 text-slate-700">{description}</p>
+      </div>
+    </button>
+  );
+}

--- a/front-end/app/src/components/PlayerRecruitCard.test.jsx
+++ b/front-end/app/src/components/PlayerRecruitCard.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import PlayerRecruitCard from './PlayerRecruitCard.jsx';
+
+test('renders player recruit card with aria label', () => {
+  render(
+    <PlayerRecruitCard
+      id="1"
+      avatar="/avatar.png"
+      name="Example Player"
+      tag="#ABC"
+      age="1d"
+      description="Looking for clan"
+    />
+  );
+  expect(screen.getByRole('button', { name: /Invite Example Player/ })).toBeInTheDocument();
+});

--- a/front-end/app/src/components/PlayerRecruitFeed.jsx
+++ b/front-end/app/src/components/PlayerRecruitFeed.jsx
@@ -1,0 +1,67 @@
+import React, { useRef, useEffect } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import PlayerRecruitCard from './PlayerRecruitCard.jsx';
+import PageChip from './PageChip.jsx';
+import RecruitSkeleton from './RecruitSkeleton.jsx';
+
+const ROW_HEIGHT = 112;
+
+export default function PlayerRecruitFeed({ items, loadMore, hasMore, onInvite, initialPage = 1 }) {
+  const parentRef = useRef(null);
+  const withChips = [];
+  items.forEach((item, i) => {
+    if (i > 0 && i % 100 === 0) {
+      withChips.push({ type: 'chip', page: i / 100 + 1 });
+    }
+    withChips.push({ type: 'card', data: item });
+  });
+
+  const count = hasMore ? withChips.length + 1 : withChips.length;
+
+  const virtualizer = useVirtualizer({
+    count,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 8,
+    initialOffset: (initialPage - 1) * ROW_HEIGHT * 100,
+  });
+
+  const itemsVirtual = virtualizer.getVirtualItems();
+
+  useEffect(() => {
+    const last = itemsVirtual[itemsVirtual.length - 1];
+    if (last && last.index >= withChips.length - 5 && hasMore) {
+      loadMore();
+    }
+  }, [itemsVirtual, hasMore]);
+
+  return (
+    <div ref={parentRef} className="h-full overflow-auto">
+      <div tabIndex="0" className="sr-only" aria-hidden="true" />
+      <a href="#" className="block p-2 text-center text-sm">
+        Load previous
+      </a>
+      <div
+        style={{ height: virtualizer.getTotalSize(), width: '100%', position: 'relative' }}
+      >
+        {itemsVirtual.map((virtual) => {
+          const item = withChips[virtual.index];
+          return (
+            <div
+              key={virtual.index}
+              className="absolute top-0 left-0 w-full"
+              style={{ transform: `translateY(${virtual.start}px)` }}
+            >
+              {!item && <RecruitSkeleton />}
+              {item &&
+                item.type === 'card' && (
+                  <PlayerRecruitCard {...item.data} onInvite={() => onInvite?.(item.data)} />
+                )}
+              {item && item.type === 'chip' && <PageChip page={item.page} />}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/front-end/app/src/hooks/usePlayerRecruitFeed.js
+++ b/front-end/app/src/hooks/usePlayerRecruitFeed.js
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+
+export default function usePlayerRecruitFeed(filters) {
+  const [items, setItems] = useState([]);
+  const [cursor, setCursor] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  async function fetchPage(c) {
+    setLoading(true);
+    const params = new URLSearchParams();
+    params.set('pageCursor', c || '');
+    if (filters.league) params.set('league', filters.league);
+    if (filters.language) params.set('language', filters.language);
+    if (filters.war) params.set('war', filters.war);
+    if (filters.q) params.set('q', filters.q);
+    if (filters.sort) params.set('sort', filters.sort);
+    const url = `/player-recruit?${params.toString()}`;
+    let data;
+    if (typeof window !== 'undefined' && 'caches' in window && (!c || c === '')) {
+      const cache = await caches.open('player-recruit');
+      const cached = await cache.match(url);
+      if (cached) {
+        data = await cached.json();
+        fetch(url)
+          .then((r) => cache.put(url, r.clone()))
+          .catch(() => {});
+      } else {
+        const res = await fetch(url).catch(() => null);
+        if (res) {
+          cache.put(url, res.clone());
+          data = await res.json();
+        } else {
+          data = { items: [], nextCursor: null };
+        }
+      }
+    } else {
+      const res = await fetch(url).catch(() => null);
+      data = res ? await res.json() : { items: [], nextCursor: null };
+    }
+    setItems((prev) => [...prev, ...data.items]);
+    setCursor(data.nextCursor || '');
+    setHasMore(Boolean(data.nextCursor));
+    setLoading(false);
+  }
+
+  function reload() {
+    setItems([]);
+    setCursor('');
+    setHasMore(true);
+    fetchPage('');
+  }
+
+  useEffect(() => {
+    reload();
+  }, [filters.league, filters.language, filters.war, filters.q, filters.sort]);
+
+  return { items, loadMore: () => fetchPage(cursor), hasMore, loading, reload };
+}

--- a/front-end/app/src/pages/Scout.test.jsx
+++ b/front-end/app/src/pages/Scout.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import Scout from './Scout.jsx';
@@ -12,5 +12,15 @@ describe('Scout page', () => {
     );
     expect(screen.getByText('Find a Clan')).toBeInTheDocument();
     expect(screen.getByText('Need a Clan')).toBeInTheDocument();
+  });
+
+  it('shows need a clan form when tab selected', () => {
+    render(
+      <MemoryRouter>
+        <Scout />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByText('Need a Clan'));
+    expect(screen.getByPlaceholderText('Describe yourself')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add PlayerRecruitCard and feed for players seeking clans
- extend Scout page with Need a Clan tab and posting form
- cover new player feed with component tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ec6b6e3f0832cafb165aec3c7315f