### PR TITLE
Add recruitment and join APIs

### DIFF
--- a/back-end/app/api/__init__.py
+++ b/back-end/app/api/__init__.py
@@ -10,6 +10,7 @@ from .health_routes import bp as health_bp
 from .user_routes import bp as user_bp
 from .asset_routes import bp as asset_bp
 from .log_routes import bp as log_bp
+from .recruit_routes import bp as recruit_bp
 
 
 def register_blueprints(app: Flask):
@@ -20,3 +21,4 @@ def register_blueprints(app: Flask):
     app.register_blueprint(user_bp)
     app.register_blueprint(asset_bp)
     app.register_blueprint(log_bp)
+    app.register_blueprint(recruit_bp)

--- a/back-end/app/api/recruit_routes.py
+++ b/back-end/app/api/recruit_routes.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from flask import Blueprint, jsonify, request, g, abort
+
+from ..services import recruit_service
+
+bp = Blueprint("recruit", __name__)
+
+
+@bp.get("/recruit")
+def list_recruit():
+    cursor = request.args.get("pageCursor", type=int)
+    filters = {
+        "league": request.args.get("league"),
+        "language": request.args.get("language"),
+        "war": request.args.get("war"),
+        "q": request.args.get("q"),
+    }
+    sort = request.args.get("sort", "slots")
+    posts, next_cursor = recruit_service.list_posts(cursor, filters, sort)
+    now = datetime.utcnow()
+    items: list[dict] = []
+    for p in posts:
+        delta = now - p.created_at
+        age_value = int(delta.total_seconds())
+        if age_value < 3600:
+            age = f"{age_value // 60}m"
+        else:
+            age = f"{age_value // 3600}h"
+        items.append(
+            {
+                "id": p.id,
+                "badge": p.badge,
+                "name": p.name,
+                "tags": p.tags or [],
+                "openSlots": p.open_slots,
+                "totalSlots": p.total_slots,
+                "age": age,
+                "ageValue": age_value,
+                "league": p.league,
+                "language": p.language,
+                "war": p.war,
+                "description": p.description,
+            }
+        )
+    return jsonify({
+        "items": items,
+        "nextCursor": str(next_cursor) if next_cursor is not None else None,
+    })
+
+
+@bp.post("/join/<int:post_id>")
+def join(post_id: int):
+    try:
+        recruit_service.record_join(g.user.id, post_id)
+    except ValueError:
+        abort(404)
+    return ("", 204)

--- a/back-end/app/services/recruit_service.py
+++ b/back-end/app/services/recruit_service.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Tuple, Optional
+
+from sqlalchemy import or_, cast, String
+
+from coclib.extensions import db
+from coclib.models import RecruitPost, RecruitJoin
+
+PAGE_SIZE = 100
+
+
+def list_posts(
+    cursor: Optional[int],
+    filters: dict,
+    sort: str,
+) -> Tuple[List[RecruitPost], Optional[int]]:
+    query = RecruitPost.query
+    if league := filters.get("league"):
+        query = query.filter_by(league=league)
+    if language := filters.get("language"):
+        query = query.filter_by(language=language)
+    if war := filters.get("war"):
+        query = query.filter_by(war=war)
+    if q := filters.get("q"):
+        pattern = f"%{q}%"
+        query = query.filter(
+            or_(
+                RecruitPost.name.ilike(pattern),
+                RecruitPost.description.ilike(pattern),
+                cast(RecruitPost.tags, String).ilike(pattern),
+            )
+        )
+    if sort == "new":
+        query = query.order_by(RecruitPost.created_at.desc())
+    else:
+        query = query.order_by(RecruitPost.open_slots.desc())
+    offset = int(cursor or 0)
+    rows = query.offset(offset).limit(PAGE_SIZE + 1).all()
+    next_cursor = offset + PAGE_SIZE if len(rows) > PAGE_SIZE else None
+    return rows[:PAGE_SIZE], next_cursor
+
+
+def record_join(user_id: int, post_id: int) -> None:
+    post = RecruitPost.query.get(post_id)
+    if post is None:
+        raise ValueError("post not found")
+    jr = RecruitJoin(post_id=post_id, user_id=user_id, created_at=datetime.utcnow())
+    db.session.add(jr)
+    db.session.commit()

--- a/coclib/models.py
+++ b/coclib/models.py
@@ -266,3 +266,35 @@ class Scouting(db.Model):
 
     user = db.relationship("User", backref=db.backref("scouting_templates", lazy="dynamic"))
 
+
+class RecruitPost(db.Model):
+    """Clan recruitment posts."""
+
+    __tablename__ = "recruit_posts"
+
+    id = db.Column(db.BigInteger, primary_key=True)
+    clan_tag = db.Column(db.String(15), index=True)
+    name = db.Column(db.String(50), nullable=False)
+    badge = db.Column(db.String(255))
+    tags = db.Column(db.JSON)
+    open_slots = db.Column(db.Integer, nullable=False)
+    total_slots = db.Column(db.Integer, nullable=False)
+    league = db.Column(db.String(50))
+    language = db.Column(db.String(50))
+    war = db.Column(db.String(50))
+    description = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class RecruitJoin(db.Model):
+    """Record of join requests for recruitment posts."""
+
+    __tablename__ = "recruit_joins"
+
+    id = db.Column(db.Integer, primary_key=True)
+    post_id = db.Column(
+        db.BigInteger, db.ForeignKey("recruit_posts.id"), index=True, nullable=False
+    )
+    user_id = db.Column(db.BigInteger, db.ForeignKey("users.id"), index=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+

--- a/migrations/versions/c86c1db6f7a3_add_recruit_tables.py
+++ b/migrations/versions/c86c1db6f7a3_add_recruit_tables.py
@@ -1,0 +1,55 @@
+"""add recruit tables
+
+Revision ID: c86c1db6f7a3
+Revises: f9040a4059c4
+Create Date: 2024-06-07 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c86c1db6f7a3"
+down_revision = "f9040a4059c4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "recruit_posts",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("clan_tag", sa.String(length=15), nullable=True),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("badge", sa.String(length=255), nullable=True),
+        sa.Column("tags", sa.JSON(), nullable=True),
+        sa.Column("open_slots", sa.Integer(), nullable=False),
+        sa.Column("total_slots", sa.Integer(), nullable=False),
+        sa.Column("league", sa.String(length=50), nullable=True),
+        sa.Column("language", sa.String(length=50), nullable=True),
+        sa.Column("war", sa.String(length=50), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_recruit_posts_clan_tag", "recruit_posts", ["clan_tag"]
+    )
+    op.create_table(
+        "recruit_joins",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("post_id", sa.BigInteger(), sa.ForeignKey("recruit_posts.id"), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_recruit_joins_post_id", "recruit_joins", ["post_id"]
+    )
+    op.create_index(
+        "ix_recruit_joins_user_id", "recruit_joins", ["user_id"]
+    )
+
+
+def downgrade():
+    op.drop_table("recruit_joins")
+    op.drop_table("recruit_posts")

--- a/tests/test_recruit_api.py
+++ b/tests/test_recruit_api.py
@@ -1,0 +1,147 @@
+import sys
+import pathlib
+from datetime import datetime, timedelta
+
+from flask.testing import FlaskClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+from app import create_app  # noqa: E402
+from coclib.config import Config  # noqa: E402
+from coclib.extensions import db  # noqa: E402
+from coclib.models import User, RecruitPost, RecruitJoin  # noqa: E402
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    JWT_SIGNING_KEY = "k"
+
+
+def _mock_verify(monkeypatch):
+    monkeypatch.setattr(
+        "app.jwt.decode", lambda t, key, algorithms: {"sub": "abc"}
+    )
+
+
+def _setup_app(monkeypatch):
+    _mock_verify(monkeypatch)
+    app = create_app(TestConfig)
+    client: FlaskClient = app.test_client()
+    with app.app_context():
+        db.create_all()
+        user = User(
+            id=1,
+            sub="abc",
+            email="u@example.com",
+            name="U",
+            player_tag="AAA",
+        )
+        db.session.add(user)
+        now = datetime.utcnow()
+        posts = [
+            RecruitPost(
+                id=i + 1,
+                name=f"Clan {i}",
+                description="desc",
+                open_slots=i % 5,
+                total_slots=50,
+                league="Gold" if i % 2 == 0 else "Silver",
+                language="EN",
+                war="Always",
+                tags=["fun"],
+                badge="",
+                created_at=now - timedelta(minutes=i),
+            )
+            for i in range(150)
+        ]
+        db.session.add_all(posts)
+        db.session.commit()
+    return app, client
+
+
+def test_recruit_pagination_and_filtering(monkeypatch):
+    app, client = _setup_app(monkeypatch)
+    resp = client.get("/recruit", headers={"Authorization": "Bearer t"})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["items"]) == 100
+    assert data["nextCursor"] == "100"
+
+    resp2 = client.get(
+        f"/recruit?pageCursor={data['nextCursor']}",
+        headers={"Authorization": "Bearer t"},
+    )
+    data2 = resp2.get_json()
+    assert len(data2["items"]) == 50
+    assert data2["nextCursor"] is None
+
+    resp3 = client.get(
+        "/recruit?league=Gold",
+        headers={"Authorization": "Bearer t"},
+    )
+    data3 = resp3.get_json()
+    assert all(item["league"] == "Gold" for item in data3["items"])  # type: ignore
+
+
+def test_recruit_sorting(monkeypatch):
+    _mock_verify(monkeypatch)
+    app = create_app(TestConfig)
+    client: FlaskClient = app.test_client()
+    with app.app_context():
+        db.create_all()
+        user = User(
+            id=1,
+            sub="abc",
+            email="u@example.com",
+            name="U",
+            player_tag="AAA",
+        )
+        db.session.add(user)
+        old = RecruitPost(
+            id=1,
+            name="Old",
+            description="",
+            open_slots=10,
+            total_slots=50,
+            league="Gold",
+            language="EN",
+            war="Always",
+            tags=[],
+            badge="",
+            created_at=datetime.utcnow() - timedelta(days=1),
+        )
+        new = RecruitPost(
+            id=2,
+            name="New",
+            description="",
+            open_slots=1,
+            total_slots=50,
+            league="Gold",
+            language="EN",
+            war="Always",
+            tags=[],
+            badge="",
+            created_at=datetime.utcnow(),
+        )
+        db.session.add_all([old, new])
+        db.session.commit()
+    resp = client.get("/recruit", headers={"Authorization": "Bearer t"})
+    data = resp.get_json()
+    assert data["items"][0]["name"] == "Old"
+    resp2 = client.get(
+        "/recruit?sort=new",
+        headers={"Authorization": "Bearer t"},
+    )
+    data2 = resp2.get_json()
+    assert data2["items"][0]["name"] == "New"
+
+
+def test_join_records_request(monkeypatch):
+    app, client = _setup_app(monkeypatch)
+    with app.app_context():
+        post_id = db.session.query(RecruitPost.id).first()[0]
+    resp = client.post(f"/join/{post_id}", headers={"Authorization": "Bearer t"})
+    assert resp.status_code == 204
+    with app.app_context():
+        jr = RecruitJoin.query.filter_by(post_id=post_id, user_id=1).one_or_none()
+        assert jr is not None


### PR DESCRIPTION
## Summary
- add RecruitPost and RecruitJoin models and schema migration
- expose /recruit listing and /join/<id> endpoints with service layer
- cover pagination, filtering, sorting and join behavior with tests

## Testing
- `ruff check back-end coclib`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_688eccbfc8b0832ca1a6db5cc61b9994