### PR TITLE
feat: add recruit post creation

### DIFF
--- a/back-end/app/api/recruit_routes.py
+++ b/back-end/app/api/recruit_routes.py
@@ -50,6 +50,27 @@ def list_recruit():
     })
 
 
+@bp.post("/recruit")
+def create_recruit():
+    data = request.get_json() or {}
+    try:
+        recruit_service.create_post(
+            clan_tag=data.get("clanTag"),
+            name=data["name"],
+            badge=data.get("badge"),
+            tags=data.get("tags"),
+            open_slots=data["openSlots"],
+            total_slots=data["totalSlots"],
+            league=data.get("league"),
+            language=data.get("language"),
+            war=data.get("war"),
+            description=data.get("description"),
+        )
+    except KeyError:
+        abort(400)
+    return ("", 201)
+
+
 @bp.post("/join/<int:post_id>")
 def join(post_id: int):
     try:

--- a/back-end/app/services/recruit_service.py
+++ b/back-end/app/services/recruit_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Tuple, Optional
 
-from sqlalchemy import or_, cast, String
+from sqlalchemy import or_, cast, String, func
 
 from coclib.extensions import db
 from coclib.models import RecruitPost, RecruitJoin
@@ -40,6 +40,39 @@ def list_posts(
     rows = query.offset(offset).limit(PAGE_SIZE + 1).all()
     next_cursor = offset + PAGE_SIZE if len(rows) > PAGE_SIZE else None
     return rows[:PAGE_SIZE], next_cursor
+
+
+def create_post(
+    *,
+    clan_tag: Optional[str],
+    name: str,
+    badge: Optional[str],
+    tags: Optional[list[str]],
+    open_slots: int,
+    total_slots: int,
+    league: Optional[str],
+    language: Optional[str],
+    war: Optional[str],
+    description: Optional[str],
+) -> RecruitPost:
+    max_id = db.session.query(func.max(RecruitPost.id)).scalar() or 0
+    post = RecruitPost(
+        id=max_id + 1,
+        clan_tag=clan_tag,
+        name=name,
+        badge=badge,
+        tags=tags,
+        open_slots=open_slots,
+        total_slots=total_slots,
+        league=league,
+        language=language,
+        war=war,
+        description=description,
+        created_at=datetime.utcnow(),
+    )
+    db.session.add(post)
+    db.session.commit()
+    return post
 
 
 def record_join(user_id: int, post_id: int) -> None:

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -16,6 +16,16 @@ export default function Scout() {
   const [params] = useSearchParams();
   const page = parseInt(params.get('page') || '1', 10);
 
+  const [clan, setClan] = useState({
+    name: '',
+    description: '',
+    openSlots: '',
+    totalSlots: '',
+    league: '',
+    language: '',
+    war: '',
+  });
+
   function joinClan(clan) {
     if (!navigator.onLine && 'serviceWorker' in navigator && 'SyncManager' in window) {
       navigator.serviceWorker.ready.then((sw) => sw.sync.register(`join-${clan.id}`));
@@ -50,6 +60,41 @@ export default function Scout() {
   const playerItems = playerFeed.items;
 
   const [message, setMessage] = useState('');
+
+  async function postClan(e) {
+    e.preventDefault();
+    try {
+      await fetch('/recruit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: clan.name,
+          description: clan.description,
+          openSlots: parseInt(clan.openSlots, 10),
+          totalSlots: parseInt(clan.totalSlots, 10),
+          league: clan.league,
+          language: clan.language,
+          war: clan.war,
+        }),
+      });
+      if (typeof window !== 'undefined' && 'caches' in window) {
+        const cache = await caches.open('recruit');
+        const keys = await cache.keys();
+        await Promise.all(keys.map((k) => cache.delete(k)));
+      }
+      setClan({
+        name: '',
+        description: '',
+        openSlots: '',
+        totalSlots: '',
+        league: '',
+        language: '',
+        war: '',
+      });
+    } catch (err) {
+      // ignore
+    }
+  }
 
   async function postPlayer(e) {
     e.preventDefault();
@@ -87,6 +132,66 @@ export default function Scout() {
       />
       {active === 'find' && (
         <>
+          <form onSubmit={postClan} className="p-3 border-b flex flex-col gap-2">
+            <input
+              value={clan.name}
+              onChange={(e) => setClan({ ...clan, name: e.target.value })}
+              placeholder="Clan name"
+              className="border p-2 rounded"
+            />
+            <textarea
+              value={clan.description}
+              onChange={(e) =>
+                setClan({ ...clan, description: e.target.value })
+              }
+              placeholder="Describe your clan"
+              className="border p-2 rounded"
+            />
+            <input
+              type="number"
+              value={clan.openSlots}
+              onChange={(e) =>
+                setClan({ ...clan, openSlots: e.target.value })
+              }
+              placeholder="Open slots"
+              className="border p-2 rounded"
+            />
+            <input
+              type="number"
+              value={clan.totalSlots}
+              onChange={(e) =>
+                setClan({ ...clan, totalSlots: e.target.value })
+              }
+              placeholder="Total slots"
+              className="border p-2 rounded"
+            />
+            <input
+              value={clan.league}
+              onChange={(e) => setClan({ ...clan, league: e.target.value })}
+              placeholder="League"
+              className="border p-2 rounded"
+            />
+            <input
+              value={clan.language}
+              onChange={(e) =>
+                setClan({ ...clan, language: e.target.value })
+              }
+              placeholder="Language"
+              className="border p-2 rounded"
+            />
+            <input
+              value={clan.war}
+              onChange={(e) => setClan({ ...clan, war: e.target.value })}
+              placeholder="War frequency"
+              className="border p-2 rounded"
+            />
+            <button
+              type="submit"
+              className="bg-blue-500 text-white py-1 px-2 rounded self-start"
+            >
+              Post
+            </button>
+          </form>
           <DiscoveryBar onChange={setFilters} />
           <div className="flex-1">
             <RecruitFeed

--- a/front-end/app/src/pages/Scout.test.jsx
+++ b/front-end/app/src/pages/Scout.test.jsx
@@ -14,6 +14,15 @@ describe('Scout page', () => {
     expect(screen.getByText('Need a Clan')).toBeInTheDocument();
   });
 
+  it('shows find a clan form by default', () => {
+    render(
+      <MemoryRouter>
+        <Scout />
+      </MemoryRouter>
+    );
+    expect(screen.getByPlaceholderText('Clan name')).toBeInTheDocument();
+  });
+
   it('shows need a clan form when tab selected', () => {
     render(
       <MemoryRouter>

--- a/tests/test_recruit_api.py
+++ b/tests/test_recruit_api.py
@@ -145,3 +145,26 @@ def test_join_records_request(monkeypatch):
     with app.app_context():
         jr = RecruitJoin.query.filter_by(post_id=post_id, user_id=1).one_or_none()
         assert jr is not None
+
+
+def test_create_recruit_post(monkeypatch):
+    app, client = _setup_app(monkeypatch)
+    payload = {
+        "name": "New Clan",
+        "description": "desc",
+        "openSlots": 5,
+        "totalSlots": 50,
+        "league": "Gold",
+        "language": "EN",
+        "war": "Always",
+    }
+    resp = client.post(
+        "/recruit",
+        json=payload,
+        headers={"Authorization": "Bearer t"},
+    )
+    assert resp.status_code == 201
+    with app.app_context():
+        post = RecruitPost.query.filter_by(name="New Clan").one_or_none()
+        assert post is not None
+        assert post.open_slots == 5

--- a/tests/test_recruit_service.py
+++ b/tests/test_recruit_service.py
@@ -1,0 +1,36 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+from app import create_app  # noqa: E402
+from coclib.config import Config  # noqa: E402
+from coclib.extensions import db  # noqa: E402
+from coclib.models import RecruitPost  # noqa: E402
+from app.services import recruit_service  # noqa: E402
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    JWT_SIGNING_KEY = "k"
+
+
+def test_create_post():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        recruit_service.create_post(
+            clan_tag="TAG",
+            name="My Clan",
+            badge="",
+            tags=["fun"],
+            open_slots=1,
+            total_slots=50,
+            league="Gold",
+            language="EN",
+            war="Always",
+            description="desc",
+        )
+        post = RecruitPost.query.filter_by(name="My Clan").one_or_none()
+        assert post is not None
+        assert post.open_slots == 1


### PR DESCRIPTION
## Summary
- add POST /recruit route for creating recruitment posts
- support inserting new RecruitPost records in service layer
- add clan recruitment form to Scout page with tests

## Testing
- `ruff check back-end`
- `nox -s tests`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ed7f9ac40832cb349be8bbb62d3db