### PR TITLE
Add invite API and notifications

### DIFF
--- a/back-end/app/api/__init__.py
+++ b/back-end/app/api/__init__.py
@@ -11,6 +11,7 @@ from .user_routes import bp as user_bp
 from .asset_routes import bp as asset_bp
 from .log_routes import bp as log_bp
 from .recruit_routes import bp as recruit_bp
+from .invite_routes import bp as invite_bp
 
 
 def register_blueprints(app: Flask):
@@ -22,3 +23,4 @@ def register_blueprints(app: Flask):
     app.register_blueprint(asset_bp)
     app.register_blueprint(log_bp)
     app.register_blueprint(recruit_bp)
+    app.register_blueprint(invite_bp)

--- a/back-end/app/api/invite_routes.py
+++ b/back-end/app/api/invite_routes.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, g
+
+from ..services import invite_service
+
+bp = Blueprint("invite", __name__)
+
+
+@bp.post("/invite/<int:player_id>")
+def invite(player_id: int):
+    invite_service.send_invite(g.user.id, player_id)
+    return ("", 204)

--- a/back-end/app/services/invite_service.py
+++ b/back-end/app/services/invite_service.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+
+import requests
+
+from coclib.extensions import db
+from coclib.models import Invite
+
+logger = logging.getLogger(__name__)
+NOTIFICATIONS_URL = os.getenv(
+    "NOTIFICATIONS_URL", "http://notifications:8080/api/v1/notifications"
+)
+
+
+def send_invite(from_user_id: int, to_user_id: int) -> None:
+    inv = Invite(
+        from_user_id=from_user_id,
+        to_user_id=to_user_id,
+        created_at=datetime.utcnow(),
+    )
+    db.session.add(inv)
+    db.session.commit()
+    send_invite_notification(to_user_id)
+
+
+def send_invite_notification(user_id: int) -> None:
+    url = f"{NOTIFICATIONS_URL}/invite/{user_id}"
+    try:
+        requests.post(url, timeout=5)
+    except Exception:
+        logger.warning("Failed to send invite notification for %s", user_id)

--- a/coclib/models.py
+++ b/coclib/models.py
@@ -298,3 +298,18 @@ class RecruitJoin(db.Model):
     user_id = db.Column(db.BigInteger, db.ForeignKey("users.id"), index=True, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
+
+class Invite(db.Model):
+    """Record of clan invitations sent to players."""
+
+    __tablename__ = "invites"
+
+    id = db.Column(db.Integer, primary_key=True)
+    from_user_id = db.Column(
+        db.BigInteger, db.ForeignKey("users.id"), index=True, nullable=False
+    )
+    to_user_id = db.Column(
+        db.BigInteger, db.ForeignKey("users.id"), index=True, nullable=False
+    )
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+

--- a/migrations/versions/2473f333fc90_add_invites_table.py
+++ b/migrations/versions/2473f333fc90_add_invites_table.py
@@ -1,0 +1,35 @@
+"""add invites table
+
+Revision ID: 2473f333fc90
+Revises: f901db3f1df2
+Create Date: 2025-08-01 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '2473f333fc90'
+down_revision = 'f901db3f1df2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'invites',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('from_user_id', sa.BigInteger(), nullable=False),
+        sa.Column('to_user_id', sa.BigInteger(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+    with op.batch_alter_table('invites', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_invites_from_user_id'), ['from_user_id'], unique=False)
+        batch_op.create_index(batch_op.f('ix_invites_to_user_id'), ['to_user_id'], unique=False)
+
+
+def downgrade():
+    with op.batch_alter_table('invites', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_invites_to_user_id'))
+        batch_op.drop_index(batch_op.f('ix_invites_from_user_id'))
+    op.drop_table('invites')

--- a/notifications/src/main/java/com/clanboards/notifications/controller/NotificationController.java
+++ b/notifications/src/main/java/com/clanboards/notifications/controller/NotificationController.java
@@ -44,6 +44,12 @@ public class NotificationController {
     return ResponseEntity.ok(Map.of("status", "sent"));
   }
 
+  @PostMapping("/invite/{userId}")
+  public ResponseEntity<?> invite(@PathVariable Long userId) {
+    service.sendInvite(userId, "invite");
+    return ResponseEntity.ok(Map.of("status", "sent"));
+  }
+
   private Long parseUserId(jakarta.servlet.http.HttpServletRequest request, Principal principal) {
     String name = null;
     if (principal != null) {

--- a/notifications/src/main/java/com/clanboards/notifications/service/NotificationService.java
+++ b/notifications/src/main/java/com/clanboards/notifications/service/NotificationService.java
@@ -53,6 +53,10 @@ public class NotificationService {
     sendNotification(userId, payload);
   }
 
+  public void sendInvite(Long userId, String payload) {
+    sendNotification(userId, payload);
+  }
+
   public boolean sendNotification(Long userId, String payload) {
     Span span = tracer.spanBuilder("sendNotification").startSpan();
     try {

--- a/tests/test_invite_api.py
+++ b/tests/test_invite_api.py
@@ -1,0 +1,50 @@
+import sys
+import pathlib
+
+from flask.testing import FlaskClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+from app import create_app  # noqa: E402
+from coclib.config import Config  # noqa: E402
+from coclib.extensions import db  # noqa: E402
+from coclib.models import User, Invite  # noqa: E402
+from app.services import invite_service  # noqa: E402
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    JWT_SIGNING_KEY = "k"
+
+
+def _mock_verify(monkeypatch):
+    monkeypatch.setattr("app.jwt.decode", lambda t, key, algorithms: {"sub": "abc"})
+
+
+def _setup_app(monkeypatch):
+    _mock_verify(monkeypatch)
+    app = create_app(TestConfig)
+    client: FlaskClient = app.test_client()
+    with app.app_context():
+        db.create_all()
+        u1 = User(id=1, sub="abc", email="u@example.com", name="U", player_tag="AAA")
+        u2 = User(id=2, sub="def", email="v@example.com", name="V", player_tag="BBB")
+        db.session.add_all([u1, u2])
+        db.session.commit()
+    return app, client
+
+
+def test_invite_creates_record_and_notifies(monkeypatch):
+    app, client = _setup_app(monkeypatch)
+    called = {}
+    monkeypatch.setattr(
+        invite_service,
+        "send_invite_notification",
+        lambda uid: called.setdefault("uid", uid),
+    )
+    resp = client.post("/invite/2", headers={"Authorization": "Bearer t"})
+    assert resp.status_code == 204
+    assert called.get("uid") == 2
+    with app.app_context():
+        inv = Invite.query.filter_by(from_user_id=1, to_user_id=2).one_or_none()
+        assert inv is not None


### PR DESCRIPTION
## Summary
- add `/invite/<player_id>` route and service
- store invites in new shared model and migration
- send invite notifications from notifications service

## Testing
- `ruff check back-end coclib`
- `cd notifications && ./gradlew test`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_688ed86f79fc832cb6010755eab246da