### PR TITLE
feat: add player recruit post model

### DIFF
--- a/coclib/models.py
+++ b/coclib/models.py
@@ -298,3 +298,21 @@ class RecruitJoin(db.Model):
     user_id = db.Column(db.BigInteger, db.ForeignKey("users.id"), index=True, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
+
+class PlayerRecruitPost(db.Model):
+    """Player recruitment posts."""
+
+    __tablename__ = "player_recruit_posts"
+
+    id = db.Column(db.BigInteger, primary_key=True)
+    user_id = db.Column(db.BigInteger, db.ForeignKey("users.id"), index=True, nullable=False)
+    description = db.Column(db.Text)
+    league = db.Column(db.String(50))
+    language = db.Column(db.String(50))
+    war = db.Column(db.String(50))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    user = db.relationship(
+        "User", backref=db.backref("player_recruit_posts", lazy="dynamic")
+    )
+

--- a/migrations/versions/b3ab9e12ec82_create_player_recruit_post_table.py
+++ b/migrations/versions/b3ab9e12ec82_create_player_recruit_post_table.py
@@ -1,0 +1,38 @@
+"""create player recruit post table
+
+Revision ID: b3ab9e12ec82
+Revises: c86c1db6f7a3
+Create Date: 2025-08-03 03:39:24.014945
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b3ab9e12ec82'
+down_revision = 'c86c1db6f7a3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "player_recruit_posts",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column(
+            "user_id", sa.BigInteger(), sa.ForeignKey("users.id"), nullable=False
+        ),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("league", sa.String(length=50), nullable=True),
+        sa.Column("language", sa.String(length=50), nullable=True),
+        sa.Column("war", sa.String(length=50), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_player_recruit_posts_user_id", "player_recruit_posts", ["user_id"]
+    )
+
+
+def downgrade():
+    op.drop_table("player_recruit_posts")

--- a/tests/test_player_recruit_post_model.py
+++ b/tests/test_player_recruit_post_model.py
@@ -1,0 +1,34 @@
+import pathlib
+import sys
+from datetime import datetime
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
+from app import create_app  # noqa: E402
+from coclib.config import Config  # noqa: E402
+from coclib.extensions import db  # noqa: E402
+from coclib.models import User, PlayerRecruitPost  # noqa: E402
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+
+
+def test_player_recruit_post_table_creation():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        db.session.add(User(id=1, sub="abc", email="u@example.com"))
+        db.session.add(
+            PlayerRecruitPost(
+                id=1,
+                user_id=1,
+                description="Looking for a clan",
+                league="Gold",
+                language="EN",
+                war="Always",
+                created_at=datetime.utcnow(),
+            )
+        )
+        db.session.commit()
+        assert PlayerRecruitPost.query.count() == 1


### PR DESCRIPTION
## Summary
- add PlayerRecruitPost model for player recruiting posts
- add Alembic migration for player_recruit_posts table
- test player recruit post model creation

## Testing
- `ruff check coclib`
- `ruff check tests/test_player_recruit_post_model.py`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_688ed8d4ef94832ca4dfec476e2dd9bf