### PR TITLE
Add clan recruitment form

### DIFF
--- a/front-end/app/src/components/ClanPostForm.jsx
+++ b/front-end/app/src/components/ClanPostForm.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { fetchJSON } from '../lib/api.js';
+
+export default function ClanPostForm({ onPosted }) {
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState('');
+  const [slots, setSlots] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const body = {
+        description,
+        tags: tags
+          .split(',')
+          .map((t) => t.trim())
+          .filter(Boolean),
+        slots: parseInt(slots, 10) || 0,
+      };
+      await fetchJSON('/recruit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (typeof window !== 'undefined' && 'caches' in window) {
+        try {
+          const cache = await caches.open('recruit');
+          const keys = await cache.keys();
+          await Promise.all(keys.map((k) => cache.delete(k)));
+        } catch {
+          // ignore
+        }
+      }
+      setDescription('');
+      setTags('');
+      setSlots('');
+      onPosted?.();
+    } catch (err) {
+      setError('Failed to post');
+    }
+    setLoading(false);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-3 border-b flex flex-col gap-2">
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Describe your clan"
+        className="border p-2 rounded"
+      />
+      <input
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        placeholder="Tags (comma separated)"
+        className="border p-2 rounded"
+      />
+      <input
+        value={slots}
+        onChange={(e) => setSlots(e.target.value)}
+        placeholder="Open slots"
+        type="number"
+        className="border p-2 rounded w-32"
+      />
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <button
+        type="submit"
+        className="bg-blue-500 text-white py-1 px-2 rounded self-start"
+        disabled={loading}
+      >
+        {loading ? 'Posting…' : 'Post'}
+      </button>
+    </form>
+  );
+}
+

--- a/front-end/app/src/components/ClanPostForm.test.jsx
+++ b/front-end/app/src/components/ClanPostForm.test.jsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('../lib/api.js', () => ({
+  fetchJSON: vi.fn().mockResolvedValue({}),
+  API_URL: '',
+}));
+
+import ClanPostForm from './ClanPostForm.jsx';
+import { fetchJSON } from '../lib/api.js';
+
+describe('ClanPostForm', () => {
+  it('posts form data to /recruit', async () => {
+    const posted = vi.fn();
+
+    render(<ClanPostForm onPosted={posted} />);
+
+    fireEvent.change(screen.getByPlaceholderText('Describe your clan'), {
+      target: { value: 'Join us' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Tags (comma separated)'), {
+      target: { value: 'war,active' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Open slots'), {
+      target: { value: '5' },
+    });
+
+    fireEvent.click(screen.getByText('Post'));
+
+    await waitFor(() => expect(fetchJSON).toHaveBeenCalled());
+
+    expect(fetchJSON).toHaveBeenCalledWith(
+      '/recruit',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: 'Join us', tags: ['war', 'active'], slots: 5 }),
+      })
+    );
+    expect(posted).toHaveBeenCalled();
+  });
+});

--- a/front-end/app/src/hooks/useRecruitFeed.js
+++ b/front-end/app/src/hooks/useRecruitFeed.js
@@ -44,12 +44,16 @@ export default function useRecruitFeed(filters) {
     setLoading(false);
   }
 
-  useEffect(() => {
+  function reload() {
     setItems([]);
     setCursor('');
     setHasMore(true);
     fetchPage('');
+  }
+
+  useEffect(() => {
+    reload();
   }, [filters.league, filters.language, filters.war, filters.q, filters.sort]);
 
-  return { items, loadMore: () => fetchPage(cursor), hasMore, loading };
+  return { items, loadMore: () => fetchPage(cursor), hasMore, loading, reload };
 }

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -4,6 +4,7 @@ import Tabs from '../components/Tabs.jsx';
 import DiscoveryBar from '../components/DiscoveryBar.jsx';
 import RecruitFeed from '../components/RecruitFeed.jsx';
 import PlayerRecruitFeed from '../components/PlayerRecruitFeed.jsx';
+import ClanPostForm from '../components/ClanPostForm.jsx';
 import useRecruitFeed from '../hooks/useRecruitFeed.js';
 import usePlayerRecruitFeed from '../hooks/usePlayerRecruitFeed.js';
 import Fuse from 'fuse.js';
@@ -87,6 +88,7 @@ export default function Scout() {
       />
       {active === 'find' && (
         <>
+          <ClanPostForm onPosted={feed.reload} />
           <DiscoveryBar onChange={setFilters} />
           <div className="flex-1">
             <RecruitFeed


### PR DESCRIPTION
## Summary
- add ClanPostForm component for creating clan recruit posts
- refresh clan feed with reloadable hook
- surface form in Scout "Find a Clan" tab with tests
- use shared API helper for recruit submissions

## Testing
- `nox -s lint tests`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ed8aa163c832c92920906d73dfa5c