### PR TITLE
Add clan post form and refreshable recruit feed

### DIFF
--- a/front-end/app/src/components/ClanPostForm.jsx
+++ b/front-end/app/src/components/ClanPostForm.jsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import { fetchJSON } from '../lib/api.js';
+
+export default function ClanPostForm({ onPosted }) {
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    tags: '',
+    openSlots: '',
+    totalSlots: '',
+    league: '',
+    language: '',
+    war: '',
+  });
+
+  function handleChange(e) {
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    try {
+      await fetchJSON('/recruit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name,
+          description: form.description,
+          tags: form.tags
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean),
+          openSlots: parseInt(form.openSlots, 10),
+          totalSlots: parseInt(form.totalSlots, 10),
+          league: form.league,
+          language: form.language,
+          war: form.war,
+        }),
+      });
+      if (typeof window !== 'undefined' && 'caches' in window) {
+        const cache = await caches.open('recruit');
+        const keys = await cache.keys();
+        await Promise.all(keys.map((k) => cache.delete(k)));
+      }
+      setForm({
+        name: '',
+        description: '',
+        tags: '',
+        openSlots: '',
+        totalSlots: '',
+        league: '',
+        language: '',
+        war: '',
+      });
+      onPosted?.();
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-3 border-b flex flex-col gap-2">
+      <input
+        name="name"
+        value={form.name}
+        onChange={handleChange}
+        placeholder="Clan name"
+        className="border p-2 rounded"
+      />
+      <textarea
+        name="description"
+        value={form.description}
+        onChange={handleChange}
+        placeholder="Describe your clan"
+        className="border p-2 rounded"
+      />
+      <input
+        name="tags"
+        value={form.tags}
+        onChange={handleChange}
+        placeholder="Tags (comma separated)"
+        className="border p-2 rounded"
+      />
+      <input
+        type="number"
+        name="openSlots"
+        value={form.openSlots}
+        onChange={handleChange}
+        placeholder="Open slots"
+        className="border p-2 rounded"
+      />
+      <input
+        type="number"
+        name="totalSlots"
+        value={form.totalSlots}
+        onChange={handleChange}
+        placeholder="Total slots"
+        className="border p-2 rounded"
+      />
+      <input
+        name="league"
+        value={form.league}
+        onChange={handleChange}
+        placeholder="League"
+        className="border p-2 rounded"
+      />
+      <input
+        name="language"
+        value={form.language}
+        onChange={handleChange}
+        placeholder="Language"
+        className="border p-2 rounded"
+      />
+      <input
+        name="war"
+        value={form.war}
+        onChange={handleChange}
+        placeholder="War frequency"
+        className="border p-2 rounded"
+      />
+      <button
+        type="submit"
+        className="bg-blue-500 text-white py-1 px-2 rounded self-start"
+      >
+        Post
+      </button>
+    </form>
+  );
+}
+

--- a/front-end/app/src/components/ClanPostForm.test.jsx
+++ b/front-end/app/src/components/ClanPostForm.test.jsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { vi } from 'vitest';
+
+vi.mock('../lib/api.js', () => ({
+  fetchJSON: vi.fn(() => Promise.resolve({})),
+  API_URL: '',
+}));
+
+import ClanPostForm from './ClanPostForm.jsx';
+import { fetchJSON } from '../lib/api.js';
+
+test('submits clan post', async () => {
+  const onPosted = vi.fn();
+  render(<ClanPostForm onPosted={onPosted} />);
+  fireEvent.change(screen.getByPlaceholderText('Clan name'), {
+    target: { value: 'Test Clan' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Describe your clan'), {
+    target: { value: 'Best clan ever' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Tags (comma separated)'), {
+    target: { value: 'war, chill' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Open slots'), {
+    target: { value: '3' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Total slots'), {
+    target: { value: '30' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('League'), {
+    target: { value: 'Gold' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Language'), {
+    target: { value: 'English' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('War frequency'), {
+    target: { value: 'Always' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Post' }));
+  await waitFor(() => expect(fetchJSON).toHaveBeenCalled());
+  const [, opts] = fetchJSON.mock.calls[0];
+  expect(JSON.parse(opts.body)).toEqual({
+    name: 'Test Clan',
+    description: 'Best clan ever',
+    tags: ['war', 'chill'],
+    openSlots: 3,
+    totalSlots: 30,
+    league: 'Gold',
+    language: 'English',
+    war: 'Always',
+  });
+  await waitFor(() => expect(onPosted).toHaveBeenCalled());
+});
+

--- a/front-end/app/src/hooks/useRecruitFeed.js
+++ b/front-end/app/src/hooks/useRecruitFeed.js
@@ -44,12 +44,16 @@ export default function useRecruitFeed(filters) {
     setLoading(false);
   }
 
-  useEffect(() => {
+  function reload() {
     setItems([]);
     setCursor('');
     setHasMore(true);
     fetchPage('');
+  }
+
+  useEffect(() => {
+    reload();
   }, [filters.league, filters.language, filters.war, filters.q, filters.sort]);
 
-  return { items, loadMore: () => fetchPage(cursor), hasMore, loading };
+  return { items, loadMore: () => fetchPage(cursor), hasMore, loading, reload };
 }

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -4,6 +4,7 @@ import Tabs from '../components/Tabs.jsx';
 import DiscoveryBar from '../components/DiscoveryBar.jsx';
 import RecruitFeed from '../components/RecruitFeed.jsx';
 import PlayerRecruitFeed from '../components/PlayerRecruitFeed.jsx';
+import ClanPostForm from '../components/ClanPostForm.jsx';
 import useRecruitFeed from '../hooks/useRecruitFeed.js';
 import usePlayerRecruitFeed from '../hooks/usePlayerRecruitFeed.js';
 import Fuse from 'fuse.js';
@@ -15,16 +16,6 @@ export default function Scout() {
   const playerFeed = usePlayerRecruitFeed(filters);
   const [params] = useSearchParams();
   const page = parseInt(params.get('page') || '1', 10);
-
-  const [clan, setClan] = useState({
-    name: '',
-    description: '',
-    openSlots: '',
-    totalSlots: '',
-    league: '',
-    language: '',
-    war: '',
-  });
 
   function joinClan(clan) {
     if (!navigator.onLine && 'serviceWorker' in navigator && 'SyncManager' in window) {
@@ -60,41 +51,6 @@ export default function Scout() {
   const playerItems = playerFeed.items;
 
   const [message, setMessage] = useState('');
-
-  async function postClan(e) {
-    e.preventDefault();
-    try {
-      await fetch('/recruit', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: clan.name,
-          description: clan.description,
-          openSlots: parseInt(clan.openSlots, 10),
-          totalSlots: parseInt(clan.totalSlots, 10),
-          league: clan.league,
-          language: clan.language,
-          war: clan.war,
-        }),
-      });
-      if (typeof window !== 'undefined' && 'caches' in window) {
-        const cache = await caches.open('recruit');
-        const keys = await cache.keys();
-        await Promise.all(keys.map((k) => cache.delete(k)));
-      }
-      setClan({
-        name: '',
-        description: '',
-        openSlots: '',
-        totalSlots: '',
-        league: '',
-        language: '',
-        war: '',
-      });
-    } catch (err) {
-      // ignore
-    }
-  }
 
   async function postPlayer(e) {
     e.preventDefault();
@@ -132,66 +88,7 @@ export default function Scout() {
       />
       {active === 'find' && (
         <>
-          <form onSubmit={postClan} className="p-3 border-b flex flex-col gap-2">
-            <input
-              value={clan.name}
-              onChange={(e) => setClan({ ...clan, name: e.target.value })}
-              placeholder="Clan name"
-              className="border p-2 rounded"
-            />
-            <textarea
-              value={clan.description}
-              onChange={(e) =>
-                setClan({ ...clan, description: e.target.value })
-              }
-              placeholder="Describe your clan"
-              className="border p-2 rounded"
-            />
-            <input
-              type="number"
-              value={clan.openSlots}
-              onChange={(e) =>
-                setClan({ ...clan, openSlots: e.target.value })
-              }
-              placeholder="Open slots"
-              className="border p-2 rounded"
-            />
-            <input
-              type="number"
-              value={clan.totalSlots}
-              onChange={(e) =>
-                setClan({ ...clan, totalSlots: e.target.value })
-              }
-              placeholder="Total slots"
-              className="border p-2 rounded"
-            />
-            <input
-              value={clan.league}
-              onChange={(e) => setClan({ ...clan, league: e.target.value })}
-              placeholder="League"
-              className="border p-2 rounded"
-            />
-            <input
-              value={clan.language}
-              onChange={(e) =>
-                setClan({ ...clan, language: e.target.value })
-              }
-              placeholder="Language"
-              className="border p-2 rounded"
-            />
-            <input
-              value={clan.war}
-              onChange={(e) => setClan({ ...clan, war: e.target.value })}
-              placeholder="War frequency"
-              className="border p-2 rounded"
-            />
-            <button
-              type="submit"
-              className="bg-blue-500 text-white py-1 px-2 rounded self-start"
-            >
-              Post
-            </button>
-          </form>
+          <ClanPostForm onPosted={feed.reload} />
           <DiscoveryBar onChange={setFilters} />
           <div className="flex-1">
             <RecruitFeed


### PR DESCRIPTION
## Summary
- add ClanPostForm component for submitting clan recruit posts
- refresh recruit feed after posting and integrate form on Scout page
- test ClanPostForm submission behavior

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_688ee82d37d0832cbc26d824347f3358