### PR TITLE
Fix recruit endpoints and update front-end

### DIFF
--- a/back-end/app/api/recruit_routes.py
+++ b/back-end/app/api/recruit_routes.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from datetime import datetime
 from flask import Blueprint, jsonify, request, g, abort
 
+from . import API_PREFIX
 from ..services import recruit_service
 
-bp = Blueprint("recruit", __name__)
+bp = Blueprint("recruit", __name__, url_prefix=f"{API_PREFIX}/recruiting")
 
 
 @bp.get("/recruit")

--- a/front-end/app/public/sw.js
+++ b/front-end/app/public/sw.js
@@ -195,16 +195,17 @@ self.addEventListener('sync', (event) => {
   if (event.tag && event.tag.startsWith('join-')) {
     const id = event.tag.slice(5);
     event.waitUntil(
-      fetch(`/join/${id}`, { method: 'POST' }).catch(() =>
-        self.registration.sync.register(event.tag)
-      )
+      fetch(`/api/v1/recruiting/join/${id}`, {
+        method: 'POST',
+        credentials: 'include',
+      }).catch(() => self.registration.sync.register(event.tag))
     );
   }
 });
 
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
-  if (url.origin === self.location.origin && url.pathname === '/recruit') {
+  if (url.origin === self.location.origin && url.pathname === '/api/v1/recruiting/recruit') {
     event.respondWith(staleWhileRevalidateRecruit(event));
     return;
   }

--- a/front-end/app/src/components/ClanPostForm.jsx
+++ b/front-end/app/src/components/ClanPostForm.jsx
@@ -21,7 +21,7 @@ export default function ClanPostForm({ onPosted }) {
   async function handleSubmit(e) {
     e.preventDefault();
     try {
-      await fetchJSON('/recruit', {
+      await fetchJSON('/recruiting/recruit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/front-end/app/src/hooks/useRecruitFeed.js
+++ b/front-end/app/src/hooks/useRecruitFeed.js
@@ -15,7 +15,7 @@ export default function useRecruitFeed(filters) {
     if (filters.war) params.set('war', filters.war);
     if (filters.q) params.set('q', filters.q);
     if (filters.sort) params.set('sort', filters.sort);
-    const url = `/recruit?${params.toString()}`;
+    const url = `/api/v1/recruiting/recruit?${params.toString()}`;
     let data;
     if (typeof window !== 'undefined' && 'caches' in window && (!c || c === '')) {
       const cache = await caches.open('recruit');

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -21,7 +21,10 @@ export default function Scout() {
     if (!navigator.onLine && 'serviceWorker' in navigator && 'SyncManager' in window) {
       navigator.serviceWorker.ready.then((sw) => sw.sync.register(`join-${clan.id}`));
     } else {
-      fetch(`/join/${clan.id}`, { method: 'POST' });
+      fetch(`/api/v1/recruiting/join/${clan.id}`, {
+        method: 'POST',
+        credentials: 'include',
+      });
     }
   }
 

--- a/front-end/app/src/sw.test.js
+++ b/front-end/app/src/sw.test.js
@@ -43,7 +43,10 @@ describe('service worker', () => {
     const listeners = setup();
     await import('../public/sw.js');
     await listeners.sync({ tag: 'join-1', waitUntil: (p) => p });
-    expect(fetch).toHaveBeenCalledWith('/join/1', { method: 'POST' });
+    expect(fetch).toHaveBeenCalledWith('/api/v1/recruiting/join/1', {
+      method: 'POST',
+      credentials: 'include',
+    });
   });
 
   it('caches only first two recruit pages', async () => {
@@ -53,21 +56,25 @@ describe('service worker', () => {
     const cache = await caches.open('recruit');
     let responsePromise;
     await handler({
-      request: new Request('https://example.com/recruit'),
+      request: new Request('https://example.com/api/v1/recruiting/recruit'),
       respondWith: (p) => (responsePromise = p),
       waitUntil: (p) => p,
     });
     await responsePromise;
     expect((await cache.keys()).length).toBe(1);
     await handler({
-      request: new Request('https://example.com/recruit?pageCursor=abc'),
+      request: new Request(
+        'https://example.com/api/v1/recruiting/recruit?pageCursor=abc'
+      ),
       respondWith: (p) => (responsePromise = p),
       waitUntil: (p) => p,
     });
     await responsePromise;
     expect((await cache.keys()).length).toBe(2);
     await handler({
-      request: new Request('https://example.com/recruit?pageCursor=def'),
+      request: new Request(
+        'https://example.com/api/v1/recruiting/recruit?pageCursor=def'
+      ),
       respondWith: (p) => (responsePromise = p),
       waitUntil: (p) => p,
     });

--- a/tests/test_recruit_api.py
+++ b/tests/test_recruit_api.py
@@ -61,14 +61,16 @@ def _setup_app(monkeypatch):
 
 def test_recruit_pagination_and_filtering(monkeypatch):
     app, client = _setup_app(monkeypatch)
-    resp = client.get("/recruit", headers={"Authorization": "Bearer t"})
+    resp = client.get(
+        "/api/v1/recruiting/recruit", headers={"Authorization": "Bearer t"}
+    )
     assert resp.status_code == 200
     data = resp.get_json()
     assert len(data["items"]) == 100
     assert data["nextCursor"] == "100"
 
     resp2 = client.get(
-        f"/recruit?pageCursor={data['nextCursor']}",
+        f"/api/v1/recruiting/recruit?pageCursor={data['nextCursor']}",
         headers={"Authorization": "Bearer t"},
     )
     data2 = resp2.get_json()
@@ -76,7 +78,7 @@ def test_recruit_pagination_and_filtering(monkeypatch):
     assert data2["nextCursor"] is None
 
     resp3 = client.get(
-        "/recruit?league=Gold",
+        "/api/v1/recruiting/recruit?league=Gold",
         headers={"Authorization": "Bearer t"},
     )
     data3 = resp3.get_json()
@@ -125,11 +127,13 @@ def test_recruit_sorting(monkeypatch):
         )
         db.session.add_all([old, new])
         db.session.commit()
-    resp = client.get("/recruit", headers={"Authorization": "Bearer t"})
+    resp = client.get(
+        "/api/v1/recruiting/recruit", headers={"Authorization": "Bearer t"}
+    )
     data = resp.get_json()
     assert data["items"][0]["name"] == "Old"
     resp2 = client.get(
-        "/recruit?sort=new",
+        "/api/v1/recruiting/recruit?sort=new",
         headers={"Authorization": "Bearer t"},
     )
     data2 = resp2.get_json()
@@ -140,7 +144,9 @@ def test_join_records_request(monkeypatch):
     app, client = _setup_app(monkeypatch)
     with app.app_context():
         post_id = db.session.query(RecruitPost.id).first()[0]
-    resp = client.post(f"/join/{post_id}", headers={"Authorization": "Bearer t"})
+    resp = client.post(
+        f"/api/v1/recruiting/join/{post_id}", headers={"Authorization": "Bearer t"}
+    )
     assert resp.status_code == 204
     with app.app_context():
         jr = RecruitJoin.query.filter_by(post_id=post_id, user_id=1).one_or_none()
@@ -159,7 +165,7 @@ def test_create_recruit_post(monkeypatch):
         "war": "Always",
     }
     resp = client.post(
-        "/recruit",
+        "/api/v1/recruiting/recruit",
         json=payload,
         headers={"Authorization": "Bearer t"},
     )


### PR DESCRIPTION
## Summary
- namespace recruit API under `/api/v1/recruiting` and expose `/recruit` & `/join`
- point scout page and service worker to new recruit/join routes
- adjust tests for updated recruit API paths

## Testing
- `ruff check back-end`
- `npm test`
- `npm run build`
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_688f6334a0ac832c8201d0254de9cd0e