### PR TITLE
fix: show confirmation after recruiting and ensure feed loads

### DIFF
--- a/front-end/app/src/components/ClanPostForm.jsx
+++ b/front-end/app/src/components/ClanPostForm.jsx
@@ -54,6 +54,9 @@ export default function ClanPostForm({ onPosted }) {
         war: '',
       });
       onPosted?.();
+      window.dispatchEvent(
+        new CustomEvent('toast', { detail: 'Recruiting post created!' })
+      );
     } catch (err) {
       // ignore
     }

--- a/front-end/app/src/components/ClanPostForm.test.jsx
+++ b/front-end/app/src/components/ClanPostForm.test.jsx
@@ -13,6 +13,7 @@ import { fetchJSON } from '../lib/api.js';
 
 test('submits clan post', async () => {
   const onPosted = vi.fn();
+  const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
   render(<ClanPostForm onPosted={onPosted} />);
   fireEvent.change(screen.getByPlaceholderText('Clan name'), {
     target: { value: 'Test Clan' },
@@ -52,5 +53,9 @@ test('submits clan post', async () => {
     war: 'Always',
   });
   await waitFor(() => expect(onPosted).toHaveBeenCalled());
+  expect(dispatchSpy).toHaveBeenCalled();
+  const [evt] = dispatchSpy.mock.calls[0];
+  expect(evt.type).toBe('toast');
+  expect(evt.detail).toBe('Recruiting post created!');
 });
 

--- a/front-end/app/src/hooks/useRecruitFeed.js
+++ b/front-end/app/src/hooks/useRecruitFeed.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { fetchJSON } from '../lib/api.js';
 
 export default function useRecruitFeed(filters) {
   const [items, setItems] = useState([]);
@@ -15,28 +16,30 @@ export default function useRecruitFeed(filters) {
     if (filters.war) params.set('war', filters.war);
     if (filters.q) params.set('q', filters.q);
     if (filters.sort) params.set('sort', filters.sort);
-    const url = `/api/v1/recruiting/recruit?${params.toString()}`;
+    const path = `/recruiting/recruit?${params.toString()}`;
     let data;
     if (typeof window !== 'undefined' && 'caches' in window && (!c || c === '')) {
       const cache = await caches.open('recruit');
-      const cached = await cache.match(url);
+      const cached = await cache.match(path);
       if (cached) {
         data = await cached.json();
-        fetch(url)
-          .then((r) => cache.put(url, r.clone()))
+        fetchJSON(path)
+          .then((d) => cache.put(path, new Response(JSON.stringify(d))))
           .catch(() => {});
       } else {
-        const res = await fetch(url).catch(() => null);
-        if (res) {
-          cache.put(url, res.clone());
-          data = await res.json();
-        } else {
+        try {
+          data = await fetchJSON(path);
+          await cache.put(path, new Response(JSON.stringify(data)));
+        } catch {
           data = { items: [], nextCursor: null };
         }
       }
     } else {
-      const res = await fetch(url).catch(() => null);
-      data = res ? await res.json() : { items: [], nextCursor: null };
+      try {
+        data = await fetchJSON(path);
+      } catch {
+        data = { items: [], nextCursor: null };
+      }
     }
     setItems((prev) => [...prev, ...data.items]);
     setCursor(data.nextCursor || '');

--- a/front-end/app/src/hooks/useRecruitFeed.test.jsx
+++ b/front-end/app/src/hooks/useRecruitFeed.test.jsx
@@ -44,5 +44,7 @@ describe('useRecruitFeed', () => {
     expect(url).toContain('war=always');
     expect(url).toContain('q=abc');
     expect(url).toContain('sort=new');
+    const opts = fetch.mock.calls[0][1];
+    expect(opts).toMatchObject({ credentials: 'include' });
   });
 });

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -7,6 +7,7 @@ import PlayerRecruitFeed from '../components/PlayerRecruitFeed.jsx';
 import ClanPostForm from '../components/ClanPostForm.jsx';
 import useRecruitFeed from '../hooks/useRecruitFeed.js';
 import usePlayerRecruitFeed from '../hooks/usePlayerRecruitFeed.js';
+import { fetchJSON } from '../lib/api.js';
 import Fuse from 'fuse.js';
 
 export default function Scout() {
@@ -21,10 +22,7 @@ export default function Scout() {
     if (!navigator.onLine && 'serviceWorker' in navigator && 'SyncManager' in window) {
       navigator.serviceWorker.ready.then((sw) => sw.sync.register(`join-${clan.id}`));
     } else {
-      fetch(`/api/v1/recruiting/join/${clan.id}`, {
-        method: 'POST',
-        credentials: 'include',
-      });
+      fetchJSON(`/recruiting/join/${clan.id}`, { method: 'POST' }).catch(() => {});
     }
   }
 
@@ -58,7 +56,7 @@ export default function Scout() {
   async function postPlayer(e) {
     e.preventDefault();
     try {
-      await fetch('/player-recruit', {
+      await fetchJSON('/player-recruit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ description: message }),
@@ -76,7 +74,7 @@ export default function Scout() {
   }
 
   function invitePlayer(player) {
-    fetch(`/invite/${player.id}`, { method: 'POST' }).catch(() => {});
+    fetchJSON(`/invite/${player.id}`, { method: 'POST' }).catch(() => {});
   }
 
   return (


### PR DESCRIPTION
## Summary
- show a toast when a recruiting post is created
- include credentials when fetching recruiting feeds so posts appear after posting and on page load
- use shared API helper for all recruiting page requests
- cover toast and credential behavior with tests

## Testing
- `nox -s lint tests`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f6a71fb48832ca15578d69c8585ca