### PR TITLE
Simplify recruit post model

### DIFF
--- a/back-end/app/api/recruit_routes.py
+++ b/back-end/app/api/recruit_routes.py
@@ -12,14 +12,8 @@ bp = Blueprint("recruit", __name__, url_prefix=f"{API_PREFIX}/recruiting")
 @bp.get("/recruit")
 def list_recruit():
     cursor = request.args.get("pageCursor", type=int)
-    filters = {
-        "league": request.args.get("league"),
-        "language": request.args.get("language"),
-        "war": request.args.get("war"),
-        "q": request.args.get("q"),
-    }
-    sort = request.args.get("sort", "slots")
-    posts, next_cursor = recruit_service.list_posts(cursor, filters, sort)
+    filters = {"q": request.args.get("q")}
+    posts, next_cursor = recruit_service.list_posts(cursor, filters)
     now = datetime.utcnow()
     items: list[dict] = []
     for p in posts:
@@ -32,17 +26,10 @@ def list_recruit():
         items.append(
             {
                 "id": p.id,
-                "badge": p.badge,
-                "name": p.name,
-                "tags": p.tags or [],
-                "openSlots": p.open_slots,
-                "totalSlots": p.total_slots,
+                "clanTag": p.clan_tag,
+                "callToAction": p.call_to_action,
                 "age": age,
                 "ageValue": age_value,
-                "league": p.league,
-                "language": p.language,
-                "war": p.war,
-                "description": p.description,
             }
         )
     return jsonify({
@@ -57,15 +44,7 @@ def create_recruit():
     try:
         recruit_service.create_post(
             clan_tag=data.get("clanTag"),
-            name=data["name"],
-            badge=data.get("badge"),
-            tags=data.get("tags"),
-            open_slots=data["openSlots"],
-            total_slots=data["totalSlots"],
-            league=data.get("league"),
-            language=data.get("language"),
-            war=data.get("war"),
-            description=data.get("description"),
+            call_to_action=data.get("callToAction"),
         )
     except KeyError:
         abort(400)

--- a/coclib/models.py
+++ b/coclib/models.py
@@ -274,15 +274,7 @@ class RecruitPost(db.Model):
 
     id = db.Column(db.BigInteger, primary_key=True)
     clan_tag = db.Column(db.String(15), index=True)
-    name = db.Column(db.String(50), nullable=False)
-    badge = db.Column(db.String(255))
-    tags = db.Column(db.JSON)
-    open_slots = db.Column(db.Integer, nullable=False)
-    total_slots = db.Column(db.Integer, nullable=False)
-    league = db.Column(db.String(50))
-    language = db.Column(db.String(50))
-    war = db.Column(db.String(50))
-    description = db.Column(db.Text)
+    call_to_action = db.Column(db.Text)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 

--- a/front-end/app/src/components/ClanPostForm.jsx
+++ b/front-end/app/src/components/ClanPostForm.jsx
@@ -2,16 +2,7 @@ import React, { useState } from 'react';
 import { fetchJSON } from '../lib/api.js';
 
 export default function ClanPostForm({ onPosted }) {
-  const [form, setForm] = useState({
-    name: '',
-    description: '',
-    tags: '',
-    openSlots: '',
-    totalSlots: '',
-    league: '',
-    language: '',
-    war: '',
-  });
+  const [form, setForm] = useState({ callToAction: '' });
 
   function handleChange(e) {
     const { name, value } = e.target;
@@ -24,35 +15,14 @@ export default function ClanPostForm({ onPosted }) {
       await fetchJSON('/recruiting/recruit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: form.name,
-          description: form.description,
-          tags: form.tags
-            .split(',')
-            .map((t) => t.trim())
-            .filter(Boolean),
-          openSlots: parseInt(form.openSlots, 10),
-          totalSlots: parseInt(form.totalSlots, 10),
-          league: form.league,
-          language: form.language,
-          war: form.war,
-        }),
+        body: JSON.stringify({ callToAction: form.callToAction }),
       });
       if (typeof window !== 'undefined' && 'caches' in window) {
         const cache = await caches.open('recruit');
         const keys = await cache.keys();
         await Promise.all(keys.map((k) => cache.delete(k)));
       }
-      setForm({
-        name: '',
-        description: '',
-        tags: '',
-        openSlots: '',
-        totalSlots: '',
-        league: '',
-        language: '',
-        war: '',
-      });
+      setForm({ callToAction: '' });
       onPosted?.();
       window.dispatchEvent(
         new CustomEvent('toast', { detail: 'Recruiting post created!' })
@@ -64,62 +34,11 @@ export default function ClanPostForm({ onPosted }) {
 
   return (
     <form onSubmit={handleSubmit} className="p-3 border-b flex flex-col gap-2">
-      <input
-        name="name"
-        value={form.name}
-        onChange={handleChange}
-        placeholder="Clan name"
-        className="border p-2 rounded"
-      />
       <textarea
-        name="description"
-        value={form.description}
+        name="callToAction"
+        value={form.callToAction}
         onChange={handleChange}
         placeholder="Describe your clan"
-        className="border p-2 rounded"
-      />
-      <input
-        name="tags"
-        value={form.tags}
-        onChange={handleChange}
-        placeholder="Tags (comma separated)"
-        className="border p-2 rounded"
-      />
-      <input
-        type="number"
-        name="openSlots"
-        value={form.openSlots}
-        onChange={handleChange}
-        placeholder="Open slots"
-        className="border p-2 rounded"
-      />
-      <input
-        type="number"
-        name="totalSlots"
-        value={form.totalSlots}
-        onChange={handleChange}
-        placeholder="Total slots"
-        className="border p-2 rounded"
-      />
-      <input
-        name="league"
-        value={form.league}
-        onChange={handleChange}
-        placeholder="League"
-        className="border p-2 rounded"
-      />
-      <input
-        name="language"
-        value={form.language}
-        onChange={handleChange}
-        placeholder="Language"
-        className="border p-2 rounded"
-      />
-      <input
-        name="war"
-        value={form.war}
-        onChange={handleChange}
-        placeholder="War frequency"
         className="border p-2 rounded"
       />
       <button

--- a/front-end/app/src/components/ClanPostForm.test.jsx
+++ b/front-end/app/src/components/ClanPostForm.test.jsx
@@ -15,43 +15,13 @@ test('submits clan post', async () => {
   const onPosted = vi.fn();
   const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
   render(<ClanPostForm onPosted={onPosted} />);
-  fireEvent.change(screen.getByPlaceholderText('Clan name'), {
-    target: { value: 'Test Clan' },
-  });
   fireEvent.change(screen.getByPlaceholderText('Describe your clan'), {
-    target: { value: 'Best clan ever' },
-  });
-  fireEvent.change(screen.getByPlaceholderText('Tags (comma separated)'), {
-    target: { value: 'war, chill' },
-  });
-  fireEvent.change(screen.getByPlaceholderText('Open slots'), {
-    target: { value: '3' },
-  });
-  fireEvent.change(screen.getByPlaceholderText('Total slots'), {
-    target: { value: '30' },
-  });
-  fireEvent.change(screen.getByPlaceholderText('League'), {
-    target: { value: 'Gold' },
-  });
-  fireEvent.change(screen.getByPlaceholderText('Language'), {
-    target: { value: 'English' },
-  });
-  fireEvent.change(screen.getByPlaceholderText('War frequency'), {
-    target: { value: 'Always' },
+    target: { name: 'callToAction', value: 'Best clan ever' },
   });
   fireEvent.click(screen.getByRole('button', { name: 'Post' }));
   await waitFor(() => expect(fetchJSON).toHaveBeenCalled());
   const [, opts] = fetchJSON.mock.calls[0];
-  expect(JSON.parse(opts.body)).toEqual({
-    name: 'Test Clan',
-    description: 'Best clan ever',
-    tags: ['war', 'chill'],
-    openSlots: 3,
-    totalSlots: 30,
-    league: 'Gold',
-    language: 'English',
-    war: 'Always',
-  });
+  expect(JSON.parse(opts.body)).toEqual({ callToAction: 'Best clan ever' });
   await waitFor(() => expect(onPosted).toHaveBeenCalled());
   expect(dispatchSpy).toHaveBeenCalled();
   const [evt] = dispatchSpy.mock.calls[0];

--- a/front-end/app/src/components/DiscoveryBar.jsx
+++ b/front-end/app/src/components/DiscoveryBar.jsx
@@ -1,18 +1,10 @@
 import React, { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-const leagues = ['None', 'Bronze', 'Silver', 'Gold', 'Crystal', 'Master', 'Champion'];
-const languages = ['Any', 'English', 'Spanish', 'French'];
-const warTypes = ['Any', 'Casual', 'Competitive'];
-
 export default function DiscoveryBar({ onChange }) {
   const [params, setParams] = useSearchParams();
   const filters = {
-    league: params.get('league') || 'None',
-    language: params.get('lang') || 'Any',
-    war: params.get('war') || 'Any',
     q: params.get('q') || '',
-    sort: params.get('sort') || 'open',
   };
 
   useEffect(() => {
@@ -30,54 +22,12 @@ export default function DiscoveryBar({ onChange }) {
 
   return (
     <div className="sticky top-0 z-10 bg-white p-2 shadow flex gap-2 overflow-x-auto">
-      <select
-        value={filters.league}
-        onChange={(e) => update('league', e.target.value)}
-        className="border rounded p-1 text-sm"
-      >
-        {leagues.map((l) => (
-          <option key={l} value={l}>
-            {l}
-          </option>
-        ))}
-      </select>
-      <select
-        value={filters.language}
-        onChange={(e) => update('lang', e.target.value)}
-        className="border rounded p-1 text-sm"
-      >
-        {languages.map((l) => (
-          <option key={l} value={l}>
-            {l}
-          </option>
-        ))}
-      </select>
-      <select
-        value={filters.war}
-        onChange={(e) => update('war', e.target.value)}
-        className="border rounded p-1 text-sm"
-      >
-        {warTypes.map((l) => (
-          <option key={l} value={l}>
-            {l}
-          </option>
-        ))}
-      </select>
       <input
         value={filters.q}
         onChange={(e) => update('q', e.target.value)}
         placeholder="Search"
         className="flex-1 border rounded p-1 text-sm"
       />
-      <button
-        type="button"
-        onClick={() =>
-          update('sort', filters.sort === 'open' ? 'new' : 'open')
-        }
-        className="border rounded px-2 text-sm"
-      >
-        Sort: {filters.sort}
-      </button>
     </div>
   );
 }

--- a/front-end/app/src/components/RecruitCard.jsx
+++ b/front-end/app/src/components/RecruitCard.jsx
@@ -1,47 +1,18 @@
 import React from 'react';
 
-export default function RecruitCard({
-  id,
-  badge,
-  name,
-  tags = [],
-  openSlots,
-  totalSlots,
-  age,
-  description,
-  onJoin,
-}) {
-  const pct = totalSlots ? (openSlots / totalSlots) * 100 : 0;
+export default function RecruitCard({ callToAction, age, onJoin }) {
   return (
     <button
       type="button"
-      aria-label={`Join ${name}`}
+      aria-label="Join clan"
       onClick={onJoin}
       className="w-full text-left p-3 border-b flex gap-3 bg-white"
     >
-      <img src={badge} alt="badge" className="w-12 h-12" />
       <div className="flex-1">
         <div className="flex items-center justify-between">
-          <h3 className="font-semibold">{name}</h3>
           <span className="text-xs text-slate-500">{age}</span>
         </div>
-        <div className="flex flex-wrap gap-1 my-1">
-          {tags.map((t) => (
-            <span
-              key={t}
-              className="text-xs bg-slate-200 rounded px-1 py-0.5"
-            >
-              {t}
-            </span>
-          ))}
-        </div>
-        <div className="h-2 bg-slate-200 rounded">
-          <div
-            className="h-full bg-green-500 rounded"
-            style={{ width: `${pct}%` }}
-          />
-        </div>
-        <p className="text-sm line-clamp-2 mt-1 text-slate-700">{description}</p>
+        <p className="text-sm line-clamp-2 mt-1 text-slate-700">{callToAction}</p>
       </div>
     </button>
   );

--- a/front-end/app/src/components/RecruitCard.test.jsx
+++ b/front-end/app/src/components/RecruitCard.test.jsx
@@ -5,16 +5,7 @@ import RecruitCard from './RecruitCard.jsx';
 
 test('renders recruit card with aria label', () => {
   render(
-    <RecruitCard
-      id="1"
-      badge="/badge.png"
-      name="Example Clan"
-      tags={['war', 'chill']}
-      openSlots={10}
-      totalSlots={50}
-      age="1d"
-      description="Join us"
-    />
+    <RecruitCard callToAction="Join us" age="1d" />
   );
-  expect(screen.getByRole('button', { name: /Join Example Clan/ })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Join clan/ })).toBeInTheDocument();
 });

--- a/front-end/app/src/hooks/usePlayerRecruitFeed.js
+++ b/front-end/app/src/hooks/usePlayerRecruitFeed.js
@@ -11,11 +11,7 @@ export default function usePlayerRecruitFeed(filters) {
     setLoading(true);
     const params = new URLSearchParams();
     params.set('pageCursor', c || '');
-    if (filters.league) params.set('league', filters.league);
-    if (filters.language) params.set('language', filters.language);
-    if (filters.war) params.set('war', filters.war);
     if (filters.q) params.set('q', filters.q);
-    if (filters.sort) params.set('sort', filters.sort);
     const path = `/player-recruit?${params.toString()}`;
     let data;
     if (typeof window !== 'undefined' && 'caches' in window && (!c || c === '')) {
@@ -56,7 +52,7 @@ export default function usePlayerRecruitFeed(filters) {
 
   useEffect(() => {
     reload();
-  }, [filters.league, filters.language, filters.war, filters.q, filters.sort]);
+  }, [filters.q]);
 
   return { items, loadMore: () => fetchPage(cursor), hasMore, loading, reload };
 }

--- a/front-end/app/src/hooks/useRecruitFeed.js
+++ b/front-end/app/src/hooks/useRecruitFeed.js
@@ -11,11 +11,7 @@ export default function useRecruitFeed(filters) {
     setLoading(true);
     const params = new URLSearchParams();
     params.set('pageCursor', c || '');
-    if (filters.league) params.set('league', filters.league);
-    if (filters.language) params.set('language', filters.language);
-    if (filters.war) params.set('war', filters.war);
     if (filters.q) params.set('q', filters.q);
-    if (filters.sort) params.set('sort', filters.sort);
     const path = `/recruiting/recruit?${params.toString()}`;
     let data;
     if (typeof window !== 'undefined' && 'caches' in window && (!c || c === '')) {
@@ -56,7 +52,7 @@ export default function useRecruitFeed(filters) {
 
   useEffect(() => {
     reload();
-  }, [filters.league, filters.language, filters.war, filters.q, filters.sort]);
+  }, [filters.q]);
 
   return { items, loadMore: () => fetchPage(cursor), hasMore, loading, reload };
 }

--- a/front-end/app/src/hooks/useRecruitFeed.test.jsx
+++ b/front-end/app/src/hooks/useRecruitFeed.test.jsx
@@ -29,21 +29,11 @@ describe('useRecruitFeed', () => {
   });
 
   it('sends filters as query params', async () => {
-    const filters = {
-      league: 'Gold',
-      language: 'EN',
-      war: 'always',
-      q: 'abc',
-      sort: 'new',
-    };
+    const filters = { q: 'abc' };
     render(<Wrapper filters={filters} />);
     await waitFor(() => expect(fetch).toHaveBeenCalled());
     const url = fetch.mock.calls[0][0];
-    expect(url).toContain('league=Gold');
-    expect(url).toContain('language=EN');
-    expect(url).toContain('war=always');
     expect(url).toContain('q=abc');
-    expect(url).toContain('sort=new');
     const opts = fetch.mock.calls[0][1];
     expect(opts).toMatchObject({ credentials: 'include' });
   });

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -29,25 +29,11 @@ export default function Scout() {
   const items = useMemo(() => {
     let data = feed.items;
     if (filters.q) {
-      const fuse = new Fuse(data, { keys: ['name', 'description', 'tags'] });
+      const fuse = new Fuse(data, { keys: ['callToAction'] });
       data = fuse.search(filters.q).map((r) => r.item);
     }
-    if (filters.league && filters.league !== 'None') {
-      data = data.filter((d) => d.league === filters.league);
-    }
-    if (filters.language && filters.language !== 'Any') {
-      data = data.filter((d) => d.language === filters.language);
-    }
-    if (filters.war && filters.war !== 'Any') {
-      data = data.filter((d) => d.war === filters.war);
-    }
-    if (filters.sort === 'new') {
-      data = [...data].sort((a, b) => b.ageValue - a.ageValue);
-    } else {
-      data = [...data].sort((a, b) => b.openSlots - a.openSlots);
-    }
-    return data;
-  }, [feed.items, filters]);
+    return data.sort((a, b) => b.ageValue - a.ageValue);
+  }, [feed.items, filters.q]);
 
   const playerItems = playerFeed.items;
 

--- a/front-end/app/src/pages/Scout.test.jsx
+++ b/front-end/app/src/pages/Scout.test.jsx
@@ -20,7 +20,7 @@ describe('Scout page', () => {
         <Scout />
       </MemoryRouter>
     );
-    expect(screen.getByPlaceholderText('Clan name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Describe your clan')).toBeInTheDocument();
   });
 
   it('shows need a clan form when tab selected', () => {

--- a/migrations/versions/fead6a7c7712_simplify_recruit_post.py
+++ b/migrations/versions/fead6a7c7712_simplify_recruit_post.py
@@ -1,0 +1,35 @@
+"""simplify recruit post
+
+Revision ID: fead6a7c7712
+Revises: f901db3f1df2
+Create Date: 2025-08-04 00:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table("recruit_posts") as batch_op:
+        batch_op.alter_column("description", new_column_name="call_to_action")
+        batch_op.drop_column("name")
+        batch_op.drop_column("badge")
+        batch_op.drop_column("tags")
+        batch_op.drop_column("open_slots")
+        batch_op.drop_column("total_slots")
+        batch_op.drop_column("league")
+        batch_op.drop_column("language")
+        batch_op.drop_column("war")
+
+
+def downgrade():
+    with op.batch_alter_table("recruit_posts") as batch_op:
+        batch_op.add_column(sa.Column("war", sa.String(length=50), nullable=True))
+        batch_op.add_column(sa.Column("language", sa.String(length=50), nullable=True))
+        batch_op.add_column(sa.Column("league", sa.String(length=50), nullable=True))
+        batch_op.add_column(sa.Column("total_slots", sa.Integer(), nullable=False))
+        batch_op.add_column(sa.Column("open_slots", sa.Integer(), nullable=False))
+        batch_op.add_column(sa.Column("tags", sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column("badge", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("name", sa.String(length=50), nullable=False))
+        batch_op.alter_column("call_to_action", new_column_name="description")

--- a/tests/test_recruit_service.py
+++ b/tests/test_recruit_service.py
@@ -21,16 +21,7 @@ def test_create_post():
         db.create_all()
         recruit_service.create_post(
             clan_tag="TAG",
-            name="My Clan",
-            badge="",
-            tags=["fun"],
-            open_slots=1,
-            total_slots=50,
-            league="Gold",
-            language="EN",
-            war="Always",
-            description="desc",
+            call_to_action="desc",
         )
-        post = RecruitPost.query.filter_by(name="My Clan").one_or_none()
+        post = RecruitPost.query.filter_by(call_to_action="desc").one_or_none()
         assert post is not None
-        assert post.open_slots == 1


### PR DESCRIPTION
## Summary
- trim `RecruitPost` to minimal fields and rename `description` to `call_to_action`
- update recruit service and API to drop unused filters and work with `call_to_action`
- simplify recruiting UI and tests to the leaner model and add migration

## Testing
- `nox -s lint`
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6890c67922c4832cadebe699a503f37d