### PR TITLE
Enhance recruitment posts with clan details and filtering

### DIFF
--- a/back-end/app/services/recruit_service.py
+++ b/back-end/app/services/recruit_service.py
@@ -1,40 +1,77 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Tuple, Optional
+from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import func
 
 from coclib.extensions import db
-from coclib.models import RecruitPost, RecruitJoin
+from coclib.models import Clan, RecruitJoin, RecruitPost
 
 PAGE_SIZE = 100
 
 
 def list_posts(
     cursor: Optional[int],
-    filters: dict,
-) -> Tuple[List[RecruitPost], Optional[int]]:
-    query = RecruitPost.query
+    filters: Dict[str, Optional[str]],
+) -> Tuple[List[Dict[str, object]], Optional[int]]:
+    """Return recruitment posts enriched with clan details."""
+
+    query = db.session.query(RecruitPost, Clan).join(Clan, RecruitPost.clan_tag == Clan.tag)
+
     if q := filters.get("q"):
         pattern = f"%{q}%"
         query = query.filter(RecruitPost.call_to_action.ilike(pattern))
+    if league := filters.get("league"):
+        query = query.filter(Clan.data["warLeague"]["name"].astext == league)
+    if language := filters.get("language"):
+        query = query.filter(Clan.data["chatLanguage"]["name"].astext == language)
+    if war := filters.get("warFrequency"):
+        query = query.filter(Clan.data["warFrequency"].astext == war)
+
     query = query.order_by(RecruitPost.created_at.desc())
     offset = int(cursor or 0)
     rows = query.offset(offset).limit(PAGE_SIZE + 1).all()
     next_cursor = offset + PAGE_SIZE if len(rows) > PAGE_SIZE else None
-    return rows[:PAGE_SIZE], next_cursor
+
+    items: List[Dict[str, object]] = []
+    for post, clan in rows[:PAGE_SIZE]:
+        data = clan.data or {}
+        members = data.get("members", 0) or 0
+        items.append(
+            {
+                "id": post.id,
+                "call_to_action": post.call_to_action,
+                "created_at": post.created_at,
+                "tag": clan.tag,
+                "deep_link": clan.deep_link,
+                "name": data.get("name"),
+                "description": data.get("description"),
+                "labels": data.get("labels", []),
+                "members": members,
+                "warFrequency": data.get("warFrequency"),
+                "chatLanguage": (data.get("chatLanguage") or {}).get("name"),
+                "openSlots": 50 - members,
+            }
+        )
+
+    return items, next_cursor
 
 
-def create_post(
-    *,
-    clan_tag: Optional[str],
-    call_to_action: Optional[str],
-) -> RecruitPost:
+def create_post(*, clan_tag: Optional[str], call_to_action: Optional[str]) -> RecruitPost:
+    """Create a recruitment post for an existing clan."""
+
+    if not clan_tag:
+        raise KeyError("clan_tag is required")
+
+    clan = Clan.query.get(clan_tag)
+    if clan is None:
+        raise ValueError("clan not found")
+
     max_id = db.session.query(func.max(RecruitPost.id)).scalar() or 0
     post = RecruitPost(
         id=max_id + 1,
-        clan_tag=clan_tag,
+        clan_tag=clan.tag,
         call_to_action=call_to_action,
         created_at=datetime.utcnow(),
     )

--- a/tests/test_recruit_service.py
+++ b/tests/test_recruit_service.py
@@ -1,11 +1,12 @@
 import sys
 import pathlib
+import pytest
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "back-end"))
 from app import create_app  # noqa: E402
 from coclib.config import Config  # noqa: E402
 from coclib.extensions import db  # noqa: E402
-from coclib.models import RecruitPost  # noqa: E402
+from coclib.models import Clan, RecruitPost  # noqa: E402
 from app.services import recruit_service  # noqa: E402
 
 
@@ -19,9 +20,47 @@ def test_create_post():
     app = create_app(TestConfig)
     with app.app_context():
         db.create_all()
+        clan = Clan(
+            tag="TAG",
+            deep_link="link",
+            data={"name": "N", "members": 40, "chatLanguage": {"name": "English"}},
+        )
+        db.session.add(clan)
+        db.session.commit()
         recruit_service.create_post(
             clan_tag="TAG",
             call_to_action="desc",
         )
         post = RecruitPost.query.filter_by(call_to_action="desc").one_or_none()
         assert post is not None
+
+
+def test_create_post_missing_clan():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        with pytest.raises(ValueError):
+            recruit_service.create_post(clan_tag="MISSING", call_to_action=None)
+
+
+def test_list_posts():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        clan = Clan(
+            tag="TAG",
+            deep_link="link",
+            data={
+                "name": "N",
+                "members": 40,
+                "description": "D",
+                "chatLanguage": {"name": "English"},
+                "warFrequency": "always",
+                "labels": [1],
+            },
+        )
+        db.session.add(clan)
+        recruit_service.create_post(clan_tag="TAG", call_to_action="desc")
+        items, _ = recruit_service.list_posts(None, {})
+        assert items[0]["tag"] == "TAG"
+        assert items[0]["openSlots"] == 10


### PR DESCRIPTION
## Summary
- Enrich recruitment post listing with clan metadata and filtering options
- Validate clan existence when creating recruit posts
- Adapt recruit API and tests for updated service contract

## Testing
- `ruff check back-end`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_6890ce1169ec832cb79c014e5ad042be