### PR TITLE
feat: fetch clan for recruiting posts

### DIFF
--- a/front-end/app/src/components/ClanPostForm.jsx
+++ b/front-end/app/src/components/ClanPostForm.jsx
@@ -1,13 +1,38 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { fetchJSON } from '../lib/api.js';
+import Loading from './Loading.jsx';
 
 export default function ClanPostForm({ onPosted }) {
-  const [form, setForm] = useState({ callToAction: '' });
+  const [callToAction, setCallToAction] = useState('');
+  const [clan, setClan] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-  function handleChange(e) {
-    const { name, value } = e.target;
-    setForm({ ...form, [name]: value });
-  }
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const me = await fetchJSON('/user/me');
+        const playerTag = me.player_tag;
+        if (!playerTag) throw new Error('no player tag');
+        const player = await fetchJSON(`/player/${encodeURIComponent(playerTag)}`);
+        if (!player.clanTag) throw new Error('no clan');
+        const data = await fetchJSON(`/clan/${encodeURIComponent(player.clanTag)}`);
+        if (!cancelled) {
+          setClan(data);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) setError('Failed to load clan');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -15,14 +40,14 @@ export default function ClanPostForm({ onPosted }) {
       await fetchJSON('/recruiting/recruit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ callToAction: form.callToAction }),
+        body: JSON.stringify({ clanTag: clan.tag, callToAction }),
       });
       if (typeof window !== 'undefined' && 'caches' in window) {
         const cache = await caches.open('recruit');
         const keys = await cache.keys();
         await Promise.all(keys.map((k) => cache.delete(k)));
       }
-      setForm({ callToAction: '' });
+      setCallToAction('');
       onPosted?.();
       window.dispatchEvent(
         new CustomEvent('toast', { detail: 'Recruiting post created!' })
@@ -32,12 +57,35 @@ export default function ClanPostForm({ onPosted }) {
     }
   }
 
+  if (loading) return <Loading className="p-3 border-b" />;
+  if (error || !clan)
+    return (
+      <div className="p-3 border-b text-sm text-red-500">
+        {error || 'Clan not found'}
+      </div>
+    );
+
   return (
     <form onSubmit={handleSubmit} className="p-3 border-b flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        {clan.badgeUrls?.small && (
+          <img src={clan.badgeUrls.small} alt="clan badge" className="w-8 h-8" />
+        )}
+        <div>
+          <div className="font-semibold">{clan.name}</div>
+          <div className="flex flex-wrap gap-1">
+            {clan.labels?.map((l) => (
+              <span key={l.id} className="text-xs bg-slate-200 px-1 rounded">
+                {l.name}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
       <textarea
         name="callToAction"
-        value={form.callToAction}
-        onChange={handleChange}
+        value={callToAction}
+        onChange={(e) => setCallToAction(e.target.value)}
         placeholder="Describe your clan"
         className="border p-2 rounded"
       />

--- a/front-end/app/src/components/ClanPostForm.test.jsx
+++ b/front-end/app/src/components/ClanPostForm.test.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { vi } from 'vitest';
 
 vi.mock('../lib/api.js', () => ({
-  fetchJSON: vi.fn(() => Promise.resolve({})),
+  fetchJSON: vi.fn(),
   API_URL: '',
 }));
 
@@ -12,16 +12,28 @@ import ClanPostForm from './ClanPostForm.jsx';
 import { fetchJSON } from '../lib/api.js';
 
 test('submits clan post', async () => {
+  fetchJSON.mockImplementation((path) => {
+    if (path === '/user/me') return Promise.resolve({ player_tag: 'PLAYER' });
+    if (path.startsWith('/player/')) return Promise.resolve({ clanTag: 'CLAN' });
+    if (path.startsWith('/clan/')) return Promise.resolve({ tag: 'CLAN', name: 'Clan', labels: [] });
+    if (path === '/recruiting/recruit') return Promise.resolve({});
+    return Promise.resolve({});
+  });
+
   const onPosted = vi.fn();
   const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
   render(<ClanPostForm onPosted={onPosted} />);
+
+  await screen.findByPlaceholderText('Describe your clan');
   fireEvent.change(screen.getByPlaceholderText('Describe your clan'), {
     target: { name: 'callToAction', value: 'Best clan ever' },
   });
   fireEvent.click(screen.getByRole('button', { name: 'Post' }));
-  await waitFor(() => expect(fetchJSON).toHaveBeenCalled());
-  const [, opts] = fetchJSON.mock.calls[0];
-  expect(JSON.parse(opts.body)).toEqual({ callToAction: 'Best clan ever' });
+
+  await waitFor(() => expect(fetchJSON).toHaveBeenCalledWith('/recruiting/recruit', expect.any(Object)));
+  const postCall = fetchJSON.mock.calls.find(([p]) => p === '/recruiting/recruit');
+  const [, opts] = postCall;
+  expect(JSON.parse(opts.body)).toEqual({ clanTag: 'CLAN', callToAction: 'Best clan ever' });
   await waitFor(() => expect(onPosted).toHaveBeenCalled());
   expect(dispatchSpy).toHaveBeenCalled();
   const [evt] = dispatchSpy.mock.calls[0];


### PR DESCRIPTION
## Summary
- show current clan preview in recruiting form and submit with clan tag
- add loading/error states and handle missing clan info
- update Scout page and tests for asynchronous clan loading

## Testing
- `nox -s tests`
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890d1d102d4832c8ddfcfc17b6b9478