### PR TITLE
feat: enhance recruit card details

### DIFF
--- a/front-end/app/src/components/RecruitCard.jsx
+++ b/front-end/app/src/components/RecruitCard.jsx
@@ -1,19 +1,82 @@
-import React from 'react';
+import React, { useState } from 'react';
+import CachedImage from './CachedImage.jsx';
 
-export default function RecruitCard({ callToAction, age, onJoin }) {
+export default function RecruitCard({
+  clanTag,
+  deepLink,
+  name,
+  description,
+  labels = [],
+  members = 0,
+  warFrequency,
+  language,
+  callToAction,
+  onJoin,
+}) {
+  const [showLabels, setShowLabels] = useState(false);
+  const openSlots = 50 - members;
+
+  function handleClick() {
+    setShowLabels((s) => !s);
+  }
+
   return (
-    <button
-      type="button"
-      aria-label="Join clan"
-      onClick={onJoin}
-      className="w-full text-left p-3 border-b flex gap-3 bg-white"
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      className="w-full text-left p-3 border-b bg-white"
     >
-      <div className="flex-1">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-slate-500">{age}</span>
-        </div>
-        <p className="text-sm line-clamp-2 mt-1 text-slate-700">{callToAction}</p>
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold">{name}</h3>
+        <a
+          href={deepLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => {
+            e.stopPropagation();
+            onJoin?.();
+          }}
+          className="text-xs text-slate-500"
+        >
+          {clanTag}
+        </a>
       </div>
-    </button>
+      <p className="text-xs text-slate-500 mt-1">
+        {warFrequency} • {typeof language === 'string' ? language : language?.name}
+      </p>
+      {description && (
+        <p className="text-sm line-clamp-2 mt-1 text-slate-700">{description}</p>
+      )}
+      {callToAction && (
+        <p className="text-sm line-clamp-2 mt-1 text-slate-700">{callToAction}</p>
+      )}
+      <div className="mt-2">
+        <div className="h-2 bg-slate-200 rounded">
+          <div
+            className="h-2 bg-blue-500 rounded"
+            style={{ width: `${(openSlots / 50) * 100}%` }}
+          />
+        </div>
+        <p className="text-xs text-slate-500 mt-1">{openSlots} open slots</p>
+      </div>
+      {labels.length > 0 && (
+        <div className="flex gap-2 mt-2">
+          {labels.map((l) => (
+            <div key={l.id || l.name} className="flex flex-col items-center w-12">
+              <CachedImage
+                src={l.iconUrls?.small || l.iconUrls?.medium}
+                alt={l.name}
+                className="w-8 h-8"
+              />
+              {showLabels && (
+                <p className="text-xs text-slate-500 mt-1 text-center">{l.name}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
+

--- a/front-end/app/src/components/RecruitCard.test.jsx
+++ b/front-end/app/src/components/RecruitCard.test.jsx
@@ -1,11 +1,35 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import RecruitCard from './RecruitCard.jsx';
 
-test('renders recruit card with aria label', () => {
+vi.mock('./CachedImage.jsx', () => ({
+  default: (props) => <img {...props} />,
+}));
+
+test('renders recruit card and toggles label names', () => {
+  const labels = [{ id: 1, name: 'Label1', iconUrls: { small: '/l1.png' } }];
   render(
-    <RecruitCard callToAction="Join us" age="1d" />
+    <RecruitCard
+      clanTag="#CLAN"
+      deepLink="https://link"
+      name="Clan"
+      description="Desc"
+      labels={labels}
+      members={40}
+      warFrequency="Always"
+      language="EN"
+      callToAction="Join us"
+    />
   );
-  expect(screen.getByRole('button', { name: /Join clan/ })).toBeInTheDocument();
+
+  expect(screen.getByRole('link', { name: '#CLAN' })).toHaveAttribute(
+    'href',
+    'https://link'
+  );
+  expect(screen.getByText('10 open slots')).toBeInTheDocument();
+  expect(screen.queryByText('Label1')).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button'));
+  expect(screen.getByText('Label1')).toBeInTheDocument();
 });
+

--- a/front-end/app/src/components/RecruitFeed.jsx
+++ b/front-end/app/src/components/RecruitFeed.jsx
@@ -55,7 +55,18 @@ export default function RecruitFeed({ items, loadMore, hasMore, onJoin, initialP
               {!item && <RecruitSkeleton />}
               {item &&
                 item.type === 'card' && (
-                  <RecruitCard {...item.data} onJoin={() => onJoin?.(item.data)} />
+                  <RecruitCard
+                    clanTag={item.data.clan?.tag}
+                    deepLink={item.data.clan?.deepLink}
+                    name={item.data.clan?.name}
+                    description={item.data.clan?.description}
+                    labels={item.data.clan?.labels}
+                    members={item.data.clan?.members}
+                    warFrequency={item.data.clan?.warFrequency}
+                    language={item.data.clan?.language}
+                    callToAction={item.data.callToAction}
+                    onJoin={() => onJoin?.(item.data)}
+                  />
                 )}
               {item && item.type === 'chip' && <PageChip page={item.page} />}
             </div>


### PR DESCRIPTION
## Summary
- expand RecruitCard to show clan details, open slots progress, and label icons
- adapt RecruitFeed to supply new clan data structure

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891060062b4832cbc974c129484c409