### PR TITLE
Add recruit detail modal and richer clan cards

### DIFF
--- a/front-end/app/src/components/RecruitCard.jsx
+++ b/front-end/app/src/components/RecruitCard.jsx
@@ -1,84 +1,67 @@
-import React, { useState } from 'react';
+import React from 'react';
 import CachedImage from './CachedImage.jsx';
 
 export default function RecruitCard({
   clanTag,
   deepLink,
   name,
-  description,
   labels = [],
-  openSlots,
-  warFrequency,
   language,
-  callToAction,
+  memberCount,
+  warLeague,
+  clanLevel,
+  requiredTrophies,
+  requiredTownhallLevel,
   onJoin,
+  onClick,
 }) {
-  const [showLabels, setShowLabels] = useState(false);
-  const showOpenSlots = typeof openSlots === 'number' && !Number.isNaN(openSlots);
-
-  function handleClick() {
-    setShowLabels((s) => !s);
-  }
-
   return (
     <div
       role="button"
       tabIndex={0}
-      onClick={handleClick}
-      className="w-full text-left p-3 border-b bg-white"
+      onClick={onClick}
+      className="w-full text-left p-3 border rounded bg-white"
     >
       <div className="flex items-center justify-between">
         <h3 className="font-semibold">{name}</h3>
-        <a
-          href={deepLink}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={(e) => {
-            e.stopPropagation();
-            onJoin?.();
-          }}
-          className="text-xs text-slate-500"
-        >
-          {clanTag}
-        </a>
+        {deepLink && (
+          <a
+            href={deepLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => {
+              e.stopPropagation();
+              onJoin?.();
+            }}
+            className="text-xs text-slate-500"
+          >
+            {clanTag}
+          </a>
+        )}
       </div>
-      {(warFrequency || language) && (
+      {language && (
         <p className="text-xs text-slate-500 mt-1">
-          {warFrequency}
-          {warFrequency && language ? ' • ' : ''}
-          {typeof language === 'string' ? language : language?.name}
+          {typeof language === 'string' ? language : language.name}
         </p>
       )}
-      {description && (
-        <p className="text-sm line-clamp-2 mt-1 text-slate-700">{description}</p>
-      )}
-      {callToAction && (
-        <p className="text-sm line-clamp-2 mt-1 text-slate-700">{callToAction}</p>
-      )}
-      {showOpenSlots && (
-        <div className="mt-2">
-          <div className="h-2 bg-slate-200 rounded">
-            <div
-              className="h-2 bg-blue-500 rounded"
-              style={{ width: `${(openSlots / 50) * 100}%` }}
-            />
-          </div>
-          <p className="text-xs text-slate-500 mt-1">{openSlots} open slots</p>
-        </div>
-      )}
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-sm text-slate-700">
+        {typeof memberCount === 'number' && (
+          <span>{memberCount}/50 members</span>
+        )}
+        {warLeague?.name && <span>{warLeague.name}</span>}
+        {clanLevel && <span>Level {clanLevel}</span>}
+        {requiredTrophies && <span>{requiredTrophies}+ trophies</span>}
+        {requiredTownhallLevel && <span>TH {requiredTownhallLevel}+</span>}
+      </div>
       {labels.length > 0 && (
-        <div className="flex gap-2 mt-2">
+        <div className="flex gap-2 mt-2 flex-wrap">
           {labels.map((l) => (
-            <div key={l.id || l.name} className="flex flex-col items-center w-12">
-              <CachedImage
-                src={l.iconUrls?.small || l.iconUrls?.medium}
-                alt={l.name}
-                className="w-8 h-8"
-              />
-              {showLabels && (
-                <p className="text-xs text-slate-500 mt-1 text-center">{l.name}</p>
-              )}
-            </div>
+            <CachedImage
+              key={l.id || l.name}
+              src={l.iconUrls?.small || l.iconUrls?.medium}
+              alt={l.name}
+              className="w-8 h-8"
+            />
           ))}
         </div>
       )}

--- a/front-end/app/src/components/RecruitCard.test.jsx
+++ b/front-end/app/src/components/RecruitCard.test.jsx
@@ -7,29 +7,31 @@ vi.mock('./CachedImage.jsx', () => ({
   default: (props) => <img {...props} />,
 }));
 
-test('renders recruit card and toggles label names', () => {
-  const labels = [{ id: 1, name: 'Label1', iconUrls: { small: '/l1.png' } }];
+test('renders summary info and handles click', () => {
+  const handleClick = vi.fn();
   render(
     <RecruitCard
       clanTag="#CLAN"
       deepLink="https://link"
       name="Clan"
-      description="Desc"
-      labels={labels}
-      openSlots={10}
-      warFrequency="Always"
+      labels={[{ id: 1, name: 'Label1', iconUrls: { small: '/l1.png' } }]}
       language="EN"
-      callToAction="Join us"
+      memberCount={30}
+      warLeague={{ name: 'Gold League' }}
+      clanLevel={5}
+      requiredTrophies={1200}
+      requiredTownhallLevel={8}
+      onClick={handleClick}
     />
   );
-
-  expect(screen.getByRole('link', { name: '#CLAN' })).toHaveAttribute(
-    'href',
-    'https://link'
-  );
-  expect(screen.getByText('10 open slots')).toBeInTheDocument();
-  expect(screen.queryByText('Label1')).not.toBeInTheDocument();
+  expect(screen.getByText('Clan')).toBeInTheDocument();
+  expect(screen.getByText('EN')).toBeInTheDocument();
+  expect(screen.getByText('30/50 members')).toBeInTheDocument();
+  expect(screen.getByText('Gold League')).toBeInTheDocument();
+  expect(screen.getByText('Level 5')).toBeInTheDocument();
+  expect(screen.getByText('1200+ trophies')).toBeInTheDocument();
+  expect(screen.getByText('TH 8+')).toBeInTheDocument();
   fireEvent.click(screen.getByRole('button'));
-  expect(screen.getByText('Label1')).toBeInTheDocument();
+  expect(handleClick).toHaveBeenCalled();
 });
 

--- a/front-end/app/src/components/RecruitDetail.jsx
+++ b/front-end/app/src/components/RecruitDetail.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import Tabs from './Tabs.jsx';
+import RecruitCard from './RecruitCard.jsx';
+import useClanInfo from '../hooks/useClanInfo.js';
+import RiskRing from './RiskRing.jsx';
+import DonationRing from './DonationRing.jsx';
+
+export default function RecruitDetail({ clan, onClose }) {
+  const [tab, setTab] = useState('health');
+  const info = useClanInfo(clan?.clanTag);
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose}></div>
+      <div className="fixed inset-0 overflow-auto z-50 flex items-start justify-center p-4">
+        <div className="bg-white w-full max-w-xl rounded-xl shadow-xl">
+          <RecruitCard
+            clanTag={clan.clanTag}
+            deepLink={clan.deepLink}
+            name={clan.name}
+            labels={clan.labels}
+            language={clan.language}
+            memberCount={clan.memberCount}
+            warLeague={clan.warLeague}
+            clanLevel={clan.clanLevel}
+            requiredTrophies={clan.requiredTrophies}
+            requiredTownhallLevel={clan.requiredTownhallLevel}
+            onJoin={() => {}}
+          />
+          <Tabs
+            tabs={[
+              { value: 'health', label: 'Clan Health' },
+              { value: 'overview', label: 'Clan Overview' },
+            ]}
+            active={tab}
+            onChange={setTab}
+          />
+          {tab === 'health' && (
+            <div className="p-4">
+              {!info && (
+                <div className="text-center text-slate-500">Loading…</div>
+              )}
+              {info && (
+                <ul className="divide-y">
+                  {info.members?.map((m) => (
+                    <li
+                      key={m.tag}
+                      className="flex justify-between items-center py-2"
+                    >
+                      <span className="text-sm">{m.name}</span>
+                      <div className="flex items-center gap-2">
+                        <RiskRing score={m.risk_score} size={32} />
+                        <DonationRing
+                          donations={m.donations}
+                          received={m.donationsReceived}
+                          size={32}
+                        />
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+          {tab === 'overview' && (
+            <div className="p-4 text-center text-slate-500">Coming soon…</div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+

--- a/front-end/app/src/components/RecruitFeed.jsx
+++ b/front-end/app/src/components/RecruitFeed.jsx
@@ -4,9 +4,14 @@ import RecruitCard from './RecruitCard.jsx';
 import PageChip from './PageChip.jsx';
 import RecruitSkeleton from './RecruitSkeleton.jsx';
 
-const ROW_HEIGHT = 112;
-
-export default function RecruitFeed({ items, loadMore, hasMore, onJoin, initialPage = 1 }) {
+export default function RecruitFeed({
+  items,
+  loadMore,
+  hasMore,
+  onJoin,
+  onSelect,
+  initialPage = 1,
+}) {
   const parentRef = useRef(null);
   const withChips = [];
   items.forEach((item, i) => {
@@ -21,9 +26,10 @@ export default function RecruitFeed({ items, loadMore, hasMore, onJoin, initialP
   const virtualizer = useVirtualizer({
     count,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => ROW_HEIGHT,
+    estimateSize: () => 140,
+    measureElement: (el) => el.getBoundingClientRect().height,
     overscan: 8,
-    initialOffset: (initialPage - 1) * ROW_HEIGHT * 100,
+    initialOffset: (initialPage - 1) * 140 * 100,
   });
 
   const itemsVirtual = virtualizer.getVirtualItems();
@@ -49,6 +55,7 @@ export default function RecruitFeed({ items, loadMore, hasMore, onJoin, initialP
           return (
             <div
               key={virtual.index}
+              ref={virtualizer.measureElement}
               className="absolute top-0 left-0 w-full"
               style={{ transform: `translateY(${virtual.start}px)` }}
             >
@@ -59,13 +66,15 @@ export default function RecruitFeed({ items, loadMore, hasMore, onJoin, initialP
                     clanTag={item.data.clanTag}
                     deepLink={item.data.deepLink}
                     name={item.data.name}
-                    description={item.data.description}
                     labels={item.data.labels}
-                    openSlots={item.data.openSlots}
-                    warFrequency={item.data.warFrequency}
                     language={item.data.language}
-                    callToAction={item.data.callToAction}
+                    memberCount={item.data.memberCount}
+                    warLeague={item.data.warLeague}
+                    clanLevel={item.data.clanLevel}
+                    requiredTrophies={item.data.requiredTrophies}
+                    requiredTownhallLevel={item.data.requiredTownhallLevel}
                     onJoin={() => onJoin?.(item.data)}
+                    onClick={() => onSelect?.(item.data)}
                   />
                 )}
               {item && item.type === 'chip' && <PageChip page={item.page} />}

--- a/front-end/app/src/hooks/useRecruitFeed.js
+++ b/front-end/app/src/hooks/useRecruitFeed.js
@@ -39,6 +39,12 @@ export default function useRecruitFeed(filters) {
     }
     const normalized = data.items.map((item) => {
       const { clan = {}, call_to_action, callToAction, ...rest } = item.data || {};
+      const memberCount =
+        rest.memberCount ??
+        clan.members ??
+        (typeof (rest.openSlots ?? clan.openSlots) === 'number'
+          ? 50 - (rest.openSlots ?? clan.openSlots)
+          : undefined);
       return {
         ...item,
         data: {
@@ -49,8 +55,14 @@ export default function useRecruitFeed(filters) {
           description: clan.description,
           labels: clan.labels,
           warFrequency: clan.warFrequency,
+          warLeague: clan.warLeague,
+          clanLevel: clan.clanLevel,
           language: clan.chatLanguage ?? clan.language,
           openSlots: rest.openSlots ?? clan.openSlots,
+          memberCount,
+          requiredTrophies: clan.requiredTrophies,
+          requiredTownhallLevel:
+            clan.requiredTownhallLevel ?? clan.requiredTownHallLevel,
           callToAction: call_to_action ?? callToAction,
         },
       };

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import Tabs from '../components/Tabs.jsx';
 import DiscoveryBar from '../components/DiscoveryBar.jsx';
 import RecruitFeed from '../components/RecruitFeed.jsx';
 import PlayerRecruitFeed from '../components/PlayerRecruitFeed.jsx';
 import ClanPostForm from '../components/ClanPostForm.jsx';
+import RecruitDetail from '../components/RecruitDetail.jsx';
 import useRecruitFeed from '../hooks/useRecruitFeed.js';
 import usePlayerRecruitFeed from '../hooks/usePlayerRecruitFeed.js';
 import { fetchJSON } from '../lib/api.js';
@@ -17,6 +18,7 @@ export default function Scout() {
   const playerFeed = usePlayerRecruitFeed(filters);
   const [params] = useSearchParams();
   const page = parseInt(params.get('page') || '1', 10);
+  const [selected, setSelected] = useState(null);
 
   function joinClan(clan) {
     if (!navigator.onLine && 'serviceWorker' in navigator && 'SyncManager' in window) {
@@ -63,6 +65,10 @@ export default function Scout() {
     fetchJSON(`/invite/${player.id}`, { method: 'POST' }).catch(() => {});
   }
 
+  useEffect(() => {
+    setSelected(null);
+  }, [active]);
+
   return (
     <div className="h-full flex flex-col">
       <Tabs
@@ -83,6 +89,7 @@ export default function Scout() {
               loadMore={feed.loadMore}
               hasMore={feed.hasMore}
               onJoin={joinClan}
+              onSelect={setSelected}
               initialPage={page}
             />
           </div>
@@ -115,6 +122,9 @@ export default function Scout() {
             />
           </div>
         </>
+      )}
+      {selected && (
+        <RecruitDetail clan={selected} onClose={() => setSelected(null)} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- enrich useRecruitFeed normalization with war league, clan level, trophy and TH requirements, and member counts
- replace RecruitCard with a flexible summary card and support variable-height virtualization
- add RecruitDetail modal with clan health tab and wire it to Scout page

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_689128057d98832ca764b92cb9be9950