### PR TITLE
Populate recruit feed clan details and allow modal dismissal

### DIFF
--- a/back-end/app/services/recruit_service.py
+++ b/back-end/app/services/recruit_service.py
@@ -36,10 +36,9 @@ def list_posts(
 
     items: List[Dict[str, object]] = []
     for post, clan in rows[:PAGE_SIZE]:
-        clan_data = dict(clan.data or {})
-        clan_data.setdefault("tag", clan.tag)
+        clan_data = {**(clan.data or {}), "tag": clan.tag}
         if clan.deep_link:
-            clan_data.setdefault("deep_link", clan.deep_link)
+            clan_data["deep_link"] = clan.deep_link
         items.append(
             {
                 "id": post.id,

--- a/front-end/app/src/components/RecruitDetail.jsx
+++ b/front-end/app/src/components/RecruitDetail.jsx
@@ -15,8 +15,14 @@ export default function RecruitDetail({ clan, onClose }) {
   return (
     <>
       <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose}></div>
-      <div className="fixed inset-0 overflow-auto z-50 flex items-start justify-center p-4">
-        <div className="bg-white w-full max-w-xl rounded-xl shadow-xl">
+      <div
+        className="fixed inset-0 overflow-auto z-50 flex items-start justify-center p-4"
+        onClick={onClose}
+      >
+        <div
+          className="bg-white w-full max-w-xl rounded-xl shadow-xl"
+          onClick={(e) => e.stopPropagation()}
+        >
           <RecruitCard
             clanTag={clan.clanTag}
             deepLink={clan.deepLink}

--- a/front-end/app/src/components/RecruitDetail.test.jsx
+++ b/front-end/app/src/components/RecruitDetail.test.jsx
@@ -1,0 +1,35 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import RecruitDetail from './RecruitDetail.jsx';
+
+vi.mock('./RecruitCard.jsx', () => ({
+  default: (props) => <div data-testid="card">{props.name}</div>,
+}));
+
+const clan = {
+  clanTag: '#1',
+  deepLink: 'link',
+  name: 'Clan',
+  labels: [],
+  language: 'EN',
+  memberCount: 10,
+  warLeague: { name: 'Gold' },
+  clanLevel: 3,
+  requiredTrophies: 1000,
+  requiredTownhallLevel: 9,
+};
+
+test('outside click closes modal', () => {
+  const handleClose = vi.fn();
+  render(<RecruitDetail clan={clan} onClose={handleClose} />);
+  fireEvent.click(document.querySelector('.z-50'));
+  expect(handleClose).toHaveBeenCalled();
+});
+
+test('inside click does not close modal', () => {
+  const handleClose = vi.fn();
+  render(<RecruitDetail clan={clan} onClose={handleClose} />);
+  fireEvent.click(document.querySelector('.bg-white'));
+  expect(handleClose).not.toHaveBeenCalled();
+});

--- a/front-end/app/src/hooks/useRecruitFeed.js
+++ b/front-end/app/src/hooks/useRecruitFeed.js
@@ -38,17 +38,16 @@ export default function useRecruitFeed(filters) {
       }
     }
     const normalized = data.items.map((item) => {
-      const { clan = {}, call_to_action, callToAction, ...rest } = item.data || {};
+      const { clan = {}, call_to_action, callToAction, openSlots, memberCount: mCount } = item;
       const memberCount =
-        rest.memberCount ??
+        mCount ??
         clan.members ??
-        (typeof (rest.openSlots ?? clan.openSlots) === 'number'
-          ? 50 - (rest.openSlots ?? clan.openSlots)
+        (typeof (openSlots ?? clan.openSlots) === 'number'
+          ? 50 - (openSlots ?? clan.openSlots)
           : undefined);
       return {
         ...item,
         data: {
-          ...rest,
           clanTag: clan.tag,
           deepLink: clan.deep_link ?? clan.deepLink,
           name: clan.name,
@@ -58,7 +57,7 @@ export default function useRecruitFeed(filters) {
           warLeague: clan.warLeague,
           clanLevel: clan.clanLevel,
           language: clan.chatLanguage ?? clan.language,
-          openSlots: rest.openSlots ?? clan.openSlots,
+          openSlots: openSlots ?? clan.openSlots,
           memberCount,
           requiredTrophies: clan.requiredTrophies,
           requiredTownhallLevel:

--- a/front-end/app/src/hooks/useRecruitFeed.test.jsx
+++ b/front-end/app/src/hooks/useRecruitFeed.test.jsx
@@ -42,18 +42,16 @@ describe('useRecruitFeed', () => {
     const data = {
       items: [
         {
-          data: {
-            clan: {
-              tag: '#1',
-              name: 'Clan',
-              warLeague: { name: 'Gold' },
-              clanLevel: 3,
-              requiredTrophies: 1000,
-              requiredTownhallLevel: 9,
-              members: 20,
-              labels: [],
-              language: 'EN',
-            },
+          clan: {
+            tag: '#1',
+            name: 'Clan',
+            warLeague: { name: 'Gold' },
+            clanLevel: 3,
+            requiredTrophies: 1000,
+            requiredTownhallLevel: 9,
+            members: 20,
+            labels: [],
+            language: 'EN',
           },
         },
       ],

--- a/tests/test_recruit_service.py
+++ b/tests/test_recruit_service.py
@@ -56,6 +56,7 @@ def test_list_posts():
                 "description": "D",
                 "chatLanguage": {"name": "English"},
                 "warFrequency": "always",
+                "warLeague": {"name": "Gold"},
                 "labels": [1],
             },
         )
@@ -64,3 +65,5 @@ def test_list_posts():
         items, _ = recruit_service.list_posts(None, {})
         assert items[0]["clan"]["tag"] == "TAG"
         assert items[0]["clan"]["members"] == 40
+        assert items[0]["clan"]["name"] == "N"
+        assert items[0]["clan"]["warLeague"]["name"] == "Gold"


### PR DESCRIPTION
## Summary
- include full clan JSON in recruitment feed responses
- normalize client-side parsing of recruit feed
- allow closing recruit detail modal by clicking outside and add tests

## Testing
- `ruff check back-end coclib db`
- `nox -s lint tests`
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689141213d50832c8a808c9a09607ffc