### PR TITLE
Fix recruit feed parsing and player recruit endpoint

### DIFF
--- a/front-end/app/src/hooks/usePlayerRecruitFeed.js
+++ b/front-end/app/src/hooks/usePlayerRecruitFeed.js
@@ -12,7 +12,7 @@ export default function usePlayerRecruitFeed(filters) {
     const params = new URLSearchParams();
     params.set('pageCursor', c || '');
     if (filters.q) params.set('q', filters.q);
-    const path = `/player-recruit?${params.toString()}`;
+    const path = `/recruiting/player-recruit?${params.toString()}`;
     let data;
     if (typeof window !== 'undefined' && 'caches' in window && (!c || c === '')) {
       const cache = await caches.open('player-recruit');

--- a/front-end/app/src/hooks/useRecruitFeed.js
+++ b/front-end/app/src/hooks/useRecruitFeed.js
@@ -38,7 +38,14 @@ export default function useRecruitFeed(filters) {
       }
     }
     const normalized = data.items.map((item) => {
-      const { clan = {}, call_to_action, callToAction, openSlots, memberCount: mCount } = item;
+      const src = item.data || item;
+      const {
+        clan = {},
+        call_to_action,
+        callToAction,
+        openSlots,
+        memberCount: mCount,
+      } = src;
       const memberCount =
         mCount ??
         clan.members ??

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -44,7 +44,7 @@ export default function Scout() {
   async function postPlayer(e) {
     e.preventDefault();
     try {
-      await fetchJSON('/player-recruit', {
+      await fetchJSON('/recruiting/player-recruit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ description: message }),

--- a/front-end/app/src/pages/Scout.test.jsx
+++ b/front-end/app/src/pages/Scout.test.jsx
@@ -17,8 +17,9 @@ describe('Scout page', () => {
       if (path === '/user/me') return Promise.resolve({ player_tag: 'PLAYER' });
       if (path.startsWith('/player/')) return Promise.resolve({ clanTag: 'CLAN' });
       if (path.startsWith('/clan/')) return Promise.resolve({ tag: 'CLAN', name: 'Clan', labels: [] });
+      if (path.startsWith('/recruiting/player-recruit'))
+        return Promise.resolve({ items: [], next: null });
       if (path.startsWith('/recruiting')) return Promise.resolve({ items: [], next: null });
-      if (path.startsWith('/player-recruit')) return Promise.resolve({ items: [], next: null });
       return Promise.resolve({});
     });
   });


### PR DESCRIPTION
## Summary
- Normalize recruitment feed entries to read clan data from nested API objects
- Point player recruiting features to `/recruiting/player-recruit` to resolve 404 errors
- Update tests to reflect new endpoint

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_68914a428d70832c9ea32c48bc538c6a