### PR TITLE
Fix recruit cards blank rows on scout page

### DIFF
--- a/front-end/app/src/components/RecruitFeed.jsx
+++ b/front-end/app/src/components/RecruitFeed.jsx
@@ -18,7 +18,7 @@ export default function RecruitFeed({
     if (i > 0 && i % 100 === 0) {
       withChips.push({ type: 'chip', page: i / 100 + 1 });
     }
-    withChips.push({ type: 'card', data: item });
+    withChips.push({ type: 'card', data: { ...item.data, id: item.id } });
   });
 
   const count = hasMore ? withChips.length + 1 : withChips.length;

--- a/front-end/app/src/components/RecruitFeed.test.jsx
+++ b/front-end/app/src/components/RecruitFeed.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import RecruitFeed from './RecruitFeed.jsx';
+import { vi } from 'vitest';
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: () => ({
+    getTotalSize: () => 140,
+    getVirtualItems: () => [{ index: 0, start: 0 }],
+    measureElement: () => {},
+  }),
+}));
+
+function noop() {}
+
+test('renders recruit card with name', () => {
+  const items = [
+    {
+      id: 1,
+      data: {
+        clanTag: '#TAG',
+        name: 'Test Clan',
+        labels: [],
+        language: 'English',
+        memberCount: 10,
+      },
+    },
+  ];
+  render(
+    <RecruitFeed items={items} loadMore={noop} hasMore={false} onJoin={noop} onSelect={noop} />
+  );
+  expect(screen.getByText('Test Clan')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- fix RecruitFeed to pass normalized card data so scout page cards are populated
- add tests ensuring RecruitFeed renders card info

## Testing
- `nox -s lint tests`
- `npm --prefix front-end/app test`


------
https://chatgpt.com/codex/tasks/task_e_68916cfa5d1c832ca69196b09c0c357c