### PR TITLE
Fix recruit posting glitches and card layout

### DIFF
--- a/front-end/app/src/components/PlayerRecruitCard.jsx
+++ b/front-end/app/src/components/PlayerRecruitCard.jsx
@@ -14,7 +14,7 @@ export default function PlayerRecruitCard({
       type="button"
       aria-label={`Invite ${name}`}
       onClick={onInvite}
-      className="w-full text-left p-3 border-b flex gap-3 bg-white"
+      className="w-full text-left p-3 border rounded-md flex gap-3 bg-white shadow-sm"
     >
       {avatar && <img src={avatar} alt="avatar" className="w-12 h-12 rounded" />}
       <div className="flex-1">
@@ -23,7 +23,7 @@ export default function PlayerRecruitCard({
           <span className="text-xs text-slate-500">{age}</span>
         </div>
         {tag && <p className="text-xs text-slate-500">{tag}</p>}
-        <p className="text-sm line-clamp-2 mt-1 text-slate-700">{description}</p>
+        <p className="text-sm mt-1 text-slate-700 whitespace-pre-wrap">{description}</p>
       </div>
     </button>
   );

--- a/front-end/app/src/components/PlayerRecruitFeed.jsx
+++ b/front-end/app/src/components/PlayerRecruitFeed.jsx
@@ -22,6 +22,7 @@ export default function PlayerRecruitFeed({ items, loadMore, hasMore, onInvite, 
     count,
     getScrollElement: () => parentRef.current,
     estimateSize: () => ROW_HEIGHT,
+    measureElement: (el) => el.getBoundingClientRect().height,
     overscan: 8,
     initialOffset: (initialPage - 1) * ROW_HEIGHT * 100,
   });
@@ -49,7 +50,8 @@ export default function PlayerRecruitFeed({ items, loadMore, hasMore, onInvite, 
           return (
             <div
               key={virtual.index}
-              className="absolute top-0 left-0 w-full"
+              ref={virtualizer.measureElement}
+              className="absolute top-0 left-0 w-full p-2"
               style={{ transform: `translateY(${virtual.start}px)` }}
             >
               {!item && <RecruitSkeleton />}

--- a/front-end/app/src/components/RecruitCard.jsx
+++ b/front-end/app/src/components/RecruitCard.jsx
@@ -29,7 +29,7 @@ export default function RecruitCard({
       role="button"
       tabIndex={0}
       onClick={onClick}
-      className="w-full text-left p-3 border rounded bg-white"
+      className="w-full text-left p-3 border rounded-md bg-white shadow-sm"
     >
       <div className="flex items-center justify-between">
         <h3 className="font-semibold">{name}</h3>

--- a/front-end/app/src/components/RecruitFeed.jsx
+++ b/front-end/app/src/components/RecruitFeed.jsx
@@ -56,7 +56,7 @@ export default function RecruitFeed({
             <div
               key={virtual.index}
               ref={virtualizer.measureElement}
-              className="absolute top-0 left-0 w-full"
+              className="absolute top-0 left-0 w-full p-2"
               style={{ transform: `translateY(${virtual.start}px)` }}
             >
               {!item && <RecruitSkeleton />}

--- a/front-end/app/src/hooks/usePlayerRecruitFeed.js
+++ b/front-end/app/src/hooks/usePlayerRecruitFeed.js
@@ -8,6 +8,7 @@ export default function usePlayerRecruitFeed(filters) {
   const [hasMore, setHasMore] = useState(true);
 
   async function fetchPage(c) {
+    if (loading) return;
     setLoading(true);
     const params = new URLSearchParams();
     params.set('pageCursor', c || '');

--- a/front-end/app/src/hooks/useRecruitFeed.js
+++ b/front-end/app/src/hooks/useRecruitFeed.js
@@ -8,6 +8,7 @@ export default function useRecruitFeed(filters) {
   const [hasMore, setHasMore] = useState(true);
 
   async function fetchPage(c) {
+    if (loading) return;
     setLoading(true);
     const params = new URLSearchParams();
     params.set('pageCursor', c || '');

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -40,9 +40,12 @@ export default function Scout() {
   const playerItems = playerFeed.items;
 
   const [message, setMessage] = useState('');
+  const [posting, setPosting] = useState(false);
 
   async function postPlayer(e) {
     e.preventDefault();
+    if (posting || !message.trim()) return;
+    setPosting(true);
     try {
       await fetchJSON('/recruiting/player-recruit', {
         method: 'POST',
@@ -56,8 +59,13 @@ export default function Scout() {
       }
       setMessage('');
       playerFeed.reload();
+      window.dispatchEvent(
+        new CustomEvent('toast', { detail: 'Recruit post created!' })
+      );
     } catch (err) {
       // ignore
+    } finally {
+      setPosting(false);
     }
   }
 
@@ -106,9 +114,10 @@ export default function Scout() {
             />
             <button
               type="submit"
-              className="bg-blue-500 text-white py-1 px-2 rounded self-start"
+              disabled={posting}
+              className="bg-blue-500 text-white py-1 px-2 rounded self-start disabled:opacity-50"
             >
-              Post
+              {posting ? 'Posting...' : 'Post'}
             </button>
           </form>
           <DiscoveryBar onChange={setFilters} />

--- a/front-end/app/src/pages/Scout.test.jsx
+++ b/front-end/app/src/pages/Scout.test.jsx
@@ -52,4 +52,25 @@ describe('Scout page', () => {
     fireEvent.click(screen.getByText('Need a Clan'));
     await screen.findByPlaceholderText('Describe yourself');
   });
+
+  it('posts a player recruit and clears form', async () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+    render(
+      <MemoryRouter>
+        <Scout />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByText('Need a Clan'));
+    const textarea = await screen.findByPlaceholderText('Describe yourself');
+    fireEvent.change(textarea, { target: { value: 'Looking for clan' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Post' }));
+    await screen.findByRole('button', { name: 'Post' });
+    expect(fetchJSON).toHaveBeenCalledWith(
+      '/recruiting/player-recruit',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(textarea.value).toBe('');
+    expect(dispatchSpy).toHaveBeenCalled();
+    dispatchSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- prevent duplicate fetches in recruit feeds
- add confirmation and disable multiple posts on player recruit form
- space out recruit cards with rounded borders and dynamic heights

## Testing
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_6891753381c0832cab6b0f730de1002c