### PR TITLE
Fix recruit feed duplication and layout

### DIFF
--- a/front-end/app/src/components/RecruitFeed.test.jsx
+++ b/front-end/app/src/components/RecruitFeed.test.jsx
@@ -2,15 +2,6 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import RecruitFeed from './RecruitFeed.jsx';
-import { vi } from 'vitest';
-
-vi.mock('@tanstack/react-virtual', () => ({
-  useVirtualizer: () => ({
-    getTotalSize: () => 140,
-    getVirtualItems: () => [{ index: 0, start: 0 }],
-    measureElement: () => {},
-  }),
-}));
 
 function noop() {}
 


### PR DESCRIPTION
## Summary
- simplify recruit feed and prevent duplicate loading
- lay out recruit posts vertically with clear spacing
- update unit test to match new feed implementation

## Testing
- `npm install`
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_68918321e00c832ca4eba8a4787384a5