### PR TITLE
Fix duplicated and overlapping recruit posts

### DIFF
--- a/front-end/app/src/components/RecruitFeed.test.jsx
+++ b/front-end/app/src/components/RecruitFeed.test.jsx
@@ -2,15 +2,6 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import RecruitFeed from './RecruitFeed.jsx';
-import { vi } from 'vitest';
-
-vi.mock('@tanstack/react-virtual', () => ({
-  useVirtualizer: () => ({
-    getTotalSize: () => 140,
-    getVirtualItems: () => [{ index: 0, start: 0 }],
-    measureElement: () => {},
-  }),
-}));
 
 function noop() {}
 

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -92,13 +92,12 @@ export default function Scout() {
           <ClanPostForm onPosted={feed.reload} />
           <DiscoveryBar onChange={setFilters} />
           <div className="flex-1">
-            <RecruitFeed
+          <RecruitFeed
               items={items}
               loadMore={feed.loadMore}
               hasMore={feed.hasMore}
               onJoin={joinClan}
               onSelect={setSelected}
-              initialPage={page}
             />
           </div>
         </>
@@ -122,12 +121,11 @@ export default function Scout() {
           </form>
           <DiscoveryBar onChange={setFilters} />
           <div className="flex-1">
-            <PlayerRecruitFeed
+          <PlayerRecruitFeed
               items={playerItems}
               loadMore={playerFeed.loadMore}
               hasMore={playerFeed.hasMore}
               onInvite={invitePlayer}
-              initialPage={page}
             />
           </div>
         </>


### PR DESCRIPTION
## Summary
- rewrite RecruitFeed to use simple scroll list and avoid duplicated posts
- mirror new scroll-based layout in PlayerRecruitFeed
- update Scout page and tests

## Testing
- `nox -s lint`
- `nox -s tests`
- `cd front-end/app && npm install`
- `cd front-end/app && npm test`
- `cd front-end/app && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68918321e00c832ca4eba8a4787384a5