### PR TITLE
Enhance recruiting feedback and card layout in Scout page

### DIFF
--- a/front-end/app/src/components/ClanPostForm.jsx
+++ b/front-end/app/src/components/ClanPostForm.jsx
@@ -7,6 +7,7 @@ export default function ClanPostForm({ onPosted }) {
   const [clan, setClan] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [posting, setPosting] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -36,6 +37,8 @@ export default function ClanPostForm({ onPosted }) {
 
   async function handleSubmit(e) {
     e.preventDefault();
+    if (posting || !callToAction.trim()) return;
+    setPosting(true);
     try {
       await fetchJSON('/recruiting/recruit', {
         method: 'POST',
@@ -48,12 +51,14 @@ export default function ClanPostForm({ onPosted }) {
         await Promise.all(keys.map((k) => cache.delete(k)));
       }
       setCallToAction('');
-      onPosted?.();
+      await onPosted?.();
       window.dispatchEvent(
         new CustomEvent('toast', { detail: 'Recruiting post created!' })
       );
     } catch (err) {
       // ignore
+    } finally {
+      setPosting(false);
     }
   }
 
@@ -91,9 +96,10 @@ export default function ClanPostForm({ onPosted }) {
       />
       <button
         type="submit"
-        className="bg-blue-500 text-white py-1 px-2 rounded self-start"
+        disabled={posting}
+        className="bg-blue-500 text-white py-1 px-2 rounded self-start disabled:opacity-50"
       >
-        Post
+        {posting ? 'Posting...' : 'Post'}
       </button>
     </form>
   );

--- a/front-end/app/src/components/RecruitCard.jsx
+++ b/front-end/app/src/components/RecruitCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import CachedImage from './CachedImage.jsx';
+import { Users, Shield, Trophy, Crown, Home } from 'lucide-react';
 
 export default function RecruitCard({
   clanTag,
@@ -14,6 +15,7 @@ export default function RecruitCard({
   clanLevel,
   requiredTrophies,
   requiredTownhallLevel,
+  callToAction,
   onJoin,
   onClick,
 }) {
@@ -53,12 +55,42 @@ export default function RecruitCard({
           {typeof lang === 'string' ? lang : lang.name}
         </p>
       )}
-      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-sm text-slate-700">
-        {typeof count === 'number' && <span>{count}/50 members</span>}
-        {warLeague?.name && <span>{warLeague.name}</span>}
-        {clanLevel && <span>Level {clanLevel}</span>}
-        {requiredTrophies && <span>{requiredTrophies}+ trophies</span>}
-        {requiredTownhallLevel && <span>TH {requiredTownhallLevel}+</span>}
+      {callToAction && (
+        <p className="mt-2 text-sm text-slate-700 whitespace-pre-line">
+          {callToAction}
+        </p>
+      )}
+      <div className="mt-2 grid grid-cols-2 gap-2 text-sm text-slate-700">
+        {typeof count === 'number' && (
+          <div className="flex items-center gap-1">
+            <Users className="w-4 h-4 text-slate-500" />
+            <span>{count}/50</span>
+          </div>
+        )}
+        {warLeague?.name && (
+          <div className="flex items-center gap-1">
+            <Shield className="w-4 h-4 text-slate-500" />
+            <span>{warLeague.name}</span>
+          </div>
+        )}
+        {clanLevel && (
+          <div className="flex items-center gap-1">
+            <Crown className="w-4 h-4 text-slate-500" />
+            <span>Lv {clanLevel}</span>
+          </div>
+        )}
+        {requiredTrophies && (
+          <div className="flex items-center gap-1">
+            <Trophy className="w-4 h-4 text-slate-500" />
+            <span>{requiredTrophies}+</span>
+          </div>
+        )}
+        {requiredTownhallLevel && (
+          <div className="flex items-center gap-1">
+            <Home className="w-4 h-4 text-slate-500" />
+            <span>TH {requiredTownhallLevel}+</span>
+          </div>
+        )}
       </div>
       {labels.length > 0 && (
         <div className="flex gap-2 mt-2 flex-wrap">

--- a/front-end/app/src/components/RecruitCard.test.jsx
+++ b/front-end/app/src/components/RecruitCard.test.jsx
@@ -21,15 +21,17 @@ test('renders summary info and handles click', () => {
       clanLevel={5}
       requiredTrophies={1200}
       requiredTownhallLevel={8}
+      callToAction="Join us!"
       onClick={handleClick}
     />
   );
   expect(screen.getByText('Clan')).toBeInTheDocument();
   expect(screen.getByText('EN')).toBeInTheDocument();
-  expect(screen.getByText('30/50 members')).toBeInTheDocument();
+  expect(screen.getByText('Join us!')).toBeInTheDocument();
+  expect(screen.getByText('30/50')).toBeInTheDocument();
   expect(screen.getByText('Gold League')).toBeInTheDocument();
-  expect(screen.getByText('Level 5')).toBeInTheDocument();
-  expect(screen.getByText('1200+ trophies')).toBeInTheDocument();
+  expect(screen.getByText('Lv 5')).toBeInTheDocument();
+  expect(screen.getByText('1200+')).toBeInTheDocument();
   expect(screen.getByText('TH 8+')).toBeInTheDocument();
   fireEvent.click(screen.getByRole('button'));
   expect(handleClick).toHaveBeenCalled();

--- a/front-end/app/src/components/RecruitDetail.jsx
+++ b/front-end/app/src/components/RecruitDetail.jsx
@@ -34,6 +34,7 @@ export default function RecruitDetail({ clan, onClose }) {
             clanLevel={clan.clanLevel}
             requiredTrophies={clan.requiredTrophies}
             requiredTownhallLevel={clan.requiredTownhallLevel}
+            callToAction={clan.callToAction}
             onJoin={() => {}}
           />
           <div className="p-4">

--- a/front-end/app/src/components/RecruitFeed.jsx
+++ b/front-end/app/src/components/RecruitFeed.jsx
@@ -36,6 +36,7 @@ export default function RecruitFeed({ items, loadMore, hasMore, onJoin, onSelect
         clanLevel={item.data.clanLevel}
         requiredTrophies={item.data.requiredTrophies}
         requiredTownhallLevel={item.data.requiredTownhallLevel}
+        callToAction={item.data.callToAction}
         onJoin={() => onJoin?.(item.data)}
         onClick={() => onSelect?.(item.data)}
       />


### PR DESCRIPTION
## Summary
- Show posting state, reload feed, and fire toast when creating a clan recruit post
- Display call-to-action and structured metrics with icons in recruit cards
- Pass call-to-action through feed and detail views so summary cards include it

## Testing
- `npm test`
- `npm run build`
- `nox -s lint tests`


------
https://chatgpt.com/codex/tasks/task_e_68918e61dfb8832cb7e119ece2045c0a