### PR TITLE
Restore clan details in recruiting listings

### DIFF
--- a/recruiting/src/main/java/com/clanboards/recruiting/model/Clan.java
+++ b/recruiting/src/main/java/com/clanboards/recruiting/model/Clan.java
@@ -1,0 +1,42 @@
+package com.clanboards.recruiting.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "clans")
+public class Clan {
+  @Id
+  @Column(name = "tag")
+  private String tag;
+
+  @Column(name = "deep_link")
+  private String deepLink;
+
+  @Lob
+  @Column(name = "data")
+  private String data;
+
+  public String getTag() {
+    return tag;
+  }
+
+  public void setTag(String tag) {
+    this.tag = tag;
+  }
+
+  public String getDeepLink() {
+    return deepLink;
+  }
+
+  public void setDeepLink(String deepLink) {
+    this.deepLink = deepLink;
+  }
+
+  public String getData() {
+    return data;
+  }
+
+  public void setData(String data) {
+    this.data = data;
+  }
+}

--- a/recruiting/src/main/java/com/clanboards/recruiting/repository/ClanRepository.java
+++ b/recruiting/src/main/java/com/clanboards/recruiting/repository/ClanRepository.java
@@ -1,0 +1,6 @@
+package com.clanboards.recruiting.repository;
+
+import com.clanboards.recruiting.model.Clan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClanRepository extends JpaRepository<Clan, String> {}

--- a/recruiting/src/main/java/com/clanboards/recruiting/service/RecruitService.java
+++ b/recruiting/src/main/java/com/clanboards/recruiting/service/RecruitService.java
@@ -1,11 +1,15 @@
 package com.clanboards.recruiting.service;
 
+import com.clanboards.recruiting.model.Clan;
 import com.clanboards.recruiting.model.PlayerRecruitPost;
 import com.clanboards.recruiting.model.RecruitJoin;
 import com.clanboards.recruiting.model.RecruitPost;
+import com.clanboards.recruiting.repository.ClanRepository;
 import com.clanboards.recruiting.repository.PlayerRecruitPostRepository;
 import com.clanboards.recruiting.repository.RecruitJoinRepository;
 import com.clanboards.recruiting.repository.RecruitPostRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -18,14 +22,20 @@ public class RecruitService {
   private final RecruitPostRepository recruitRepo;
   private final PlayerRecruitPostRepository playerRepo;
   private final RecruitJoinRepository joinRepo;
+  private final ClanRepository clanRepo;
+  private final ObjectMapper objectMapper;
 
   public RecruitService(
       RecruitPostRepository recruitRepo,
       PlayerRecruitPostRepository playerRepo,
-      RecruitJoinRepository joinRepo) {
+      RecruitJoinRepository joinRepo,
+      ClanRepository clanRepo,
+      ObjectMapper objectMapper) {
     this.recruitRepo = recruitRepo;
     this.playerRepo = playerRepo;
     this.joinRepo = joinRepo;
+    this.clanRepo = clanRepo;
+    this.objectMapper = objectMapper;
   }
 
   public List<Map<String, Object>> listRecruitPosts() {
@@ -36,9 +46,38 @@ public class RecruitService {
               m.put("id", p.getId());
               m.put("clanTag", p.getClanTag());
               m.put("callToAction", p.getCallToAction());
+
+              String normTag = normalizeTag(p.getClanTag());
+              Clan clan = clanRepo.findById(normTag).orElse(null);
+              if (clan != null) {
+                Map<String, Object> clanMap = new java.util.HashMap<>();
+                clanMap.put("tag", p.getClanTag());
+                String deepLink = clan.getDeepLink();
+                if (deepLink == null || deepLink.isBlank()) {
+                  deepLink =
+                      "https://link.clashofclans.com/?action=OpenClanProfile&tag=%23" + normTag;
+                }
+                clanMap.put("deep_link", deepLink);
+                String data = clan.getData();
+                if (data != null && !data.isBlank()) {
+                  try {
+                    Map<String, Object> parsed =
+                        objectMapper.readValue(data, new TypeReference<Map<String, Object>>() {});
+                    clanMap.putAll(parsed);
+                  } catch (Exception e) {
+                    // ignore malformed json
+                  }
+                }
+                m.put("clan", clanMap);
+              }
+
               return m;
             })
         .collect(Collectors.toList());
+  }
+
+  private static String normalizeTag(String tag) {
+    return tag == null ? "" : tag.replace("#", "").toUpperCase();
   }
 
   public void createRecruitPost(String clanTag, String callToAction) {

--- a/recruiting/src/test/java/com/clanboards/recruiting/RecruitControllerTest.java
+++ b/recruiting/src/test/java/com/clanboards/recruiting/RecruitControllerTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.clanboards.recruiting.model.Clan;
+import com.clanboards.recruiting.repository.ClanRepository;
 import com.clanboards.recruiting.repository.RecruitJoinRepository;
 import com.clanboards.recruiting.repository.RecruitPostRepository;
 import io.jsonwebtoken.Jwts;
@@ -24,6 +26,7 @@ class RecruitControllerTest {
   @Autowired private MockMvc mockMvc;
   @Autowired private RecruitPostRepository recruitPostRepository;
   @Autowired private RecruitJoinRepository recruitJoinRepository;
+  @Autowired private ClanRepository clanRepository;
 
   private static final byte[] KEY =
       "0123456789abcdef0123456789abcdef".getBytes(StandardCharsets.UTF_8);
@@ -42,6 +45,12 @@ class RecruitControllerTest {
 
   @Test
   void createAndListRecruit() throws Exception {
+    Clan clan = new Clan();
+    clan.setTag("ABC");
+    clan.setDeepLink("https://link.clashofclans.com/?action=OpenClanProfile&tag=%23ABC");
+    clan.setData("{\"name\":\"TestClan\",\"requiredTrophies\":1000}");
+    clanRepository.save(clan);
+
     mockMvc
         .perform(
             post("/api/v1/recruiting/recruit")
@@ -52,7 +61,9 @@ class RecruitControllerTest {
     mockMvc
         .perform(get("/api/v1/recruiting/recruit"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.items[0].clanTag").value("#ABC"));
+        .andExpect(jsonPath("$.items[0].clan.tag").value("#ABC"))
+        .andExpect(jsonPath("$.items[0].clan.requiredTrophies").value(1000))
+        .andExpect(jsonPath("$.items[0].clan.deep_link").value(clan.getDeepLink()));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- enrich recruiting service responses with clan metadata
- expose deep links and requirements for recruit posts
- cover clan enrichment with unit tests

## Testing
- `nox -s lint`
- `nox -s tests`
- `cd recruiting && ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6892c9ab7368832caae6a98ae8cd685d