### PR TITLE
Restore clan details in recruiting listings

### DIFF
--- a/recruiting/src/main/java/com/clanboards/recruiting/model/Clan.java
+++ b/recruiting/src/main/java/com/clanboards/recruiting/model/Clan.java
@@ -1,0 +1,45 @@
+package com.clanboards.recruiting.model;
+
+import jakarta.persistence.*;
+import java.util.Map;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "clans")
+public class Clan {
+  @Id
+  @Column(name = "tag")
+  private String tag;
+
+  @Column(name = "deep_link")
+  private String deepLink;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "data")
+  private Map<String, Object> data;
+
+  public String getTag() {
+    return tag;
+  }
+
+  public void setTag(String tag) {
+    this.tag = tag;
+  }
+
+  public String getDeepLink() {
+    return deepLink;
+  }
+
+  public void setDeepLink(String deepLink) {
+    this.deepLink = deepLink;
+  }
+
+  public Map<String, Object> getData() {
+    return data;
+  }
+
+  public void setData(Map<String, Object> data) {
+    this.data = data;
+  }
+}

--- a/recruiting/src/main/java/com/clanboards/recruiting/repository/ClanRepository.java
+++ b/recruiting/src/main/java/com/clanboards/recruiting/repository/ClanRepository.java
@@ -1,0 +1,6 @@
+package com.clanboards.recruiting.repository;
+
+import com.clanboards.recruiting.model.Clan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClanRepository extends JpaRepository<Clan, String> {}

--- a/recruiting/src/main/java/com/clanboards/recruiting/service/RecruitService.java
+++ b/recruiting/src/main/java/com/clanboards/recruiting/service/RecruitService.java
@@ -8,8 +8,6 @@ import com.clanboards.recruiting.repository.ClanRepository;
 import com.clanboards.recruiting.repository.PlayerRecruitPostRepository;
 import com.clanboards.recruiting.repository.RecruitJoinRepository;
 import com.clanboards.recruiting.repository.RecruitPostRepository;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
## Summary
- map clan `data` column as JSON to avoid Postgres type mismatch
- merge stored clan details into recruiting responses
- cover JSON mapping and deep link enrichment with tests

## Testing
- `nox -s lint`
- `nox -s tests`
- `cd recruiting && ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6892c9ab7368832caae6a98ae8cd685d