### PR TITLE
Revamp clan recruiting UI

### DIFF
--- a/front-end/app/src/components/ClanPostForm.jsx
+++ b/front-end/app/src/components/ClanPostForm.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchJSON } from '../lib/api.js';
 import Loading from './Loading.jsx';
+import RecruitCard from './RecruitCard.jsx';
 
 export default function ClanPostForm({ onPosted }) {
   const [callToAction, setCallToAction] = useState('');
@@ -71,22 +72,19 @@ export default function ClanPostForm({ onPosted }) {
     );
 
   return (
-    <form onSubmit={handleSubmit} className="p-3 border-b flex flex-col gap-2">
-      <div className="flex items-center gap-2">
-        {clan.badgeUrls?.small && (
-          <img src={clan.badgeUrls.small} alt="clan badge" className="w-8 h-8" />
-        )}
-        <div>
-          <div className="font-semibold">{clan.name}</div>
-          <div className="flex flex-wrap gap-1">
-            {clan.labels?.map((l) => (
-              <span key={l.id} className="text-xs bg-slate-200 px-1 rounded">
-                {l.name}
-              </span>
-            ))}
-          </div>
-        </div>
-      </div>
+    <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-2">
+      <RecruitCard
+        clanTag={clan.tag}
+        name={clan.name}
+        labels={clan.labels}
+        language={clan.language}
+        memberCount={clan.memberCount}
+        warLeague={clan.warLeague}
+        clanLevel={clan.clanLevel}
+        requiredTrophies={clan.requiredTrophies}
+        requiredTownhallLevel={clan.requiredTownhallLevel}
+        callToAction={callToAction}
+      />
       <textarea
         name="callToAction"
         value={callToAction}

--- a/front-end/app/src/components/RecruitCard.jsx
+++ b/front-end/app/src/components/RecruitCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import CachedImage from './CachedImage.jsx';
-import { Users, Shield, Trophy, Crown, Home } from 'lucide-react';
+import { Users, Shield, Crown } from 'lucide-react';
 
 export default function RecruitCard({
   clanTag,
@@ -55,53 +55,72 @@ export default function RecruitCard({
           {typeof lang === 'string' ? lang : lang.name}
         </p>
       )}
-      {callToAction && (
-        <p className="mt-2 text-sm text-slate-700 whitespace-pre-line">
-          {callToAction}
-        </p>
+      {(requiredTownhallLevel || requiredTrophies) && (
+        <div className="mt-2">
+          <h4 className="text-xs font-semibold text-slate-500 uppercase">
+            Requirements
+          </h4>
+          <div className="flex gap-2 mt-1 flex-wrap">
+            {requiredTownhallLevel && (
+              <span className="bg-slate-200 px-2 py-0.5 rounded-full text-xs">
+                TH {requiredTownhallLevel}+
+              </span>
+            )}
+            {requiredTrophies && (
+              <span className="bg-slate-200 px-2 py-0.5 rounded-full text-xs">
+                {requiredTrophies}+
+              </span>
+            )}
+          </div>
+        </div>
       )}
-      <div className="mt-2 grid grid-cols-2 gap-2 text-sm text-slate-700">
-        {typeof count === 'number' && (
-          <div className="flex items-center gap-1">
-            <Users className="w-4 h-4 text-slate-500" />
-            <span>{count}/50</span>
+      {(typeof count === 'number' || warLeague?.name || clanLevel || labels.length > 0) && (
+        <div className="mt-2">
+          <h4 className="text-xs font-semibold text-slate-500 uppercase">
+            Clan Info
+          </h4>
+          <div className="mt-1 grid grid-cols-2 gap-2 text-sm text-slate-700">
+            {typeof count === 'number' && (
+              <div className="flex items-center gap-1">
+                <Users className="w-4 h-4 text-slate-500" />
+                <span>{count}/50</span>
+              </div>
+            )}
+            {warLeague?.name && (
+              <div className="flex items-center gap-1">
+                <Shield className="w-4 h-4 text-slate-500" />
+                <span>{warLeague.name}</span>
+              </div>
+            )}
+            {clanLevel && (
+              <div className="flex items-center gap-1">
+                <Crown className="w-4 h-4 text-slate-500" />
+                <span>Lv {clanLevel}</span>
+              </div>
+            )}
           </div>
-        )}
-        {warLeague?.name && (
-          <div className="flex items-center gap-1">
-            <Shield className="w-4 h-4 text-slate-500" />
-            <span>{warLeague.name}</span>
-          </div>
-        )}
-        {clanLevel && (
-          <div className="flex items-center gap-1">
-            <Crown className="w-4 h-4 text-slate-500" />
-            <span>Lv {clanLevel}</span>
-          </div>
-        )}
-        {requiredTrophies && (
-          <div className="flex items-center gap-1">
-            <Trophy className="w-4 h-4 text-slate-500" />
-            <span>{requiredTrophies}+</span>
-          </div>
-        )}
-        {requiredTownhallLevel && (
-          <div className="flex items-center gap-1">
-            <Home className="w-4 h-4 text-slate-500" />
-            <span>TH {requiredTownhallLevel}+</span>
-          </div>
-        )}
-      </div>
-      {labels.length > 0 && (
-        <div className="flex gap-2 mt-2 flex-wrap">
-          {labels.map((l) => (
-            <CachedImage
-              key={l.id || l.name}
-              src={l.iconUrls?.small || l.iconUrls?.medium}
-              alt={l.name}
-              className="w-8 h-8"
-            />
-          ))}
+          {labels.length > 0 && (
+            <div className="flex gap-2 mt-2 flex-wrap">
+              {labels.map((l) => (
+                <CachedImage
+                  key={l.id || l.name}
+                  src={l.iconUrls?.small || l.iconUrls?.medium}
+                  alt={l.name}
+                  className="w-8 h-8"
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+      {callToAction && (
+        <div className="mt-2">
+          <h4 className="text-xs font-semibold text-slate-500 uppercase">
+            Description
+          </h4>
+          <p className="mt-1 text-sm text-slate-700 whitespace-pre-line">
+            {callToAction}
+          </p>
         </div>
       )}
     </div>

--- a/front-end/app/src/components/RecruitCard.test.jsx
+++ b/front-end/app/src/components/RecruitCard.test.jsx
@@ -27,6 +27,9 @@ test('renders summary info and handles click', () => {
   );
   expect(screen.getByText('Clan')).toBeInTheDocument();
   expect(screen.getByText('EN')).toBeInTheDocument();
+  expect(screen.getByText('Requirements')).toBeInTheDocument();
+  expect(screen.getByText('Clan Info')).toBeInTheDocument();
+  expect(screen.getByText('Description')).toBeInTheDocument();
   expect(screen.getByText('Join us!')).toBeInTheDocument();
   expect(screen.getByText('30/50')).toBeInTheDocument();
   expect(screen.getByText('Gold League')).toBeInTheDocument();

--- a/front-end/app/src/pages/Scout.jsx
+++ b/front-end/app/src/pages/Scout.jsx
@@ -6,6 +6,8 @@ import RecruitFeed from '../components/RecruitFeed.jsx';
 import PlayerRecruitFeed from '../components/PlayerRecruitFeed.jsx';
 import ClanPostForm from '../components/ClanPostForm.jsx';
 import RecruitDetail from '../components/RecruitDetail.jsx';
+import BottomSheet from '../components/BottomSheet.jsx';
+import { Plus } from 'lucide-react';
 import useRecruitFeed from '../hooks/useRecruitFeed.js';
 import usePlayerRecruitFeed from '../hooks/usePlayerRecruitFeed.js';
 import { fetchJSON } from '../lib/api.js';
@@ -19,6 +21,7 @@ export default function Scout() {
   const [params] = useSearchParams();
   const page = parseInt(params.get('page') || '1', 10);
   const [selected, setSelected] = useState(null);
+  const [showForm, setShowForm] = useState(false);
 
   function joinClan(clan) {
     if (!navigator.onLine && 'serviceWorker' in navigator && 'SyncManager' in window) {
@@ -89,10 +92,9 @@ export default function Scout() {
       />
       {active === 'find' && (
         <>
-          <ClanPostForm onPosted={feed.reload} />
           <DiscoveryBar onChange={setFilters} />
           <div className="flex-1">
-          <RecruitFeed
+            <RecruitFeed
               items={items}
               loadMore={feed.loadMore}
               hasMore={feed.hasMore}
@@ -100,6 +102,21 @@ export default function Scout() {
               onSelect={setSelected}
             />
           </div>
+          <button
+            aria-label="Create clan post"
+            className="fixed bottom-20 right-4 w-12 h-12 rounded-full bg-blue-500 text-white flex items-center justify-center shadow-lg"
+            onClick={() => setShowForm(true)}
+          >
+            <Plus className="w-6 h-6" />
+          </button>
+          <BottomSheet open={showForm} onClose={() => setShowForm(false)}>
+            <ClanPostForm
+              onPosted={() => {
+                setShowForm(false);
+                feed.reload();
+              }}
+            />
+          </BottomSheet>
         </>
       )}
       {active === 'need' && (

--- a/front-end/app/src/pages/Scout.test.jsx
+++ b/front-end/app/src/pages/Scout.test.jsx
@@ -34,12 +34,24 @@ describe('Scout page', () => {
     expect(screen.getByText('Need a Clan')).toBeInTheDocument();
   });
 
-  it('shows find a clan form by default', async () => {
+  it('shows create post button by default', () => {
     render(
       <MemoryRouter>
         <Scout />
       </MemoryRouter>
     );
+    expect(
+      screen.getByRole('button', { name: 'Create clan post' })
+    ).toBeInTheDocument();
+  });
+
+  it('opens clan post form when button clicked', async () => {
+    render(
+      <MemoryRouter>
+        <Scout />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Create clan post' }));
     await screen.findByPlaceholderText('Describe your clan');
   });
 


### PR DESCRIPTION
## Summary
- display recruiting requirements with dedicated sections and move description to the end of each clan card
- preview clan post in a bottom-sheet form and open it with a floating action button

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893609e8cbc832cbec8ad56d8f84c62