### PR TITLE
feat: enhance clan recruit details

### DIFF
--- a/front-end/app/src/components/ClanPostForm.jsx
+++ b/front-end/app/src/components/ClanPostForm.jsx
@@ -82,6 +82,7 @@ export default function ClanPostForm({ onPosted }) {
         warLeague={clan.warLeague}
         clanLevel={clan.clanLevel}
         requiredTrophies={clan.requiredTrophies}
+        requiredBuilderBaseTrophies={clan.requiredBuilderBaseTrophies}
         requiredTownhallLevel={clan.requiredTownhallLevel}
         callToAction={callToAction}
       />

--- a/front-end/app/src/components/RecruitCard.jsx
+++ b/front-end/app/src/components/RecruitCard.jsx
@@ -14,6 +14,7 @@ export default function RecruitCard({
   warLeague,
   clanLevel,
   requiredTrophies,
+  requiredBuilderBaseTrophies,
   requiredTownhallLevel,
   callToAction,
   onJoin,
@@ -52,10 +53,10 @@ export default function RecruitCard({
       </div>
       {lang && (
         <p className="text-xs text-slate-500 mt-1">
-          {typeof lang === 'string' ? lang : lang.name}
+          Language: {typeof lang === 'string' ? lang : lang.name}
         </p>
       )}
-      {(requiredTownhallLevel || requiredTrophies) && (
+      {(requiredTownhallLevel || requiredTrophies || requiredBuilderBaseTrophies) && (
         <div className="mt-2">
           <h4 className="text-xs font-semibold text-slate-500 uppercase">
             Requirements
@@ -68,7 +69,12 @@ export default function RecruitCard({
             )}
             {requiredTrophies && (
               <span className="bg-slate-200 px-2 py-0.5 rounded-full text-xs">
-                {requiredTrophies}+
+                Base Trophies: {requiredTrophies}+
+              </span>
+            )}
+            {requiredBuilderBaseTrophies && (
+              <span className="bg-slate-200 px-2 py-0.5 rounded-full text-xs">
+                Builder Base Trophies: {requiredBuilderBaseTrophies}+
               </span>
             )}
           </div>
@@ -79,38 +85,39 @@ export default function RecruitCard({
           <h4 className="text-xs font-semibold text-slate-500 uppercase">
             Clan Info
           </h4>
-          <div className="mt-1 grid grid-cols-2 gap-2 text-sm text-slate-700">
+          <div className="mt-1 grid grid-cols-3 gap-2 text-xs text-slate-700">
             {typeof count === 'number' && (
-              <div className="flex items-center gap-1">
+              <span className="flex items-center gap-1 bg-slate-200 px-2 py-0.5 rounded-full">
                 <Users className="w-4 h-4 text-slate-500" />
                 <span>{count}/50</span>
-              </div>
+              </span>
             )}
             {warLeague?.name && (
-              <div className="flex items-center gap-1">
+              <span className="flex items-center gap-1 bg-slate-200 px-2 py-0.5 rounded-full">
                 <Shield className="w-4 h-4 text-slate-500" />
                 <span>{warLeague.name}</span>
-              </div>
+              </span>
             )}
             {clanLevel && (
-              <div className="flex items-center gap-1">
+              <span className="flex items-center gap-1 bg-slate-200 px-2 py-0.5 rounded-full">
                 <Crown className="w-4 h-4 text-slate-500" />
                 <span>Lv {clanLevel}</span>
-              </div>
+              </span>
             )}
-          </div>
-          {labels.length > 0 && (
-            <div className="flex gap-2 mt-2 flex-wrap">
-              {labels.map((l) => (
+            {labels.map((l) => (
+              <span
+                key={l.id || l.name}
+                className="flex items-center justify-center bg-slate-200 px-2 py-0.5 rounded-full"
+                title={l.name}
+              >
                 <CachedImage
-                  key={l.id || l.name}
                   src={l.iconUrls?.small || l.iconUrls?.medium}
                   alt={l.name}
-                  className="w-8 h-8"
+                  className="w-5 h-5"
                 />
-              ))}
-            </div>
-          )}
+              </span>
+            ))}
+          </div>
         </div>
       )}
       {callToAction && (

--- a/front-end/app/src/components/RecruitCard.test.jsx
+++ b/front-end/app/src/components/RecruitCard.test.jsx
@@ -20,13 +20,14 @@ test('renders summary info and handles click', () => {
       warLeague={{ name: 'Gold League' }}
       clanLevel={5}
       requiredTrophies={1200}
+      requiredBuilderBaseTrophies={500}
       requiredTownhallLevel={8}
       callToAction="Join us!"
       onClick={handleClick}
     />
   );
   expect(screen.getByText('Clan')).toBeInTheDocument();
-  expect(screen.getByText('EN')).toBeInTheDocument();
+  expect(screen.getByText('Language: EN')).toBeInTheDocument();
   expect(screen.getByText('Requirements')).toBeInTheDocument();
   expect(screen.getByText('Clan Info')).toBeInTheDocument();
   expect(screen.getByText('Description')).toBeInTheDocument();
@@ -34,8 +35,12 @@ test('renders summary info and handles click', () => {
   expect(screen.getByText('30/50')).toBeInTheDocument();
   expect(screen.getByText('Gold League')).toBeInTheDocument();
   expect(screen.getByText('Lv 5')).toBeInTheDocument();
-  expect(screen.getByText('1200+')).toBeInTheDocument();
+  expect(screen.getByText('Base Trophies: 1200+')).toBeInTheDocument();
+  expect(
+    screen.getByText('Builder Base Trophies: 500+')
+  ).toBeInTheDocument();
   expect(screen.getByText('TH 8+')).toBeInTheDocument();
+  expect(screen.getByTitle('Label1')).toBeInTheDocument();
   fireEvent.click(screen.getByRole('button'));
   expect(handleClick).toHaveBeenCalled();
 });

--- a/front-end/app/src/components/RecruitDetail.jsx
+++ b/front-end/app/src/components/RecruitDetail.jsx
@@ -33,6 +33,7 @@ export default function RecruitDetail({ clan, onClose }) {
             warLeague={clan.warLeague}
             clanLevel={clan.clanLevel}
             requiredTrophies={clan.requiredTrophies}
+            requiredBuilderBaseTrophies={clan.requiredBuilderBaseTrophies}
             requiredTownhallLevel={clan.requiredTownhallLevel}
             callToAction={clan.callToAction}
             onJoin={() => {}}

--- a/front-end/app/src/components/RecruitFeed.jsx
+++ b/front-end/app/src/components/RecruitFeed.jsx
@@ -35,6 +35,7 @@ export default function RecruitFeed({ items, loadMore, hasMore, onJoin, onSelect
         warLeague={item.data.warLeague}
         clanLevel={item.data.clanLevel}
         requiredTrophies={item.data.requiredTrophies}
+        requiredBuilderBaseTrophies={item.data.requiredBuilderBaseTrophies}
         requiredTownhallLevel={item.data.requiredTownhallLevel}
         callToAction={item.data.callToAction}
         onJoin={() => onJoin?.(item.data)}


### PR DESCRIPTION
## Summary
- show recruit language with a contextual label
- separate base and builder base trophy requirements and present clan info as pills with label hover text
- propagate builder base trophy requirement across feed, detail, and post form components

## Testing
- `nox -s lint tests`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893bdeb0194832c81f85514f9359442