### PR TITLE
CodeQL: fix Java build step to use Gradle wrapper

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -97,14 +97,10 @@ jobs:
     - if: matrix.build-mode == 'manual' && matrix.language == 'java'
       shell: bash
       run: |
-        gradle -p messages-java wrapper
-        gradle -p user_service wrapper
-        gradle -p notifications wrapper
-        gradle -p recruiting wrapper
-        ./messages-java/gradlew -p messages-java test
-        ./user_service/gradlew -p user_service test
-        ./notifications/gradlew -p notifications test
-        ./recruiting/gradlew -p recruiting test
+        ./messages-java/gradlew -p messages-java --no-daemon test
+        ./user_service/gradlew -p user_service --no-daemon test
+        ./notifications/gradlew -p notifications --no-daemon test
+        ./recruiting/gradlew -p recruiting --no-daemon test
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,15 +45,15 @@ jobs:
         include:
         - language: actions
           build-mode: none
-        - language: java-kotlin
+        - language: java
           build-mode: manual
         - language: javascript-typescript
           build-mode: none
         - language: python
           build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # CodeQL supports the following language keywords: 'actions', 'c-cpp', 'csharp', 'go', 'java', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'java' to analyze code written in Java, Kotlin or both
         # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
         # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
         # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
@@ -94,7 +94,7 @@ jobs:
     # to build your code.
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual' && matrix.language == 'java-kotlin'
+    - if: matrix.build-mode == 'manual' && matrix.language == 'java'
       shell: bash
       run: |
         gradle -p messages-java wrapper


### PR DESCRIPTION
Use only Gradle wrapper scripts in CodeQL manual Java build to avoid requiring system Gradle on runners. This should resolve build failures in the Java CodeQL job.\n\n- Removed `gradle ... wrapper` calls\n- Run tests via `./<module>/gradlew -p <module> --no-daemon test`