### PR TITLE
feat(messages): add Spring Security config to fix health endpoint auth

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/config/SecurityConfig.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.clanboards.messages.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  private final OidcAuthenticationFilter oidcAuthenticationFilter;
+
+  public SecurityConfig(OidcAuthenticationFilter oidcAuthenticationFilter) {
+    this.oidcAuthenticationFilter = oidcAuthenticationFilter;
+  }
+
+  @Bean
+  @Order(1)
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.authorizeHttpRequests(
+            authz ->
+                authz
+                    .requestMatchers(
+                        "/api/v1/health",
+                        "/api/v1/chat/health",
+                        "/actuator/health",
+                        "/health",
+                        "/api/v1/chat/debug/config",
+                        "/api/v1/chat/debug/validate",
+                        "/api/v1/chat/debug/request-info")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .addFilterBefore(oidcAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .csrf(csrf -> csrf.disable())
+        .httpBasic(httpBasic -> httpBasic.disable())
+        .formLogin(formLogin -> formLogin.disable());
+
+    return http.build();
+  }
+}


### PR DESCRIPTION
## Summary
- Add explicit Spring Security configuration to resolve authentication issues with health endpoints when using java-auth-common library
- Allow health and debug endpoints to bypass OIDC authentication while maintaining security for other endpoints  
- Update documentation with Spring Security configuration fix for java-auth-common integration

## Test plan
- [x] All Java services tests pass (`./gradlew test`)
- [x] All linting checks pass (`./gradlew spotlessCheck`) 
- [x] Mobile app tests pass (247 tests)
- [x] Complete monorepo test suite passes (`nox -s lint tests`)
- [x] Health endpoints accessible without authentication
- [x] Other endpoints still require proper OIDC authentication

🤖 Generated with [Claude Code](https://claude.ai/code)