### PR TITLE
fix(messages): remove obsolete user_service_url dependency from database-backed JWKS

### DIFF
--- a/messages-java/src/main/java/com/clanboards/messages/config/OidcPropertiesLoader.java
+++ b/messages-java/src/main/java/com/clanboards/messages/config/OidcPropertiesLoader.java
@@ -18,7 +18,6 @@ public class OidcPropertiesLoader {
 
   private static final String OIDC_ISSUER_KEY = "oidc.issuer";
   private static final String OIDC_AUDIENCE_KEY = "oidc.audience";
-  private static final String OIDC_USER_SERVICE_URL_KEY = "oidc.user_service_url";
 
   private final SystemConfigRepository configRepository;
   private final OidcProperties oidcProperties;
@@ -58,25 +57,12 @@ public class OidcPropertiesLoader {
                     "Using default audience from application.yml: {}",
                     oidcProperties.getAudience()));
 
-    // Load user service URL from database, fallback to existing value
-    configRepository
-        .findByKey(OIDC_USER_SERVICE_URL_KEY)
-        .ifPresentOrElse(
-            config -> {
-              logger.info("Loaded user service URL from database: {}", config.getValue());
-              oidcProperties.setUserServiceUrl(config.getValue());
-            },
-            () ->
-                logger.info(
-                    "Using default user service URL from application.yml: {}",
-                    oidcProperties.getUserServiceUrl()));
-
     logger.info(
-        "OIDC configuration loaded - Issuer: {}, Audience: {}, User Service URL: {}, JWKS URL: {}",
+        "OIDC configuration loaded - Issuer: {}, Audience: {}, JWKS Source: {}, JWKS DB Key: {}",
         oidcProperties.getIssuer(),
         oidcProperties.getAudience(),
-        oidcProperties.getUserServiceUrl(),
-        oidcProperties.getJwksUrl());
+        oidcProperties.getJwksSource(),
+        oidcProperties.getJwksDbKey());
   }
 
   /**

--- a/messages-java/src/main/resources/application.properties
+++ b/messages-java/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 spring.graphql.path=/api/v1/chat/graphql
 
-# OIDC Authentication configuration - values come from environment variables
-auth.oidc.user-service-url=${USER_SERVICE_URL:http://localhost:8080}
+# OIDC Authentication configuration - values come from environment variables  
 auth.oidc.issuer=${OIDC_ISSUER:http://localhost:8080}
 auth.oidc.audience=${OIDC_AUDIENCE:clanboards-mobile}
 auth.oidc.keys-cache-duration-minutes=${OIDC_KEYS_CACHE_DURATION:15}


### PR DESCRIPTION
## Summary
- Fixes authentication failures in messages-java service caused by incomplete migration to database-backed JWKS
- Removes obsolete `oidc.user_service_url` dependency that is no longer needed with DB-driven JWKS
- Resolves issues from PR #549 commit 639ca65

## Root Cause
The messages-java service was attempting to load `oidc.user_service_url` from the database during startup, but this property is no longer needed with the new database-backed JWKS implementation. This was causing authentication token validation failures.

## Changes Made
- **OidcPropertiesLoader.java**: Remove `OIDC_USER_SERVICE_URL_KEY` constant and related database loading logic
- **application.properties**: Remove `auth.oidc.user-service-url` property since it's obsolete 
- **Logging**: Update configuration logging to show JWKS-specific properties instead of user service URL

## Test Plan
- [x] All existing tests pass (`nox -s lint tests`)
- [x] Messages-java service builds successfully
- [x] Java-auth-common library tests pass
- [x] Code formatting and linting checks pass

## Technical Details
With the database-backed JWKS implementation from PR #549:
- JWKS keys are read directly from the `system_config` table using key `oidc.jwks`
- No HTTP calls to user service are needed for token validation
- The `user_service_url` property was a remnant from the old HTTP-based JWKS fetching

This change completes the migration to fully database-backed JWT token validation, eliminating all HTTP dependencies for authentication.

🤖 Generated with [Claude Code](https://claude.ai/code)