### PR TITLE
CI: Parallelize PR workflow and include java-auth-common in Java checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,47 +9,194 @@ permissions:
   pull-requests: write
   actions: write
 
+concurrency:
+  group: pr-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  nox:
+  changes:
+    name: Detect changes
     runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      lambdas_refresh_worker: ${{ steps.filter.outputs.lambdas_refresh_worker }}
+      frontend_app: ${{ steps.filter.outputs.frontend_app }}
+      frontend_mobile: ${{ steps.filter.outputs.frontend_mobile }}
+      java_auth_common: ${{ steps.filter.outputs.java_auth_common }}
+      messages_java: ${{ steps.filter.outputs.messages_java }}
+      user_service: ${{ steps.filter.outputs.user_service }}
+      notifications: ${{ steps.filter.outputs.notifications }}
+      recruiting: ${{ steps.filter.outputs.recruiting }}
+      clash_data: ${{ steps.filter.outputs.clash_data }}
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            python:
+              - 'coclib/**'
+              - 'db/**'
+              - 'migrations/**'
+              - 'noxfile.py'
+            lambdas_refresh_worker:
+              - 'lambdas/refresh-worker/**'
+            frontend_app:
+              - 'front-end/app/**'
+            frontend_mobile:
+              - 'front-end/mobile/**'
+            java_auth_common:
+              - 'java-auth-common/**'
+            messages_java:
+              - 'messages-java/**'
+            user_service:
+              - 'user_service/**'
+            notifications:
+              - 'notifications/**'
+            recruiting:
+              - 'recruiting/**'
+            clash_data:
+              - 'clash-data/**'
+            workflows:
+              - '.github/workflows/**'
 
-      - uses: actions/setup-python@v4
+  python-lint:
+    name: Python lint
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.workflows == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
+      - name: Install ruff
+        run: pip install ruff
+      - name: Ruff check (coclib, db)
+        run: ruff check coclib db
 
+  lambdas-refresh-worker:
+    name: Lambda tests (refresh-worker)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.lambdas_refresh_worker == 'true' || needs.changes.outputs.python == 'true' || needs.changes.outputs.workflows == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            lambdas/refresh-worker/requirements-test.txt
+      - name: Install test deps
+        working-directory: lambdas/refresh-worker
+        run: pip install -r requirements-test.txt
+      - name: Run pytest
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        working-directory: lambdas/refresh-worker
+        run: pytest -q test_lambda_function.py -q
+
+  frontend-app:
+    name: Front-end web
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.frontend_app == 'true' || needs.changes.outputs.workflows == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: front-end/app/package-lock.json
+      - name: Install deps
+        working-directory: front-end/app
+        run: npm ci
+      - name: Run tests
+        working-directory: front-end/app
+        run: npm test --silent
+      - name: Build
+        working-directory: front-end/app
+        run: npm run build
+
+  frontend-mobile:
+    name: Mobile
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.frontend_mobile == 'true' || needs.changes.outputs.workflows == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: front-end/mobile/package-lock.json
+      - name: Install deps
+        working-directory: front-end/mobile
+        run: npm ci
+      - name: Run tests
+        working-directory: front-end/mobile
+        run: npm run test --silent
+      - name: Typecheck
+        working-directory: front-end/mobile
+        run: npm run typecheck
+      - name: Lint
+        working-directory: front-end/mobile
+        run: npm run lint
+
+  java:
+    name: Java (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      ${{ needs.changes.outputs.java_auth_common == 'true' ||
+          needs.changes.outputs.messages_java == 'true' ||
+          needs.changes.outputs.user_service == 'true' ||
+          needs.changes.outputs.notifications == 'true' ||
+          needs.changes.outputs.recruiting == 'true' ||
+          needs.changes.outputs.clash_data == 'true' ||
+          needs.changes.outputs.workflows == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [ 'java-auth-common', 'messages-java', 'user_service', 'notifications', 'recruiting', 'clash-data' ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
+      - name: Gradle build setup and cache
+        uses: gradle/gradle-build-action@v2
       - name: Publish coc-java to Maven Local
         run: |
           cd coc-py
           ./gradlew :coc-java:publishToMavenLocal -Pversion=0.1.0 --no-daemon
+      - name: Ensure recruiting wrapper
+        if: matrix.project == 'recruiting'
+        run: |
+          if [ ! -f recruiting/gradle/wrapper/gradle-wrapper.jar ]; then
+            ./messages-java/gradlew -p recruiting wrapper
+          fi
+      - name: Spotless + Tests
+        working-directory: ${{ matrix.project }}
+        run: ./gradlew --no-daemon spotlessCheck test
 
-      - name: Install nox
-        run: pip install nox
-
-      - name: Run nox
-        run: nox -s lint tests
-
+  enable-auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    needs: [changes, python-lint, lambdas-refresh-worker, frontend-app, frontend-mobile, java]
+    steps:
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.PR_TOKEN }} 
+          token: ${{ secrets.PR_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,13 @@ npm run build
 
 Any lint errors or build failures should fail the PR.
 
+## CI notes
+
+- PR CI runs jobs in parallel per stack (Python lint, Lambdas tests, front-end web/mobile, and a Java matrix including `java-auth-common`).
+- Java modules run `spotlessCheck` and `test` with Gradle caching enabled. `coc-py/:coc-java` is published to `mavenLocal` in each Java job before builds.
+- The old monolithic `nox` CI driver is retained for local dev convenience; CI no longer calls `nox` directly.
+- Path filters skip unaffected jobs to reduce build time.
+
 ## Development notes
 
 - Keep shared logic in `coclib` rather than duplicating it in other projects.

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ from pathlib import Path
 def lint(session: nox.Session) -> None:
     session.install("ruff")
     session.run("ruff", "check", "coclib", "db")
-    for project in ("messages-java", "user_service", "notifications", "recruiting", "clash-data"):
+    for project in ("java-auth-common", "messages-java", "user_service", "notifications", "recruiting", "clash-data"):
         # Ensure recruiting has a wrapper JAR (it's missing in the repo).
         if project == "recruiting":
             wrapper_jar = Path("recruiting/gradle/wrapper/gradle-wrapper.jar")
@@ -26,6 +26,9 @@ def tests(session: nox.Session) -> None:
         session.chdir("coc-py")
         session.run("./gradlew", ":coc-java:publishToMavenLocal", "-Pversion=0.1.0", "--no-daemon", external=True)
         session.chdir("..")
+    session.chdir("java-auth-common")
+    session.run("./gradlew", "--no-daemon", "test", external=True)
+    session.chdir("..")
     session.chdir("messages-java")
     session.run("./gradlew", "--no-daemon", "test", external=True)
     session.chdir("..")


### PR DESCRIPTION
This PR modernizes the PR CI to reduce build time and fix gaps:

- Split monolithic `nox` CI into parallel jobs by stack:
  - Python lint (ruff for `coclib` and `db`)
  - Lambda tests (`lambdas/refresh-worker` with `pytest`)
  - Front-end web (`front-end/app`): npm ci/test/build
  - Mobile (`front-end/mobile`): npm ci/test/typecheck/lint
  - Java matrix: `java-auth-common`, `messages-java`, `user_service`, `notifications`, `recruiting`, `clash-data`
- Add `java-auth-common` to spotless and test coverage.
- Use `dorny/paths-filter` to run only affected jobs.
- Add Gradle caching via `gradle/gradle-build-action`.
- Publish `coc-py/:coc-java` to `mavenLocal` before Java builds.
- Bootstrap recruiting’s Gradle wrapper when missing.
- Add concurrency to cancel superseded runs.
- Keep auto-merge step gated on all job results.

Local parity updates:
- `noxfile.py` updated to include `java-auth-common` for lint/tests.
- Root `AGENTS.md` documents the new CI shape and intent.

I validated locally with `nox -s lint tests` (ruff, Java spotless checks, mobile tests, Lambda tests) and all checks passed. CI path filters ensure unaffected stacks are skipped to speed up PR builds.

Please review and let me know if you want any job scopes adjusted or additional caches added.