### PR TITLE
chore: CI-friendly Makefile targets and docs updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,12 @@ This repo is mobile‑first with Java microservices. Use the Makefile for common
 ## Quick Start
 - List commands: `make help`
 - Install git hooks: `make hooks`
-- Lint all stacks: `make lint`
-- Run tests (Java + mobile + Lambda via nox): `make test`
+- Lint all stacks: `make lint` (or `make check` to include wrapper alignment)
+- Run tests (Java + mobile + Lambda via nox): `make test` (or `make verify` for lint+tests)
 - Lambda tests only:
   - With nox: `make lambda-test`
   - Without nox: `make lambda-test-standalone`
+ - CI-like suite: `make ci` (java + mobile + web + lambdas)
 
 ## Java/Gradle Notes
 - Always use the module Gradle Wrapper (`./gradlew`) — do not use the global `gradle` CLI.
@@ -26,6 +27,7 @@ This repo is mobile‑first with Java microservices. Use the Makefile for common
 ## Mobile & Web
 - Mobile setup: `make mobile-setup` (then `make mobile-lint`, `make mobile-typecheck`, `make mobile-test`)
 - Web (optional; PWA obsolete): `make web-setup`, `make web-test`, `make web-build`
+  - Note: Web uses Vitest; Jest’s `--ci` flag is not supported. The Makefile uses `CI=1` without `--ci` for web tests.
 
 ## Python
 - Lint: `make lint-python` (runs ruff on `coclib`, `db`, `lambdas/refresh-worker`)

--- a/Makefile
+++ b/Makefile
@@ -12,32 +12,65 @@ JAVA_MODULES := java-auth-common messages-java user_service notifications recrui
 help:
 	@echo "Available targets:";
 	@echo "  hooks                   Install pre-commit git hook";
+	@echo "  env-check               Show tool versions and warn on mismatches";
 	@echo "  lint                    Lint Python + Java (spotless) + mobile";
+	@echo "  check                   Lint + Gradle wrapper alignment check";
 	@echo "  test                    Run Java tests, mobile tests, and lambda tests (via nox)";
+	@echo "  verify                  check + full test suite";
 	@echo "  lint-python             Run ruff on Python sources";
 	@echo "  lint-java               Run spotlessCheck on all Java modules";
 	@echo "  test-java               Run tests on all Java modules";
+	@echo "  fmt-java                Run Spotless apply on all Java modules";
 	@echo "  mobile-setup            Install mobile dependencies (npm ci)";
 	@echo "  mobile-lint             ESLint for mobile app";
 	@echo "  mobile-typecheck        TypeScript typecheck for mobile app";
 	@echo "  mobile-test             Jest tests for mobile app";
+	@echo "  mobile-fix              ESLint --fix for mobile app";
 	@echo "  web-setup               Install web dependencies (npm ci)";
-	@echo "  web-test                Jest tests for web app";
+	@echo "  web-test                Vitest tests for web app";
 	@echo "  web-build               Build web app (vite)";
 	@echo "  lambda-test             Run Lambda tests via nox suite";
 	@echo "  lambda-test-standalone  Run Lambda tests without nox (local venv)";
 	@echo "  gradle-align            Align Gradle wrapper distribution across modules ($(GRADLE_VERSION))";
+	@echo "  ci                      Run CI-like suite (java, mobile, web, lambdas)";
+	@echo "  ci-java                 Java spotlessCheck + tests with stable flags";
+	@echo "  ci-mobile               Mobile tests in CI mode (npm ci, --ci)";
+	@echo "  ci-web                  Web tests+build in CI mode";
+	@echo "  ci-lambdas              Lambda tests; uses nox if available, else standalone";
+	@echo "  ci-python               Python lint (ruff)";
+	@echo "  ci-precommit            Run pre-commit full suite (nox) to mirror local hook";
+	@echo "  ci-gradle-align-check   Assert all Gradle wrappers are pinned uniformly";
 
 .PHONY: hooks
 hooks:
 	bash tools/setup-git-hooks.sh
 
+# Environment check
+.PHONY: env-check
+env-check:
+	@echo "== Environment Versions =="; \
+	JAVA_VER=$$(java -version 2>&1 | head -n1 | sed -E 's/.*version "?([0-9]+).*/\1/' || true); \
+	NODE_VER=$$(node -v 2>/dev/null | sed -E 's/v([0-9]+).*/\1/' || true); \
+	PY_VER=$$(python3 -V 2>&1 | sed -E 's/Python ([0-9]+)\..*/\1/' || true); \
+	echo "Java:   $$JAVA_VER (expected >= 21)"; \
+	echo "Node:   $$NODE_VER (expected >= 20)"; \
+	echo "Python: $$PY_VER (expected = 3.11)"; \
+	if [ -n "$$JAVA_VER" ] && [ "$$JAVA_VER" -lt 21 ]; then echo "WARN: Java < 21"; fi; \
+	if [ -n "$$NODE_VER" ] && [ "$$NODE_VER" -lt 20 ]; then echo "WARN: Node < 20"; fi; \
+	if ! python3 -c 'import sys; sys.exit(0 if sys.version_info[:2]==(3,11) else 1)' >/dev/null 2>&1; then echo "WARN: Python is not 3.11"; fi
+
 # Aggregate
 .PHONY: lint
 lint: lint-python lint-java mobile-lint mobile-typecheck
 
+.PHONY: check
+check: env-check lint ci-gradle-align-check
+
 .PHONY: test
 test: test-java mobile-test lambda-test
+
+.PHONY: verify
+verify: check test
 
 # Python
 .PHONY: lint-python
@@ -65,6 +98,13 @@ test-java:
 		( cd $$m && GRADLE_USER_HOME=$(GRADLE_USER_HOME) ./gradlew --no-daemon test ); \
 	done
 
+.PHONY: fmt-java
+fmt-java:
+	@for m in $(JAVA_MODULES); do \
+		echo "[gradle] $$m spotlessApply"; \
+		( cd $$m && GRADLE_USER_HOME=$(GRADLE_USER_HOME) ./gradlew --no-daemon -q spotlessApply ); \
+	done
+
 # Mobile
 .PHONY: mobile-setup
 mobile-setup:
@@ -81,6 +121,10 @@ mobile-typecheck:
 .PHONY: mobile-test
 mobile-test:
 	cd front-end/mobile && npm test --silent
+
+.PHONY: mobile-fix
+mobile-fix:
+	cd front-end/mobile && npm run -s lint -- --fix
 
 # Web (optional; PWA obsolete)
 .PHONY: web-setup
@@ -126,4 +170,52 @@ gradle-align:
 		fi; \
 	 done
 	@echo "Aligned Gradle wrapper distributionUrl to $(GRADLE_VERSION)"
+
+# CI-like wrappers
+.PHONY: ci
+ci: env-check ci-gradle-align-check ci-java ci-mobile ci-web ci-lambdas
+
+.PHONY: ci-java
+ci-java:
+	@for m in $(JAVA_MODULES); do \
+		echo "[gradle] $$m spotlessCheck test"; \
+		( cd $$m && GRADLE_USER_HOME=$(GRADLE_USER_HOME) ./gradlew --no-daemon --build-cache -q spotlessCheck && ./gradlew --no-daemon --build-cache test ); \
+	done
+
+.PHONY: ci-mobile
+ci-mobile:
+	cd front-end/mobile && npm ci && CI=1 npm test --silent -- --ci
+
+.PHONY: ci-web
+ci-web:
+	cd front-end/app && npm ci && CI=1 npm test --silent && npm run -s build
+
+.PHONY: ci-lambdas
+ci-lambdas:
+	@if command -v nox >/dev/null 2>&1; then \
+		echo "[nox] running lambda tests"; \
+		nox -s tests ; \
+	else \
+		echo "[standalone] running lambda tests"; \
+		cd lambdas/refresh-worker && python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements-test.txt && PYTHONPATH=../../ pytest -v test_lambda_function.py ; \
+	fi
+
+.PHONY: ci-python
+ci-python: lint-python
+
+.PHONY: ci-precommit
+ci-precommit:
+	@if command -v nox >/dev/null 2>&1; then \
+		PRECOMMIT_FULL=1 bash tools/hooks/pre-commit ; \
+	else \
+		echo "nox not found; install with pipx install nox"; exit 1; \
+	fi
+
+.PHONY: ci-gradle-align-check
+ci-gradle-align-check:
+	@urls=$$(grep -h '^distributionUrl=' $(addsuffix /gradle/wrapper/gradle-wrapper.properties,$(JAVA_MODULES)) | sed 's/^distributionUrl=//' | sort -u); \
+	count=$$(echo "$$urls" | sed '/^$$/d' | wc -l | tr -d ' '); \
+	echo "Wrapper URLs:"; echo "$$urls"; \
+	if [ "$$count" -ne 1 ]; then echo "Mismatch in Gradle wrapper distributionUrl across modules"; exit 1; fi; \
+	echo "Gradle wrapper URLs are aligned"
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ Details and integration guidance:
 ### Makefile shortcuts
 - List commands: `make help`
 - Lint everything: `make lint`
+- Quick check (lint + wrapper alignment): `make check`
 - Run tests (Java + mobile + lambdas via nox): `make test`
+- Full verify (check + tests): `make verify`
+- CI-like suite: `make ci` (java, mobile, web, lambdas)
 - Lambda tests only: `make lambda-test` (nox) or `make lambda-test-standalone`
 
 Common tasks:
@@ -80,6 +83,8 @@ Notes:
 
 ### Gradle consistency
 - All Java modules use the Gradle Wrapper and are pinned to the same distribution (8.14.3). Avoid the global `gradle` CLI to prevent wrapper changes or version drift. Dockerfiles have been updated to use the wrapper.
+
+Note on web tests: The web app uses Vitest and does not support Jest’s `--ci` flag. The Makefile sets `CI=1` but does not pass `--ci` to web tests.
 
 ## Auth Migration Status
 - Mobile auth migration plan (`front-end/MOBILE_AUTH_MIGRATION.md`) is essentially complete. Remaining work is for services to adopt the DB‑backed JWKS validation as specified in `AUTHENTICATION_INTEGRATION.md`.


### PR DESCRIPTION
Summary
- Enhance Makefile with CI-friendly targets: env-check, check, verify, ci, ci-java, ci-mobile, ci-web, ci-lambdas, ci-python, ci-precommit, ci-gradle-align-check, fmt-java, mobile-fix.
- Update README and CONTRIBUTING with Makefile usage (check/verify/ci) and clarify web tests use Vitest (no --ci flag; CI=1 only).

Why
- Make local runs mirror CI more closely and reduce friction across stacks.
- Avoids passing Jest's --ci to Vitest in web app.

Notes
- No functional code changes; docs + task runners only.
- Pre-commit hook left intact and used for commit.

Validation
- Ran `make ci-web` successfully locally; Vitest runs and Vite build completes. The Makefile targets are designed to be compatible with CI's non-interactive environment.