### PR TITLE
Switch README CI badge to deploy.yml (main branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clash of Clans Dashboard
 
-[![CI](https://github.com/ChangeinX/coc/actions/workflows/pr.yml/badge.svg?branch=main)](https://github.com/ChangeinX/coc/actions/workflows/pr.yml)
+[![Build and Deploy](https://github.com/ChangeinX/coc/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/ChangeinX/coc/actions/workflows/deploy.yml)
 
 Modernized monorepo for the Clan Boards project. The stack has shifted to Java microservices and a mobile‑first client. The legacy Flask API has been archived.
 


### PR DESCRIPTION
Updates the README status badge to track `deploy.yml` on `main` instead of `pr.yml` which only runs on pull_request events. This fixes the badge showing "no status" on the main branch.

- Old: `pr.yml` badge → "no status" on main
- New: `deploy.yml` badge → reflects main push status

No code changes; docs-only.